### PR TITLE
refactor(billing): render pricing from shared keeperhub-pricing-ui package

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -182,3 +182,6 @@ minimum-release-age-exclude[]=@types/deep-diff
 # driver.js (MIT) is the onboarding-tour library; pnpm's release-age gate flags
 # it on resolve, so exclude it so lockfile regeneration / fresh installs succeed.
 minimum-release-age-exclude[]=driver.js
+# keeperhub-pricing-ui is our own shared pricing package; a fresh publish trips
+# the release-age gate on lockfile regeneration until it ages past the window.
+minimum-release-age-exclude[]=keeperhub-pricing-ui

--- a/components/billing/pricing-table/index.tsx
+++ b/components/billing/pricing-table/index.tsx
@@ -1,35 +1,41 @@
 "use client";
 
-import { ChevronDown, Info } from "lucide-react";
-import { useEffect, useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  type BillingInterval as PkgBillingInterval,
+  type ComparisonCell as PkgComparisonCell,
+  type ComparisonColumn as PkgComparisonColumn,
+  type ComparisonRow as PkgComparisonRow,
+  type PricingCard as PkgPricingCard,
+  PricingCards,
+  PricingComparisonTable,
+  type PricingCtaContext,
+} from "keeperhub-pricing-ui";
+import "keeperhub-pricing-ui/styles.css";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { BILLING_API } from "@/lib/billing/constants";
-import type { BillingInterval, PlanName } from "@/lib/billing/plans";
-import { PLANS } from "@/lib/billing/plans";
-import { cn } from "@/lib/utils";
+import {
+  type BillingInterval,
+  PLANS,
+  type PlanName,
+  type TierKey,
+} from "@/lib/billing/plans";
 import {
   SPONSORSHIP_MAINNET_NAMES,
   SPONSORSHIP_TESTNET_NAMES,
 } from "@/lib/web3/sponsorship-chains-meta";
-import { PlanCard } from "./plan-card";
-import type { PricingTableProps } from "./types";
+import { ConfirmPlanChangeDialog } from "../confirm-plan-change-dialog";
+import type { GasCreditCapsMap, PricingTableProps } from "./types";
+import {
+  cancelSubscription,
+  computeDisplayPrice,
+  getButtonLabel,
+  isCurrentPlan,
+  resolveExecutions,
+  startCheckout,
+} from "./utils";
 
-type ComparisonRow = {
-  label: string;
-  tooltip?: {
-    title: string;
-    body: React.ReactNode;
-  };
-  free: React.ReactNode;
-  pro: React.ReactNode;
-  business: React.ReactNode;
-  enterprise: React.ReactNode;
-};
+type TieredPlanName = "pro" | "business";
 
 const PLAN_ORDER: readonly PlanName[] = [
   "free",
@@ -38,13 +44,465 @@ const PLAN_ORDER: readonly PlanName[] = [
   "enterprise",
 ];
 
-/** Included executions per plan (cheapest tier for the tiered plans). */
+type ConfirmTarget = {
+  planName: PlanName;
+  tierKey: TierKey | null;
+  appInterval: BillingInterval;
+};
+
+type CheckoutHandlers = {
+  currentPlan: PlanName;
+  currentTier: TierKey | null | undefined;
+  currentInterval: BillingInterval | null | undefined;
+  hasSubscription: boolean;
+  onPlanUpdated?: () => Promise<void>;
+  setLoadingCardId: (id: PlanName | null) => void;
+  setConfirmTarget: (target: ConfirmTarget) => void;
+  setConfirmOpen: (open: boolean) => void;
+};
+
+function appIntervalToPkg(value: BillingInterval): PkgBillingInterval {
+  return value === "yearly" ? "annual" : "monthly";
+}
+
+function pkgIntervalToApp(value: PkgBillingInterval): BillingInterval {
+  return value === "annual" ? "yearly" : "monthly";
+}
+
+function formatFreePrice(paygPriceUsdc: string | null): string {
+  if (!paygPriceUsdc) {
+    return "$0.01";
+  }
+  return `$${Number(paygPriceUsdc).toLocaleString(undefined, {
+    maximumFractionDigits: 6,
+  })}`;
+}
+
+function formatCardGas(capCents: number): string {
+  return `$${(capCents / 100).toFixed(0)}`;
+}
+
+// -- Checkout orchestration (mirrors the previous per-card PlanCard logic) --
+
+async function executeCheckout(
+  planName: PlanName,
+  tierKey: TierKey | null,
+  appInterval: BillingInterval,
+  handlers: Pick<
+    CheckoutHandlers,
+    "onPlanUpdated" | "setLoadingCardId" | "setConfirmOpen"
+  >
+): Promise<void> {
+  handlers.setLoadingCardId(planName);
+  try {
+    if (planName === "free") {
+      const result = await cancelSubscription();
+      if (!result.success) {
+        return;
+      }
+      if (result.periodEnd) {
+        const endDate = new Intl.DateTimeFormat("en-US", {
+          month: "long",
+          day: "numeric",
+          year: "numeric",
+        }).format(new Date(result.periodEnd));
+        toast.success(
+          `Your subscription will cancel on ${endDate}. You keep your current plan until then.`
+        );
+      } else {
+        toast.success("Subscription canceled.");
+      }
+      handlers.setConfirmOpen(false);
+      await handlers.onPlanUpdated?.();
+      return;
+    }
+    const updated = await startCheckout(planName, tierKey, appInterval);
+    if (updated) {
+      handlers.setConfirmOpen(false);
+      await handlers.onPlanUpdated?.();
+    }
+  } catch {
+    toast.error("Something went wrong. Please try again.");
+  } finally {
+    handlers.setLoadingCardId(null);
+  }
+}
+
+function handleSubscribe(
+  planName: PlanName,
+  tierKey: TierKey | null,
+  appInterval: BillingInterval,
+  handlers: CheckoutHandlers
+): void {
+  if (planName === "enterprise") {
+    window.open(
+      "mailto:human@keeperhub.com?subject=Enterprise%20Plan",
+      "_blank",
+      "noopener"
+    );
+    return;
+  }
+  const isCurrent = isCurrentPlan(
+    planName,
+    tierKey,
+    appInterval,
+    handlers.currentPlan,
+    handlers.currentTier,
+    handlers.currentInterval
+  );
+  if (isCurrent) {
+    return;
+  }
+  if (planName === "free" && handlers.hasSubscription) {
+    handlers.setConfirmTarget({ planName, tierKey, appInterval });
+    handlers.setConfirmOpen(true);
+    return;
+  }
+  if (planName === "free") {
+    return;
+  }
+  if (handlers.hasSubscription) {
+    handlers.setConfirmTarget({ planName, tierKey, appInterval });
+    handlers.setConfirmOpen(true);
+    return;
+  }
+  executeCheckout(planName, tierKey, appInterval, handlers).catch(() => {
+    // handled inside executeCheckout
+  });
+}
+
+// -- Card builders --
+
+function buildFreeCard(params: {
+  currentPlan: PlanName;
+  freePriceDisplay: string;
+  gasCreditCaps?: GasCreditCapsMap;
+  hasSubscription: boolean;
+  loading: boolean;
+  onSelect: (context: PricingCtaContext) => void;
+}): PkgPricingCard {
+  const {
+    currentPlan,
+    freePriceDisplay,
+    gasCreditCaps,
+    hasSubscription,
+    loading,
+    onSelect,
+  } = params;
+  const plan = PLANS.free;
+  const isCurrent = currentPlan === "free";
+  const capCents = gasCreditCaps?.free ?? plan.features.gasCreditsCents;
+
+  return {
+    id: "free",
+    name: "Pay per execution",
+    highlight: isCurrent,
+    badgeText: isCurrent ? "CURRENT" : undefined,
+    metricsLabel: "Includes per month",
+    fixedPrice: freePriceDisplay,
+    fixedSubtitle: "Free to start. No commitments.",
+    fixedMetrics: [
+      {
+        label: "Executions",
+        value: plan.features.maxExecutionsPerMonth.toLocaleString(),
+      },
+      { label: "Gas credits", value: formatCardGas(capCents) },
+    ],
+    cta: {
+      label: getButtonLabel("free", isCurrent, loading, hasSubscription),
+      onClick: onSelect,
+      variant: "primary",
+      disabled: isCurrent || loading,
+    },
+    footnote: `${plan.features.maxExecutionsPerMonth.toLocaleString()} free / mo, then pay-as-you-go`,
+  };
+}
+
+function buildTieredCard(params: {
+  planName: TieredPlanName;
+  interval: BillingInterval;
+  selectedTier: TierKey | null;
+  currentPlan: PlanName;
+  currentTier: TierKey | null | undefined;
+  currentInterval: BillingInterval | null | undefined;
+  gasCreditCaps?: GasCreditCapsMap;
+  hasSubscription: boolean;
+  loading: boolean;
+  onSelect: (context: PricingCtaContext) => void;
+}): PkgPricingCard {
+  const {
+    planName,
+    interval,
+    selectedTier,
+    currentPlan,
+    currentTier,
+    currentInterval,
+    gasCreditCaps,
+    hasSubscription,
+    loading,
+    onSelect,
+  } = params;
+  const plan = PLANS[planName];
+  const isCurrent = isCurrentPlan(
+    planName,
+    selectedTier,
+    interval,
+    currentPlan,
+    currentTier,
+    currentInterval
+  );
+  const capCents = gasCreditCaps?.[planName] ?? plan.features.gasCreditsCents;
+  const gas = formatCardGas(capCents);
+  const isHighlighted = currentPlan === planName;
+
+  return {
+    id: planName,
+    name: plan.name,
+    highlight: isHighlighted,
+    badgeText: isHighlighted ? "CURRENT" : undefined,
+    metricsLabel: "Includes per month",
+    tiers: plan.tiers.map((tier) => ({
+      key: tier.key,
+      executions: tier.executions.toLocaleString(),
+      monthlyPrice: tier.monthlyPrice,
+      annualPrice: tier.monthlyPriceAnnual,
+      gas,
+    })),
+    tierKey: selectedTier ?? undefined,
+    cta: {
+      label: getButtonLabel(planName, isCurrent, loading, hasSubscription),
+      onClick: onSelect,
+      variant: "secondary",
+      disabled: isCurrent || loading,
+    },
+    footnote: plan.overage.enabled
+      ? `$${plan.overage.ratePerThousand}/1K additional executions`
+      : undefined,
+  };
+}
+
+function buildEnterpriseCard(params: {
+  currentPlan: PlanName;
+  currentTier: TierKey | null | undefined;
+  currentInterval: BillingInterval | null | undefined;
+  interval: BillingInterval;
+  hasSubscription: boolean;
+  loading: boolean;
+  onSelect: (context: PricingCtaContext) => void;
+}): PkgPricingCard {
+  const {
+    currentPlan,
+    currentTier,
+    currentInterval,
+    interval,
+    hasSubscription,
+    loading,
+    onSelect,
+  } = params;
+  const plan = PLANS.enterprise;
+  const isCurrent = isCurrentPlan(
+    "enterprise",
+    null,
+    interval,
+    currentPlan,
+    currentTier,
+    currentInterval
+  );
+  const isHighlighted = currentPlan === "enterprise";
+
+  return {
+    id: "enterprise",
+    name: plan.name,
+    highlight: isHighlighted,
+    badgeText: isHighlighted ? "CURRENT" : undefined,
+    metricsLabel: "Includes per month",
+    fixedPrice: "Custom",
+    fixedSubtitle: "Custom everything",
+    fixedMetrics: [
+      { label: "Executions", value: "Custom" },
+      { label: "Gas credits", value: "Custom" },
+    ],
+    cta: {
+      label: getButtonLabel("enterprise", isCurrent, loading, hasSubscription),
+      onClick: onSelect,
+      variant: "secondary",
+      disabled: isCurrent || loading,
+    },
+    footnote: "Custom overage terms",
+  };
+}
+
+function buildCards(params: {
+  currentPlan: PlanName;
+  currentTier: TierKey | null | undefined;
+  currentInterval: BillingInterval | null | undefined;
+  interval: BillingInterval;
+  selectedTierByCard: Record<TieredPlanName, TierKey | null>;
+  gasCreditCaps: GasCreditCapsMap | undefined;
+  hasSubscription: boolean;
+  loadingCardId: PlanName | null;
+  freePriceDisplay: string;
+  onSelect: (planName: PlanName, context: PricingCtaContext) => void;
+}): PkgPricingCard[] {
+  const {
+    currentPlan,
+    currentTier,
+    currentInterval,
+    interval,
+    selectedTierByCard,
+    gasCreditCaps,
+    hasSubscription,
+    loadingCardId,
+    freePriceDisplay,
+    onSelect,
+  } = params;
+
+  return [
+    buildFreeCard({
+      currentPlan,
+      freePriceDisplay,
+      gasCreditCaps,
+      hasSubscription,
+      loading: loadingCardId === "free",
+      onSelect: (context) => onSelect("free", context),
+    }),
+    buildTieredCard({
+      planName: "pro",
+      interval,
+      selectedTier: selectedTierByCard.pro,
+      currentPlan,
+      currentTier,
+      currentInterval,
+      gasCreditCaps,
+      hasSubscription,
+      loading: loadingCardId === "pro",
+      onSelect: (context) => onSelect("pro", context),
+    }),
+    buildTieredCard({
+      planName: "business",
+      interval,
+      selectedTier: selectedTierByCard.business,
+      currentPlan,
+      currentTier,
+      currentInterval,
+      gasCreditCaps,
+      hasSubscription,
+      loading: loadingCardId === "business",
+      onSelect: (context) => onSelect("business", context),
+    }),
+    buildEnterpriseCard({
+      currentPlan,
+      currentTier,
+      currentInterval,
+      interval,
+      hasSubscription,
+      loading: loadingCardId === "enterprise",
+      onSelect: (context) => onSelect("enterprise", context),
+    }),
+  ];
+}
+
+// -- Comparison table --
+
 const EXECUTIONS_INCLUDED: Record<PlanName, number> = {
   free: PLANS.free.features.maxExecutionsPerMonth,
   pro: PLANS.pro.tiers[0]?.executions ?? 0,
   business: PLANS.business.tiers[0]?.executions ?? 0,
   enterprise: PLANS.enterprise.features.maxExecutionsPerMonth,
 };
+
+const PER_EXECUTION_HINT =
+  "Cost per execution once a plan's monthly limit is reached. Free uses pay-as-you-go, charged in USDC from your organization wallet; paid plans bill overage on the next invoice.";
+
+const SPONSORED_GAS_HINT = `Sponsored via Turnkey Gas Station. Mainnets: ${SPONSORSHIP_MAINNET_NAMES.join(
+  ", "
+)}. Testnets: ${SPONSORSHIP_TESTNET_NAMES.join(
+  ", "
+)}. Monthly cap of sponsored gas credits in USD; transactions on other chains fall back to your wallet's native balance for gas.`;
+
+const STATIC_COMPARISON_ROWS: readonly PkgComparisonRow[] = [
+  {
+    label: "Chains",
+    cells: {
+      free: "All EVM + Solana",
+      pro: "All EVM + Solana",
+      business: "All EVM + Solana",
+      enterprise: "All EVM + Solana",
+    },
+  },
+  {
+    label: "Triggers",
+    cells: {
+      free: "Standard",
+      pro: "Advanced",
+      business: "Advanced + Custom",
+      enterprise: "Custom",
+    },
+  },
+  {
+    label: "API",
+    cells: {
+      free: "Rate-limited",
+      pro: "Full",
+      business: "Full",
+      enterprise: "Full",
+    },
+  },
+  {
+    label: "Logs",
+    cells: {
+      free: "7 days",
+      pro: "30 days",
+      business: "90 days",
+      enterprise: "Custom",
+    },
+  },
+  {
+    label: "Support",
+    cells: {
+      free: "Community",
+      pro: "Email",
+      business: "Dedicated",
+      enterprise: "Dedicated (1h)",
+    },
+  },
+  {
+    label: "SLA",
+    cells: {
+      free: "—",
+      pro: "—",
+      business: "99.9%",
+      enterprise: "99.999%",
+    },
+  },
+  {
+    label: "Builder",
+    cells: {
+      free: "Visual + AI",
+      pro: "Visual + AI",
+      business: "Visual + AI",
+      enterprise: "Visual + AI",
+    },
+  },
+  {
+    label: "MCP Server",
+    cells: {
+      free: "Included",
+      pro: "Included",
+      business: "Included",
+      enterprise: "Included",
+    },
+  },
+  {
+    label: "Ops team",
+    cells: {
+      free: "—",
+      pro: "—",
+      business: "—",
+      enterprise: "Dedicated",
+    },
+  },
+];
 
 function formatExecutions(count: number): string {
   return count === -1 ? "Unlimited" : count.toLocaleString();
@@ -61,173 +519,177 @@ function formatGasCreditCap(planName: PlanName, capCents: number): string {
   return `$${(capCents / 100).toFixed(0)}/mo`;
 }
 
-/** Green "+delta" shown next to a plan value that beats the current plan. */
-function gainNode(
+/** Green "+delta" cell shown when a plan value beats the current plan. */
+function gainCell(
+  value: string,
   currentValue: number,
   planValue: number,
   format: (delta: number) => string
-): React.ReactNode {
+): PkgComparisonCell {
   if (planValue === -1 || currentValue === -1 || planValue <= currentValue) {
-    return null;
+    return value;
   }
-  return (
-    <span className="ml-1.5 text-[11px] text-keeperhub-green-dark">
-      +{format(planValue - currentValue)}
-    </span>
-  );
+  return { value, gain: `+${format(planValue - currentValue)}` };
+}
+
+function buildExecutionsRow(currentPlan: PlanName): PkgComparisonRow {
+  const currentIncluded = EXECUTIONS_INCLUDED[currentPlan];
+  const execFormat = (delta: number): string => delta.toLocaleString();
+  const cell = (planName: PlanName): PkgComparisonCell =>
+    gainCell(
+      formatExecutions(EXECUTIONS_INCLUDED[planName]),
+      currentIncluded,
+      EXECUTIONS_INCLUDED[planName],
+      execFormat
+    );
+  return {
+    label: "Executions / month",
+    cells: {
+      free: cell("free"),
+      pro: cell("pro"),
+      business: cell("business"),
+      enterprise: formatExecutions(EXECUTIONS_INCLUDED.enterprise),
+    },
+  };
+}
+
+function buildPerExecutionRow(paygPriceUsdc: string | null): PkgComparisonRow {
+  const freeCell = paygPriceUsdc
+    ? `$${Number(paygPriceUsdc).toLocaleString(undefined, {
+        maximumFractionDigits: 6,
+      })}`
+    : "Pay as you go";
+  return {
+    label: "Per extra execution",
+    hint: PER_EXECUTION_HINT,
+    cells: {
+      free: freeCell,
+      pro: formatPerExecution(PLANS.pro.overage.ratePerThousand / 1000),
+      business: formatPerExecution(
+        PLANS.business.overage.ratePerThousand / 1000
+      ),
+      enterprise: "Custom",
+    },
+  };
 }
 
 function buildSponsoredGasRow(
   currentPlan: PlanName,
-  gasCreditCaps?: Record<PlanName, number>
-): ComparisonRow {
+  gasCreditCaps?: GasCreditCapsMap
+): PkgComparisonRow {
   const resolveCents = (planName: PlanName): number =>
     gasCreditCaps?.[planName] ?? PLANS[planName].features.gasCreditsCents;
   const gasFormat = (delta: number): string =>
     `$${(delta / 100).toFixed(0)}/mo`;
-  const cell = (planName: PlanName): React.ReactNode => (
-    <>
-      {formatGasCreditCap(planName, resolveCents(planName))}
-      {gainNode(resolveCents(currentPlan), resolveCents(planName), gasFormat)}
-    </>
-  );
+  const cell = (planName: PlanName): PkgComparisonCell =>
+    gainCell(
+      formatGasCreditCap(planName, resolveCents(planName)),
+      resolveCents(currentPlan),
+      resolveCents(planName),
+      gasFormat
+    );
   return {
     label: "Sponsored gas",
-    tooltip: {
-      title: "Sponsored via Turnkey Gas Station",
-      body: (
-        <>
-          <div className="space-y-1">
-            <p className="text-[10px] uppercase tracking-wide opacity-70">
-              Mainnets
-            </p>
-            <p>{SPONSORSHIP_MAINNET_NAMES.join(", ")}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-[10px] uppercase tracking-wide opacity-70">
-              Testnets
-            </p>
-            <p>{SPONSORSHIP_TESTNET_NAMES.join(", ")}</p>
-          </div>
-          <p className="opacity-70">
-            Monthly cap of sponsored gas credits in USD. Transactions on other
-            chains fall back to your wallet's native balance for gas.
-          </p>
-        </>
-      ),
+    hint: SPONSORED_GAS_HINT,
+    cells: {
+      free: cell("free"),
+      pro: cell("pro"),
+      business: cell("business"),
+      enterprise: formatGasCreditCap("enterprise", resolveCents("enterprise")),
     },
-    free: cell("free"),
-    pro: cell("pro"),
-    business: cell("business"),
-    enterprise: formatGasCreditCap("enterprise", resolveCents("enterprise")),
   };
 }
 
-const STATIC_COMPARISON_ROWS: readonly ComparisonRow[] = [
-  {
-    label: "Chains",
-    free: "All EVM + Solana",
-    pro: "All EVM + Solana",
-    business: "All EVM + Solana",
-    enterprise: "All EVM + Solana",
-  },
-  {
-    label: "Triggers",
-    free: "Standard",
-    pro: "Advanced",
-    business: "Advanced + Custom",
-    enterprise: "Custom",
-  },
-  {
-    label: "API",
-    free: "Rate-limited",
-    pro: "Full",
-    business: "Full",
-    enterprise: "Full",
-  },
-  {
-    label: "Logs",
-    free: "7 days",
-    pro: "30 days",
-    business: "90 days",
-    enterprise: "Custom",
-  },
-  {
-    label: "Support",
-    free: "Community",
-    pro: "Email",
-    business: "Dedicated",
-    enterprise: "Dedicated (1h)",
-  },
-  {
-    label: "SLA",
-    free: "\u2014",
-    pro: "\u2014",
-    business: "99.9%",
-    enterprise: "99.999%",
-  },
-  {
-    label: "Builder",
-    free: "Visual + AI",
-    pro: "Visual + AI",
-    business: "Visual + AI",
-    enterprise: "Visual + AI",
-  },
-  {
-    label: "MCP Server",
-    free: "Included",
-    pro: "Included",
-    business: "Included",
-    enterprise: "Included",
-  },
-  {
-    label: "Ops team",
-    free: "\u2014",
-    pro: "\u2014",
-    business: "\u2014",
-    enterprise: "Dedicated",
-  },
-];
-
-function ComparisonRowLabel({
-  row,
-}: {
-  row: ComparisonRow;
-}): React.ReactElement {
-  if (!row.tooltip) {
-    return <>{row.label}</>;
-  }
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      {row.label}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            aria-label={`Learn more about ${row.label}`}
-            className="inline-flex items-center text-muted-foreground/70 transition-colors hover:text-foreground"
-            type="button"
-          >
-            <Info className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent className="max-w-xs space-y-2 px-3 py-2 text-left">
-          <p className="font-medium">{row.tooltip.title}</p>
-          {row.tooltip.body}
-        </TooltipContent>
-      </Tooltip>
-    </span>
-  );
+function buildComparisonRows(
+  currentPlan: PlanName,
+  gasCreditCaps: GasCreditCapsMap | undefined,
+  paygPriceUsdc: string | null
+): PkgComparisonRow[] {
+  return [
+    buildExecutionsRow(currentPlan),
+    buildPerExecutionRow(paygPriceUsdc),
+    ...STATIC_COMPARISON_ROWS.slice(0, 2),
+    buildSponsoredGasRow(currentPlan, gasCreditCaps),
+    ...STATIC_COMPARISON_ROWS.slice(2),
+  ];
 }
 
-function ComparisonTable({
-  currentPlan,
+function buildComparisonColumns(): PkgComparisonColumn[] {
+  return PLAN_ORDER.map((planName) => ({
+    key: planName,
+    label: planName === "free" ? "Pay per execution" : PLANS[planName].name,
+  }));
+}
+
+// -- Confirm dialog derived data --
+
+type DialogData = {
+  planName: PlanName;
+  tierKey: TierKey | null;
+  appInterval: BillingInterval;
+  price: number;
+  tierLabel: string | null;
+  currentExecutions: number;
+  newExecutions: number;
+};
+
+function buildDialogData(
+  target: ConfirmTarget | null,
+  currentPlan: PlanName,
+  currentTier: TierKey | null | undefined
+): DialogData {
+  const resolved = target ?? {
+    planName: "free" as PlanName,
+    tierKey: null,
+    appInterval: "monthly" as BillingInterval,
+  };
+  const activeTier = PLANS[resolved.planName].tiers.find(
+    (tier) => tier.key === resolved.tierKey
+  );
+  return {
+    planName: resolved.planName,
+    tierKey: resolved.tierKey,
+    appInterval: resolved.appInterval,
+    price:
+      computeDisplayPrice(
+        resolved.planName,
+        activeTier,
+        resolved.appInterval
+      ) ?? 0,
+    tierLabel: activeTier
+      ? `${activeTier.executions.toLocaleString()} executions`
+      : null,
+    currentExecutions: resolveExecutions(currentPlan, currentTier),
+    newExecutions: resolveExecutions(resolved.planName, resolved.tierKey),
+  };
+}
+
+export function PricingTable({
+  currentPlan = "free",
+  currentTier,
+  currentInterval,
   gasCreditCaps,
-}: {
-  currentPlan: PlanName;
-  gasCreditCaps?: Record<PlanName, number>;
-}): React.ReactElement {
-  const [isOpen, setIsOpen] = useState(true);
+  onPlanUpdated,
+}: PricingTableProps): React.ReactElement {
+  const [interval, setInterval] = useState<BillingInterval>("monthly");
+  const [selectedTierByCard, setSelectedTierByCard] = useState<
+    Record<TieredPlanName, TierKey | null>
+  >({
+    pro:
+      currentPlan === "pro" && currentTier
+        ? currentTier
+        : (PLANS.pro.tiers[0]?.key ?? null),
+    business:
+      currentPlan === "business" && currentTier
+        ? currentTier
+        : (PLANS.business.tiers[0]?.key ?? null),
+  });
+  const [loadingCardId, setLoadingCardId] = useState<PlanName | null>(null);
   const [paygPriceUsdc, setPaygPriceUsdc] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmTarget, setConfirmTarget] = useState<ConfirmTarget | null>(
+    null
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -242,232 +704,104 @@ function ComparisonTable({
       }
     }
     loadPrice().catch(() => {
-      // PAYG price is optional context for this table; ignore load failures.
+      // PAYG price is optional context for pricing display; ignore load failures.
     });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const currentIncluded = EXECUTIONS_INCLUDED[currentPlan];
-  const execFormat = (delta: number): string => delta.toLocaleString();
-
-  const executionsRow: ComparisonRow = {
-    label: "Executions / month",
-    free: (
-      <>
-        {formatExecutions(EXECUTIONS_INCLUDED.free)}
-        {gainNode(currentIncluded, EXECUTIONS_INCLUDED.free, execFormat)}
-      </>
-    ),
-    pro: (
-      <>
-        {formatExecutions(EXECUTIONS_INCLUDED.pro)}
-        {gainNode(currentIncluded, EXECUTIONS_INCLUDED.pro, execFormat)}
-      </>
-    ),
-    business: (
-      <>
-        {formatExecutions(EXECUTIONS_INCLUDED.business)}
-        {gainNode(currentIncluded, EXECUTIONS_INCLUDED.business, execFormat)}
-      </>
-    ),
-    enterprise: formatExecutions(EXECUTIONS_INCLUDED.enterprise),
+  const hasSubscription = currentPlan !== "free";
+  const handlers: CheckoutHandlers = {
+    currentPlan,
+    currentTier,
+    currentInterval,
+    hasSubscription,
+    onPlanUpdated,
+    setLoadingCardId,
+    setConfirmTarget,
+    setConfirmOpen,
   };
 
-  const perExecutionRow: ComparisonRow = {
-    label: "Per extra execution",
-    tooltip: {
-      title: "Beyond the included limit",
-      body: (
-        <p>
-          Cost per execution once a plan's monthly limit is reached. Free uses
-          pay-as-you-go, charged in USDC from your organization wallet; paid
-          plans bill overage on the next invoice.
-        </p>
-      ),
-    },
-    free: paygPriceUsdc
-      ? `$${Number(paygPriceUsdc).toLocaleString(undefined, {
-          maximumFractionDigits: 6,
-        })}`
-      : "Pay as you go",
-    pro: formatPerExecution(PLANS.pro.overage.ratePerThousand / 1000),
-    business: formatPerExecution(PLANS.business.overage.ratePerThousand / 1000),
-    enterprise: "Custom",
-  };
+  function onCardCta(planName: PlanName, context: PricingCtaContext): void {
+    const tierKey = (context.tierKey as TierKey | undefined) ?? null;
+    handleSubscribe(
+      planName,
+      tierKey,
+      pkgIntervalToApp(context.interval),
+      handlers
+    );
+  }
 
-  const rows: ComparisonRow[] = [
-    executionsRow,
-    perExecutionRow,
-    ...STATIC_COMPARISON_ROWS.slice(0, 2),
-    buildSponsoredGasRow(currentPlan, gasCreditCaps),
-    ...STATIC_COMPARISON_ROWS.slice(2),
-  ];
+  function onCardTierChange(cardId: string, tierKey: string): void {
+    if (cardId === "pro" || cardId === "business") {
+      setSelectedTierByCard((prev) => ({
+        ...prev,
+        [cardId]: tierKey as TierKey,
+      }));
+    }
+  }
 
-  return (
-    <div className="mx-auto mt-6 max-w-7xl">
-      <button
-        className="mx-auto flex cursor-pointer items-center gap-2 text-keeperhub-green-dark text-sm transition-colors hover:text-keeperhub-green"
-        onClick={() => setIsOpen((v) => !v)}
-        type="button"
-      >
-        <span>{isOpen ? "Hide comparison" : "Compare all features"}</span>
-        <ChevronDown
-          className={cn(
-            "size-4 transition-transform duration-200",
-            isOpen && "rotate-180"
-          )}
-        />
-      </button>
+  const freePriceDisplay = formatFreePrice(paygPriceUsdc);
+  const cards = buildCards({
+    currentPlan,
+    currentTier,
+    currentInterval,
+    interval,
+    selectedTierByCard,
+    gasCreditCaps,
+    hasSubscription,
+    loadingCardId,
+    freePriceDisplay,
+    onSelect: onCardCta,
+  });
 
-      {isOpen && (
-        <div className="mt-6 overflow-x-auto rounded-2xl border border-border/60 bg-sidebar">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border/60">
-                <th className="w-[20%] px-5 py-3.5 text-left font-medium text-muted-foreground">
-                  Feature
-                </th>
-                {PLAN_ORDER.map((plan) => (
-                  <th
-                    className={cn(
-                      "w-[20%] px-5 py-3.5 text-center font-medium",
-                      plan === currentPlan && "text-keeperhub-green-dark"
-                    )}
-                    key={plan}
-                  >
-                    {plan === "free" ? "Pay per execution" : PLANS[plan].name}
-                    {plan === currentPlan && (
-                      <span className="block font-normal text-[10px] text-keeperhub-green-dark/80 uppercase tracking-wide">
-                        Current plan
-                      </span>
-                    )}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row) => (
-                <tr
-                  className="border-b border-border/30 last:border-b-0"
-                  key={row.label}
-                >
-                  <td className="px-5 py-3 font-medium text-muted-foreground">
-                    <ComparisonRowLabel row={row} />
-                  </td>
-                  {PLAN_ORDER.map((plan) => (
-                    <td
-                      className={cn(
-                        "px-5 py-3 text-center",
-                        plan === currentPlan
-                          ? "text-keeperhub-green-dark"
-                          : "text-foreground"
-                      )}
-                      key={plan}
-                    >
-                      {row[plan]}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
+  const comparisonColumns = buildComparisonColumns();
+  const comparisonRows = buildComparisonRows(
+    currentPlan,
+    gasCreditCaps,
+    paygPriceUsdc
   );
-}
-
-export function PricingTable({
-  currentPlan = "free",
-  currentTier,
-  currentInterval,
-  gasCreditCaps,
-  onPlanUpdated,
-}: PricingTableProps): React.ReactElement {
-  const [interval, setInterval] = useState<BillingInterval>("monthly");
+  const dialogData = buildDialogData(confirmTarget, currentPlan, currentTier);
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center justify-center gap-3">
-        <div className="inline-flex items-center gap-1 rounded-full border border-border/60 bg-sidebar p-1">
-          <button
-            className={cn(
-              "rounded-full px-5 py-2 font-medium text-sm transition-colors",
-              interval === "monthly"
-                ? "bg-keeperhub-green-dark text-white shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-            onClick={() => setInterval("monthly")}
-            type="button"
-          >
-            Monthly
-          </button>
-          <button
-            className={cn(
-              "flex items-center gap-2 rounded-full px-5 py-2 font-medium text-sm transition-colors",
-              interval === "yearly"
-                ? "bg-keeperhub-green-dark text-white shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            )}
-            onClick={() => setInterval("yearly")}
-            type="button"
-          >
-            Annual
-          </button>
-        </div>
-        <Badge className="border border-keeperhub-green-dark/20 bg-keeperhub-green-dark/10 text-keeperhub-green-dark text-xs font-medium">
-          Save 20%
-        </Badge>
-      </div>
+      <PricingCards
+        cards={cards}
+        interval={appIntervalToPkg(interval)}
+        onIntervalChange={(next) => setInterval(pkgIntervalToApp(next))}
+        onTierChange={onCardTierChange}
+      />
 
-      <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
-        <PlanCard
-          currentInterval={currentInterval}
-          currentPlan={currentPlan}
-          currentTier={currentTier}
-          gasCreditCaps={gasCreditCaps}
-          interval={interval}
-          onPlanUpdated={onPlanUpdated}
-          plan={PLANS.free}
-          planName="free"
-        />
-        <PlanCard
-          currentInterval={currentInterval}
-          currentPlan={currentPlan}
-          currentTier={currentTier}
-          gasCreditCaps={gasCreditCaps}
-          interval={interval}
-          onPlanUpdated={onPlanUpdated}
-          plan={PLANS.pro}
-          planName="pro"
-        />
-        <PlanCard
-          currentInterval={currentInterval}
-          currentPlan={currentPlan}
-          currentTier={currentTier}
-          gasCreditCaps={gasCreditCaps}
-          interval={interval}
-          onPlanUpdated={onPlanUpdated}
-          plan={PLANS.business}
-          planName="business"
-        />
-        <PlanCard
-          currentInterval={currentInterval}
-          currentPlan={currentPlan}
-          currentTier={currentTier}
-          gasCreditCaps={gasCreditCaps}
-          interval={interval}
-          onPlanUpdated={onPlanUpdated}
-          plan={PLANS.enterprise}
-          planName="enterprise"
-        />
-      </div>
+      <PricingComparisonTable
+        collapsible
+        columns={comparisonColumns}
+        currentColumnKey={currentPlan}
+        defaultOpen
+        rows={comparisonRows}
+      />
 
-      <ComparisonTable
-        currentPlan={currentPlan}
+      <ConfirmPlanChangeDialog
+        currentExecutions={dialogData.currentExecutions}
+        currentPlanName={currentPlan}
         gasCreditCaps={gasCreditCaps}
+        interval={dialogData.appInterval}
+        newExecutions={dialogData.newExecutions}
+        newPlanName={dialogData.planName}
+        newTier={dialogData.tierKey}
+        onConfirm={() =>
+          executeCheckout(
+            dialogData.planName,
+            dialogData.tierKey,
+            dialogData.appInterval,
+            handlers
+          )
+        }
+        onOpenChange={setConfirmOpen}
+        open={confirmOpen}
+        planName={PLANS[dialogData.planName].name}
+        price={dialogData.price}
+        tierLabel={dialogData.tierLabel}
       />
 
       <p className="text-center text-muted-foreground text-xs">

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "ioredis": "5.4.2",
     "jose": "^6.2.2",
     "jotai": "^2.19.0",
+    "keeperhub-pricing-ui": "^0.1.1",
     "lucide-react": "^0.577.0",
     "motion": "^12.38.0",
     "mppx": "^0.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       jotai:
         specifier: ^2.19.0
         version: 2.19.0(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.14)(react@19.2.4)
+      keeperhub-pricing-ui:
+        specifier: ^0.1.1
+        version: 0.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.4)
@@ -370,7 +373,7 @@ importers:
         version: 5.9.3
       ultracite:
         specifier: 6.5.1
-        version: 6.5.1(effect@3.21.2)(typescript@5.9.3)
+        version: 6.5.1(effect@3.21.2)(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3))
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -7166,6 +7169,13 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
+
+  keeperhub-pricing-ui@0.1.1:
+    resolution: {integrity: sha512-E9PKIv23V8CUoUVxcVqoWKwpVwCqq2/r0RttE3MbZa5SHOjCcPNAt/gfLiaTn1BiPC5+CeRCZiM8vuqM5UlDOA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -17371,6 +17381,11 @@ snapshots:
 
   jwt-decode@4.0.0: {}
 
+  keeperhub-pricing-ui@0.1.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -19145,12 +19160,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  trpc-cli@0.12.4(@trpc/server@11.15.0(typescript@5.9.3))(effect@3.21.2)(zod@4.3.6):
+  trpc-cli@0.12.4(@trpc/server@11.15.0(typescript@5.9.3))(effect@3.21.2)(valibot@1.4.2(typescript@5.9.3))(zod@4.3.6):
     dependencies:
       commander: 14.0.3
     optionalDependencies:
       '@trpc/server': 11.15.0(typescript@5.9.3)
       effect: 3.21.2
+      valibot: 1.4.2(typescript@5.9.3)
       zod: 4.3.6
 
   ts-command-line-args@2.5.1:
@@ -19246,7 +19262,7 @@ snapshots:
 
   ulid@3.0.2: {}
 
-  ultracite@6.5.1(effect@3.21.2)(typescript@5.9.3):
+  ultracite@6.5.1(effect@3.21.2)(typescript@5.9.3)(valibot@1.4.2(typescript@5.9.3)):
     dependencies:
       '@clack/prompts': 0.11.0
       '@trpc/server': 11.15.0(typescript@5.9.3)
@@ -19255,7 +19271,7 @@ snapshots:
       jsonc-parser: 3.3.1
       nypm: 0.6.5
       picocolors: 1.1.1
-      trpc-cli: 0.12.4(@trpc/server@11.15.0(typescript@5.9.3))(effect@3.21.2)(zod@4.3.6)
+      trpc-cli: 0.12.4(@trpc/server@11.15.0(typescript@5.9.3))(effect@3.21.2)(valibot@1.4.2(typescript@5.9.3))(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@orpc/server'


### PR DESCRIPTION
Migrates the app billing page to render `PricingCards` and `PricingComparisonTable` from the shared `keeperhub-pricing-ui` package (public npm), so the app and marketing landing share one pricing component and look. Checkout, the confirm-plan-change dialog, downgrade/cancel, current-plan highlight, tier selection (preselected to the subscriber's tier via the package's controlled `tierKey`), gas credits, and the live PAYG price on the free card are all preserved. The per-card checkout logic is lifted to the table level.

Stacked on the pay-as-you-go branch and kept as its own PR, separate from that one. Adopts the shared green card style in app billing.

Notes for review:
- Gas-credits metric now always renders on tiered cards. Previously it was hidden when `NEXT_PUBLIC_GAS_SPONSORSHIP_ENABLED` is not `true`; if that flag is off in an environment, gas shows where it did not before.
- Comparison-row tooltips are now native title hovers rather than the Radix tooltip.
- `tests/e2e/playwright/billing.test.ts` targets `data-testid="plan-card-pro"`, which the shared cards do not emit; it has a role-based fallback selector but should be run to confirm.