### PR TITLE
fix: #2057 collect listing inputs before manual workflow run

### DIFF
--- a/components/overlays/manual-run-input-overlay.tsx
+++ b/components/overlays/manual-run-input-overlay.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Overlay } from "@/components/overlays/overlay";
+import { useOverlay } from "@/components/overlays/overlay-provider";
+import type { OverlayComponentProps } from "@/components/overlays/types";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  buildManualRunSample,
+  validateManualRunInput,
+} from "@/lib/workflow/editor/manual-run-input";
+
+type ManualRunInputOverlayProps = OverlayComponentProps<{
+  inputSchema: Record<string, unknown>;
+  onSubmit: (input: Record<string, unknown>) => void | Promise<void>;
+}>;
+
+export function ManualRunInputOverlay({
+  overlayId,
+  inputSchema,
+  onSubmit,
+}: ManualRunInputOverlayProps) {
+  const { pop } = useOverlay();
+  const initialValue = useMemo(
+    () => JSON.stringify(buildManualRunSample(inputSchema), null, 2),
+    [inputSchema]
+  );
+  const [value, setValue] = useState(initialValue);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    try {
+      const input = JSON.parse(value) as unknown;
+      if (!input || typeof input !== "object" || Array.isArray(input)) {
+        setError("Input must be a JSON object.");
+        return;
+      }
+      const errors = validateManualRunInput(
+        inputSchema,
+        input as Record<string, unknown>
+      );
+      if (errors.length > 0) {
+        setError(errors.join(" "));
+        return;
+      }
+      await onSubmit(input as Record<string, unknown>);
+      pop();
+    } catch {
+      setError("Input must be valid JSON.");
+    }
+  };
+
+  return (
+    <Overlay
+      actions={[
+        { label: "Cancel", onClick: pop, variant: "outline" },
+        { label: "Run workflow", onClick: handleSubmit },
+      ]}
+      description="Provide the same input object exposed to Marketplace callers."
+      overlayId={overlayId}
+      title="Test workflow input"
+    >
+      <div className="space-y-2">
+        <Label htmlFor="manual-run-input">Input JSON</Label>
+        <Textarea
+          aria-invalid={error ? true : undefined}
+          className="min-h-64 font-mono text-sm"
+          id="manual-run-input"
+          onChange={(event) => {
+            setValue(event.target.value);
+            setError(null);
+          }}
+          value={value}
+        />
+        {error && (
+          <p className="text-destructive text-sm" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Overlay>
+  );
+}

--- a/components/workflow/workflow-toolbar.tsx
+++ b/components/workflow/workflow-toolbar.tsx
@@ -27,6 +27,7 @@ import { ButtonGroup } from "@/components/ui/button-group";
 import { OrgSwitcher } from "@/components/organization/org-switcher";
 import { GoLiveOverlay } from "@/components/overlays/go-live-overlay";
 import { ListingOverlay } from "@/components/overlays/listing-overlay";
+import { ManualRunInputOverlay } from "@/components/overlays/manual-run-input-overlay";
 import { Switch } from "@/components/ui/switch";
 import { WalletToolbarButton } from "@/components/workflow/wallet-toolbar-button";
 import { BUILTIN_NODE_ID } from "@/lib/workflow/editor/builtin-variables";
@@ -43,6 +44,7 @@ import type { IntegrationType } from "@/lib/types/integration";
 import { cn } from "@/lib/utils";
 import { evaluateShowWhen, type ShowWhen } from "@/lib/workflow/editor/show-when";
 import { runWorkflowValidationPreflight } from "@/lib/workflow/editor/run-validation";
+import { hasManualRunInputs } from "@/lib/workflow/editor/manual-run-input";
 import { ensureSavedBeforeRun } from "@/lib/workflow/run-preflight";
 import {
   addNodeAtom,
@@ -446,6 +448,7 @@ function getMissingIntegrations(
 
 type ExecuteTestWorkflowParams = {
   workflowId: string;
+  input: Record<string, unknown>;
   nodes: WorkflowNode[];
   updateNodeData: (update: {
     id: string;
@@ -460,6 +463,7 @@ type ExecuteTestWorkflowParams = {
 
 async function executeTestWorkflow({
   workflowId,
+  input,
   nodes,
   updateNodeData,
   pollingIntervalRef,
@@ -485,7 +489,7 @@ async function executeTestWorkflow({
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ input: {} }),
+      body: JSON.stringify({ input }),
     });
 
     if (!response.ok) {
@@ -618,6 +622,7 @@ function useWorkflowHandlers({
   const [isPreflighting, setIsPreflighting] = useState(false);
   const setRunsRefreshTrigger = useSetAtom(runsRefreshTriggerAtom);
   const previewVersion = useAtomValue(previewVersionAtom);
+  const inputSchema = useAtomValue(currentWorkflowInputSchemaAtom);
 
   // Cleanup polling interval on unmount
   useEffect(
@@ -656,7 +661,9 @@ function useWorkflowHandlers({
     await saveWorkflow();
   };
 
-  const startWorkflowExecution = async () => {
+  const startWorkflowExecution = async (
+    input: Record<string, unknown> = {}
+  ) => {
     if (!currentWorkflowId) {
       return;
     }
@@ -672,6 +679,7 @@ function useWorkflowHandlers({
     setIsExecuting(true);
     await executeTestWorkflow({
       workflowId: currentWorkflowId,
+      input,
       nodes,
       updateNodeData,
       pollingIntervalRef,
@@ -681,6 +689,22 @@ function useWorkflowHandlers({
       onExecutionStarted: () => setRunsRefreshTrigger((c) => c + 1),
     });
     // Don't set executing to false here - let polling handle it
+  };
+
+  const collectInputAndStartWorkflow = async () => {
+    const hasManualTrigger = nodes.some(
+      (node) =>
+        node.data.type === "trigger" &&
+        (node.data.config?.triggerType ?? "Manual") === "Manual"
+    );
+    if (hasManualTrigger && hasManualRunInputs(inputSchema)) {
+      openOverlay(ManualRunInputOverlay, {
+        inputSchema: inputSchema ?? {},
+        onSubmit: startWorkflowExecution,
+      });
+      return;
+    }
+    await startWorkflowExecution();
   };
 
   const executeWorkflow = async () => {
@@ -731,7 +755,7 @@ function useWorkflowHandlers({
             onRunAnyway,
           });
         },
-        onStartWorkflowExecution: startWorkflowExecution,
+        onStartWorkflowExecution: collectInputAndStartWorkflow,
         onError: (message) => toast.error(message),
       });
     } finally {

--- a/lib/workflow/editor/manual-run-input.test.ts
+++ b/lib/workflow/editor/manual-run-input.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildManualRunSample,
+  hasManualRunInputs,
+  validateManualRunInput,
+} from "./manual-run-input";
+
+const schema = {
+  type: "object",
+  properties: {
+    sender: { type: "string" },
+    value: { type: "string", default: "0" },
+    dryRun: { type: "boolean" },
+  },
+  required: ["sender", "value"],
+};
+
+describe("manual run input", () => {
+  it("detects workflows with declared inputs", () => {
+    expect(hasManualRunInputs(schema)).toBe(true);
+    expect(hasManualRunInputs({ type: "object", properties: {} })).toBe(false);
+  });
+
+  it("builds a schema-shaped starting payload", () => {
+    expect(buildManualRunSample(schema)).toEqual({
+      sender: "",
+      value: "0",
+      dryRun: false,
+    });
+  });
+
+  it("reports every missing required input", () => {
+    expect(validateManualRunInput(schema, {})).toEqual([
+      'Required input "sender" is missing.',
+      'Required input "value" is missing.',
+    ]);
+  });
+});

--- a/lib/workflow/editor/manual-run-input.ts
+++ b/lib/workflow/editor/manual-run-input.ts
@@ -1,0 +1,62 @@
+type InputSchema = Record<string, unknown>;
+
+export function hasManualRunInputs(schema: InputSchema | null): boolean {
+  if (!schema || typeof schema.properties !== "object" || !schema.properties) {
+    return false;
+  }
+  return Object.keys(schema.properties).length > 0;
+}
+
+export function buildManualRunSample(
+  schema: InputSchema
+): Record<string, unknown> {
+  const properties = asRecord(schema.properties);
+  const result: Record<string, unknown> = {};
+  for (const [name, rawProperty] of Object.entries(properties)) {
+    result[name] = sampleValue(asRecord(rawProperty));
+  }
+  return result;
+}
+
+export function validateManualRunInput(
+  schema: InputSchema,
+  input: Record<string, unknown>
+): string[] {
+  const required = Array.isArray(schema.required)
+    ? schema.required.filter((name): name is string => typeof name === "string")
+    : [];
+  return required
+    .filter((name) => input[name] === undefined || input[name] === "")
+    .map((name) => `Required input "${name}" is missing.`);
+}
+
+function sampleValue(schema: InputSchema): unknown {
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+  if (Array.isArray(schema.examples) && schema.examples.length > 0) {
+    return schema.examples[0];
+  }
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+  if (schema.type === "boolean") {
+    return false;
+  }
+  if (schema.type === "number" || schema.type === "integer") {
+    return 0;
+  }
+  if (schema.type === "array") {
+    return [];
+  }
+  if (schema.type === "object") {
+    return buildManualRunSample(schema);
+  }
+  return "";
+}
+
+function asRecord(value: unknown): InputSchema {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as InputSchema)
+    : {};
+}


### PR DESCRIPTION
## Issue

Closes #2057

Issue #2057 is still awaiting maintainer triage. This PR is intentionally a draft until the issue receives `accepted` or triage redirects the plan; the outside-contributor issue-link check is expected to remain blocked in the meantime.

## What this changes

- Reads the listed workflow's existing `inputSchema` before a Manual editor run.
- Opens a test-input overlay when the schema declares properties, with a schema-shaped JSON payload initialized from defaults, examples, enums, and primitive types.
- Validates required values locally and passes the reviewed object to the existing execute request instead of the hard-coded empty input.
- Preserves the current one-click Run behavior for workflows without declared Manual inputs.

This changes no API response shape, database schema, authentication rule, dependency, pricing, or default for workflows without listing inputs.

## Scope

The overlay and execute-request change are one unit: collecting input without forwarding it, or forwarding input without a collection surface, would leave the editor path broken. Scheduled, webhook, and API-triggered executions are unchanged.

## How it was verified

The focused unit tests cover schema detection, sample generation, and reporting all missing required inputs. They fail without the new helper implementation.

```bash
pnpm discover-plugins
pnpm vitest run lib/workflow/editor/manual-run-input.test.ts
pnpm check
pnpm type-check
```

Results: 3 focused tests passed; Biome checked 2,013 files with no errors; full TypeScript typecheck passed.

## Screenshots

Not captured yet. This draft is pending issue triage; UI proof for initial, invalid, and valid input states will be added before marking it ready for review.

---

- [x] Targets `staging`
- [x] Title carries the issue number
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
