### PR TITLE
fix: KEEP-1216 register the schedule when a workflow is created through the API

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -517,7 +517,13 @@ export async function PATCH(
     // rather than beside the other body checks. extractScheduleConfig keys on
     // `data.type`, which only the sanitizer writes, so checking the raw body
     // let a sub-60s interval from a docs-shaped client skip this 400 entirely.
-    // This still runs ahead of the write below, so the guarantee above holds.
+    //
+    // Moving it past the visibility and project/tag gates changes nothing that
+    // persists: those only run db.select lookups and return 400/404, so no
+    // write can land ahead of this check and the guarantee above holds. It does
+    // reorder which error a doubly-invalid request sees - an invalid visibility
+    // or an unknown project now wins over SCHEDULE_INTERVAL_TOO_SMALL. Both are
+    // client errors the caller has to fix either way.
     if (Array.isArray(updateData.nodes)) {
       try {
         extractScheduleConfig(

--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -316,7 +316,8 @@ async function validateWorkflowAccess(
 
 async function handlePostUpdateSideEffects(
   workflowId: string,
-  body: Record<string, unknown>
+  body: Record<string, unknown>,
+  sanitizedNodes: unknown
 ): Promise<void> {
   // Tags are Hub-discovery only; clear them on any demote off of "public",
   // including demote-to-unlisted (link-only) and demote-to-private.
@@ -337,10 +338,18 @@ async function handlePostUpdateSideEffects(
     revalidateTag("marketplace", "max");
   }
 
+  // KEEP-1216: `body.nodes` decides WHETHER the caller sent nodes; the
+  // sanitized set decides WHAT gets synced. The row written above is the
+  // sanitized one, and extractScheduleConfig keys on `data.type`, which only
+  // the sanitizer writes. Syncing from the raw body made a request shaped the
+  // way the public API docs show it resolve to "no schedule trigger", which
+  // takes the delete branch in syncWorkflowSchedule and silently removed the
+  // schedule row - returning {synced:true}, so not even a warning. Harmless
+  // while create never registered a schedule; destructive now that it does.
   if (body.nodes !== undefined) {
     const syncResult = await syncWorkflowSchedule(
       workflowId,
-      body.nodes as Parameters<typeof syncWorkflowSchedule>[1]
+      sanitizedNodes as Parameters<typeof syncWorkflowSchedule>[1]
     );
     if (!syncResult.synced) {
       logSystemWarn(
@@ -414,28 +423,6 @@ export async function PATCH(
           },
           { status: 400 }
         );
-      }
-
-      // KEEP-581: schedule interval pre-check. Runs before the DB update so
-      // a rejected sub-60s value never lands as persisted nodes paired with
-      // an unsynced schedule. extractScheduleConfig is the only thing that
-      // throws here; bad timezones/cron strings still take the warn-and-
-      // continue path in handlePostUpdateSideEffects.
-      try {
-        extractScheduleConfig(
-          body.nodes as Parameters<typeof extractScheduleConfig>[0]
-        );
-      } catch (error) {
-        if (error instanceof IntervalTooSmallError) {
-          return NextResponse.json(
-            {
-              error: "SCHEDULE_INTERVAL_TOO_SMALL",
-              message: error.message,
-            },
-            { status: 400 }
-          );
-        }
-        throw error;
       }
     }
 
@@ -519,6 +506,36 @@ export async function PATCH(
     }
 
     const updateData = buildUpdateData(body);
+
+    // KEEP-581: schedule interval pre-check. Runs before the DB update so a
+    // rejected sub-60s value never lands as persisted nodes paired with an
+    // unsynced schedule. extractScheduleConfig is the only thing that throws
+    // here; bad timezones and invalid cron strings still take the warn-and-
+    // continue path in handlePostUpdateSideEffects.
+    //
+    // KEEP-1216: reads the SANITIZED nodes, so it sits after buildUpdateData
+    // rather than beside the other body checks. extractScheduleConfig keys on
+    // `data.type`, which only the sanitizer writes, so checking the raw body
+    // let a sub-60s interval from a docs-shaped client skip this 400 entirely.
+    // This still runs ahead of the write below, so the guarantee above holds.
+    if (Array.isArray(updateData.nodes)) {
+      try {
+        extractScheduleConfig(
+          updateData.nodes as Parameters<typeof extractScheduleConfig>[0]
+        );
+      } catch (error) {
+        if (error instanceof IntervalTooSmallError) {
+          return NextResponse.json(
+            {
+              error: "SCHEDULE_INTERVAL_TOO_SMALL",
+              message: error.message,
+            },
+            { status: 400 }
+          );
+        }
+        throw error;
+      }
+    }
 
     if (Array.isArray(updateData.nodes)) {
       // What these two gates do NOT do: prove the workflow will run.
@@ -809,7 +826,7 @@ export async function PATCH(
       throw dbError;
     }
 
-    await handlePostUpdateSideEffects(workflowId, body);
+    await handlePostUpdateSideEffects(workflowId, body, updateData.nodes);
 
     // Resolve project/tag names so a move/tagging shows "Project: A -> B" in
     // the activity feed rather than opaque ids.

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { NextResponse } from "next/server";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { recordWorkflowCreatedFromSource } from "@/lib/metrics/collectors/prometheus";
 import { authFailureResponse, getDualAuthContext } from "@/lib/middleware/auth-helpers";
@@ -18,6 +18,12 @@ import {
   idempotencyEarlyResponse,
   recordIdempotentResponse,
 } from "@/lib/idempotency";
+import { IntervalTooSmallError } from "@/lib/cron-utils";
+import {
+  type ExtractedScheduleConfig,
+  extractScheduleConfig,
+  syncWorkflowSchedule,
+} from "@/lib/schedule-service";
 import { generateId } from "@/lib/utils/id";
 import { sanitizeWorkflowData } from "@/lib/workflow/editor/sanitize-nodes";
 import { workflowNotDeleted } from "@/lib/workflow/soft-delete";
@@ -190,6 +196,39 @@ export async function POST(request: Request) {
       return featureGuard.response;
     }
 
+    // KEEP-1216: read the schedule config before the insert, so a schedule the
+    // dispatcher cannot honour is rejected instead of stored. Two details
+    // matter here.
+    //
+    // First, this reads the SANITIZED nodes, not body.nodes.
+    // extractScheduleConfig keys on `data.type === "trigger"`, and only
+    // sanitizeNode writes that field. A request shaped the way the public API
+    // docs show it carries no data.type, so a check against the raw body
+    // would miss the trigger and fall through to "no schedule".
+    //
+    // Second, it runs before db.insert for the KEEP-581 reason: a sub-60s
+    // interval must never land as a stored workflow paired with a missing
+    // schedule row. extractScheduleConfig is the only thing that throws here.
+    // A bad timezone or a broken cron string still takes the warn-and-continue
+    // path below, matching the PATCH handler.
+    let scheduleConfig: ExtractedScheduleConfig | null;
+    try {
+      scheduleConfig = extractScheduleConfig(
+        nodes as Parameters<typeof extractScheduleConfig>[0]
+      );
+    } catch (error) {
+      if (error instanceof IntervalTooSmallError) {
+        return NextResponse.json(
+          {
+            error: "SCHEDULE_INTERVAL_TOO_SMALL",
+            message: error.message,
+          },
+          { status: 400 }
+        );
+      }
+      throw error;
+    }
+
     const workflowName = await generateWorkflowName(body.name, organizationId);
 
     // Validate projectId/tagId ownership when provided
@@ -273,6 +312,38 @@ export async function POST(request: Request) {
       actor: { userId, organizationId, authMethod: authContext.authMethod },
       source: "create",
     });
+
+    // KEEP-1216: write the workflow_schedules row the dispatcher reads. Before
+    // this, only PATCH synced, so a schedule workflow created through the API
+    // alone was stored, reported enabled, and never fired. The UI never saw it
+    // because the editor saves through PATCH; every direct API consumer did.
+    //
+    // Guarded on scheduleConfig on purpose. syncWorkflowSchedule reads a null
+    // config as "delete any existing schedule", and a freshly generated id has
+    // no row to delete, so an unguarded call would add a wasted DELETE to every
+    // workflow create. The pre-check above already computed the answer.
+    //
+    // The sync runs whatever `enabled` says. syncWorkflowSchedule writes
+    // workflow_schedules.enabled = true, and the scheduler select gates on
+    // workflows.enabled through workflowExecutableConditions(). So a workflow
+    // created with enabled:false gets a dormant row, and a later
+    // PATCH {enabled:true} starts it on the next tick.
+    //
+    // Soft failures warn and let the create stand, matching the PATCH handler.
+    if (scheduleConfig) {
+      const syncResult = await syncWorkflowSchedule(
+        newWorkflow.id,
+        nodes as Parameters<typeof syncWorkflowSchedule>[1]
+      );
+      if (!syncResult.synced) {
+        logSystemWarn(
+          ErrorCategory.WORKFLOW_ENGINE,
+          "[Workflow] Schedule sync failed",
+          syncResult.error,
+          { workflow_id: newWorkflow.id }
+        );
+      }
+    }
 
     // Scan-funnel conversion signal: the scan drawer / pending-scan runner
     // tag their create calls with x-keeperhub-source; everything else counts

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -146,6 +146,32 @@ POST /api/workflows/create
 
 `name`, `nodes`, and `edges` are required. `description`, `projectId`, `tagId`, and `enabled` are optional. `projectId` assigns the workflow to a [project](/api/projects); `tagId` assigns it to an organization tag for categorization; `enabled` (boolean) controls whether the workflow is active on creation.
 
+#### Schedule triggers
+
+A `Schedule` trigger is registered by this call. One request is enough - no
+follow-up `PATCH` is needed to start the schedule.
+
+`enabled` decides whether that schedule dispatches. Create with `enabled: true`
+and the workflow runs on its next occurrence. Create with `enabled: false` and
+the schedule is stored but dormant until you enable the workflow.
+
+Set the cadence with either `scheduleCron` (a 5-field cron expression) or
+`scheduleIntervalSeconds` (run every N seconds). Supply one or the other;
+`scheduleIntervalSeconds` wins when both are present. `scheduleTimezone` is
+optional and defaults to `UTC`.
+
+The dispatcher polls once a minute, so a schedule cannot fire faster than that.
+A `scheduleIntervalSeconds` below 60 is rejected:
+
+```json
+{
+  "error": "SCHEDULE_INTERVAL_TOO_SMALL",
+  "message": "scheduleIntervalSeconds must be >= 60 (got 30)"
+}
+```
+
+The request returns `400` and no workflow is stored.
+
 ### Generic web3 write-contract example (Manual trigger)
 
 Named-protocol actions (`aave-v3/supply`, etc.) hide most of the plumbing behind protocol-aware config keys. When you want to call an arbitrary contract that isn't in the [plugin catalog](/plugins/web3), use the generic `web3/write-contract` action. The trap is that the UI labels ("Function", "Function Arguments") don't line up 1:1 with the API field names, and `functionArgs` is a **JSON-encoded array string**, not a raw array. The full config shape:

--- a/lib/scan/persist-suggestion.ts
+++ b/lib/scan/persist-suggestion.ts
@@ -47,8 +47,11 @@ function applyDefaultEmail(
  * Steps:
  *   1. buildWorkflow(descriptor) — factory re-derivation
  *   2. POST /api/workflows/create  (enabled:true for schedule, false for run)
- *   3. PATCH /api/workflows/{id} with {nodes} — triggers syncWorkflowSchedule
- *      (schedule mode only)
+ *   3. PATCH /api/workflows/{id} with {nodes} — schedule mode only, and
+ *      redundant since KEEP-1216. The create route registers the schedule
+ *      itself now, so this PATCH re-saves nodes the server already holds.
+ *      It stays because it is harmless and this path is UAT-sensitive; a
+ *      later cleanup can drop it.
  *   4. api.workflow.execute(id, {}) — immediate one-off run, "run" mode only.
  *      Schedule mode does NOT auto-run (UAT feedback): "Use this workflow"
  *      saves the monitor and lets its schedule fire it; the first run happens
@@ -101,7 +104,8 @@ export async function persistSuggestion(
   const created = (await createRes.json()) as CreateWorkflowResponse;
   const { id } = created;
 
-  // PATCH triggers syncWorkflowSchedule server-side (schedule mode only)
+  // Redundant since KEEP-1216: POST /api/workflows/create registers the
+  // schedule itself. Kept as a no-op re-save; see the step list above.
   if (mode === "schedule") {
     const patchRes = await fetch(`/api/workflows/${id}`, {
       method: "PATCH",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -54,7 +54,7 @@
       "path": "/api/workflows/{workflowId}",
       "route_file": "app/api/workflows/[workflowId]/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 230
+      "line": 256
     },
     {
       "method": "DELETE",
@@ -174,7 +174,7 @@
       "path": "/api/mcp/schemas",
       "route_file": "app/api/mcp/schemas/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 384
+      "line": 410
     },
     {
       "method": "GET",
@@ -272,7 +272,7 @@
       "path": "/api/workflows/public",
       "route_file": "app/api/workflows/public/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 337
+      "line": 363
     },
     {
       "method": "GET",
@@ -286,14 +286,14 @@
       "path": "/api/workflows/{workflowId}/code",
       "route_file": "app/api/workflows/[workflowId]/code/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 302
+      "line": 328
     },
     {
       "method": "GET",
       "path": "/api/workflows/{workflowId}/download",
       "route_file": "app/api/workflows/[workflowId]/download/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 294
+      "line": 320
     },
     {
       "method": "GET",
@@ -342,7 +342,7 @@
       "path": "/api/workflows/{workflowId}",
       "route_file": "app/api/workflows/[workflowId]/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 208
+      "line": 234
     },
     {
       "method": "POST",
@@ -412,7 +412,7 @@
       "path": "/api/hub/featured",
       "route_file": "app/api/hub/featured/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 376
+      "line": 402
     },
     {
       "method": "POST",
@@ -489,7 +489,7 @@
       "path": "/api/workflow/{workflowId}/execute",
       "route_file": "app/api/workflow/[workflowId]/execute/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 245
+      "line": 271
     },
     {
       "method": "POST",
@@ -503,35 +503,35 @@
       "path": "/api/workflows/{id}/execute",
       "route_file": "app/api/workflows/[workflowId]/execute/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 199
+      "line": 225
     },
     {
       "method": "POST",
       "path": "/api/workflows/{id}/webhook",
       "route_file": "app/api/workflows/[workflowId]/webhook/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 199
+      "line": 225
     },
     {
       "method": "POST",
       "path": "/api/workflows/{workflowId}/claim",
       "route_file": "app/api/workflows/[workflowId]/claim/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 310
+      "line": 336
     },
     {
       "method": "POST",
       "path": "/api/workflows/{workflowId}/duplicate",
       "route_file": "app/api/workflows/[workflowId]/duplicate/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 286
+      "line": 312
     },
     {
       "method": "POST",
       "path": "/api/workflows/{workflowId}/execute",
       "route_file": "app/api/workflows/[workflowId]/execute/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 242
+      "line": 268
     },
     {
       "method": "POST",
@@ -545,7 +545,7 @@
       "path": "/api/workflows/{workflowId}/webhook",
       "route_file": "app/api/workflows/[workflowId]/webhook/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 278
+      "line": 304
     },
     {
       "method": "PUT",
@@ -566,7 +566,7 @@
       "path": "/api/workflows/{workflowId}/go-live",
       "route_file": "app/api/workflows/[workflowId]/go-live/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 318
+      "line": 344
     }
   ]
 }

--- a/tests/integration/execute-scope-enforcement.test.ts
+++ b/tests/integration/execute-scope-enforcement.test.ts
@@ -89,8 +89,9 @@ vi.mock("@/lib/features/route-guard", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "DATABASE" },
+  ErrorCategory: { DATABASE: "DATABASE", WORKFLOW_ENGINE: "WORKFLOW_ENGINE" },
   logSystemError: vi.fn(),
+  logSystemWarn: vi.fn(),
 }));
 
 vi.mock("@/lib/db", () => ({

--- a/tests/integration/workflow-create-route.test.ts
+++ b/tests/integration/workflow-create-route.test.ts
@@ -4,12 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // step-registry, which `import "server-only"`. Stub the guard for vitest.
 vi.mock("server-only", () => ({}));
 
-const { mockGetDualAuthContext, mockInsert, mockValidateWorkflowIntegrations } =
-  vi.hoisted(() => ({
-    mockGetDualAuthContext: vi.fn(),
-    mockInsert: vi.fn(),
-    mockValidateWorkflowIntegrations: vi.fn(),
-  }));
+const {
+  mockGetDualAuthContext,
+  mockInsert,
+  mockValidateWorkflowIntegrations,
+  mockSyncWorkflowSchedule,
+} = vi.hoisted(() => ({
+  mockGetDualAuthContext: vi.fn(),
+  mockInsert: vi.fn(),
+  mockValidateWorkflowIntegrations: vi.fn(),
+  mockSyncWorkflowSchedule: vi.fn(),
+}));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
   getDualAuthContext: mockGetDualAuthContext,
@@ -25,6 +30,7 @@ vi.mock("@/lib/db/schema", () => ({
   projects: { id: "id", organizationId: "organization_id" },
   tags: { id: "id", organizationId: "organization_id" },
   workflows: {},
+  workflowSchedules: { workflowId: "workflow_id" },
 }));
 
 vi.mock("@/lib/db/integrations", () => ({
@@ -38,9 +44,23 @@ vi.mock("@/lib/features/route-guard", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
-  ErrorCategory: { DATABASE: "DATABASE" },
+  ErrorCategory: { DATABASE: "DATABASE", WORKFLOW_ENGINE: "WORKFLOW_ENGINE" },
   logSystemError: vi.fn(),
+  logSystemWarn: vi.fn(),
 }));
+
+// Only the side-effect sync is mocked. extractScheduleConfig runs for real so
+// the interval guard exercises the actual parseIntervalSeconds floor from
+// cron-utils, and so the sanitized-nodes contract is tested rather than stubbed.
+vi.mock("@/lib/schedule-service", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/schedule-service")>(
+    "@/lib/schedule-service"
+  );
+  return {
+    ...actual,
+    syncWorkflowSchedule: mockSyncWorkflowSchedule,
+  };
+});
 
 // Idempotency wraps the route but is covered by its own unit tests. Stub it to
 // a pass-through so this suite stays focused on create logic and does not pull
@@ -61,6 +81,13 @@ vi.mock("@/lib/security/audit-log", () => ({
 }));
 
 import { POST } from "@/app/api/workflows/create/route";
+import {
+  createActionNode,
+  createEdge,
+  createManualTriggerNode,
+  createScheduleTriggerNode,
+  cronExpressions,
+} from "../fixtures/workflows";
 
 function request(body: Record<string, unknown>): Request {
   return new Request("http://localhost:3000/api/workflows/create", {
@@ -253,5 +280,187 @@ describe("POST /api/workflows/create action config validation", () => {
 
     expect(response.status).not.toBe(422);
     expect(mockInsert).toHaveBeenCalled();
+  });
+});
+
+// KEEP-1216: the create route now registers the schedule itself. Before this,
+// only PATCH called syncWorkflowSchedule, so a schedule workflow created
+// through the API alone was stored, reported enabled, and never dispatched.
+describe("POST /api/workflows/create schedule registration", () => {
+  function insertReturns(row: Record<string, unknown>) {
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([row]),
+      }),
+    });
+  }
+
+  function createdWorkflow(enabled = true) {
+    return {
+      id: "wf-1",
+      name: "Scheduled workflow",
+      enabled,
+      createdAt: new Date("2024-01-01"),
+      updatedAt: new Date("2024-01-01"),
+    };
+  }
+
+  function scheduleBody(triggerNode: unknown, enabled = true) {
+    const actionNode = createActionNode();
+    return {
+      name: "Scheduled workflow",
+      nodes: [triggerNode, actionNode],
+      edges: [createEdge("trigger-1", actionNode.id)],
+      enabled,
+    };
+  }
+
+  function intervalTriggerNode(scheduleIntervalSeconds: number) {
+    return {
+      id: "trigger-1",
+      type: "trigger",
+      position: { x: 0, y: 0 },
+      data: {
+        type: "trigger",
+        label: "Schedule",
+        config: {
+          triggerType: "Schedule",
+          scheduleIntervalSeconds,
+          scheduleTimezone: "UTC",
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-123",
+      organizationId: "org-123",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockSyncWorkflowSchedule.mockResolvedValue({ synced: true });
+    insertReturns(createdWorkflow());
+  });
+
+  it("registers the schedule for a cron trigger, with no PATCH", async () => {
+    const response = await POST(
+      request(
+        scheduleBody(createScheduleTriggerNode(cronExpressions.everyMinute))
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+
+    const [workflowId, syncedNodes] = mockSyncWorkflowSchedule.mock.calls[0];
+    expect(workflowId).toBe("wf-1");
+    expect(syncedNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: "trigger",
+            config: expect.objectContaining({
+              triggerType: "Schedule",
+              scheduleCron: cronExpressions.everyMinute,
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("registers the schedule for a trigger sent the way the API docs show it", async () => {
+    // No data.type. The docs example omits it and the sanitizer adds it, so the
+    // route must read the sanitized nodes rather than the raw request body.
+    const docsShapedTrigger = {
+      id: "trigger-1",
+      type: "trigger",
+      data: {
+        label: "Schedule Trigger",
+        config: {
+          triggerType: "Schedule",
+          scheduleCron: "*/30 * * * *",
+        },
+      },
+    };
+
+    const response = await POST(request(scheduleBody(docsShapedTrigger)));
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a dormant schedule when the workflow is created disabled", async () => {
+    insertReturns(createdWorkflow(false));
+
+    const response = await POST(
+      request(
+        scheduleBody(
+          createScheduleTriggerNode(cronExpressions.everyMinute),
+          false
+        )
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a sub-minute interval with 400 and stores nothing", async () => {
+    const response = await POST(request(scheduleBody(intervalTriggerNode(30))));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("SCHEDULE_INTERVAL_TOO_SMALL");
+    expect(body.message).toContain(">= 60");
+    expect(mockInsert).not.toHaveBeenCalled();
+    expect(mockSyncWorkflowSchedule).not.toHaveBeenCalled();
+  });
+
+  it("accepts an interval at the exact floor of 60", async () => {
+    const response = await POST(request(scheduleBody(intervalTriggerNode(60))));
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch the schedule table for a manual trigger", async () => {
+    const actionNode = createActionNode();
+    const triggerNode = createManualTriggerNode();
+
+    const response = await POST(
+      request({
+        name: "Manual workflow",
+        nodes: [triggerNode, actionNode],
+        edges: [createEdge(triggerNode.id, actionNode.id)],
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockSyncWorkflowSchedule).not.toHaveBeenCalled();
+  });
+
+  it("still returns the created workflow when the sync fails softly", async () => {
+    mockSyncWorkflowSchedule.mockResolvedValue({
+      synced: false,
+      kind: "soft",
+      error: "Invalid timezone: Mars/Olympus",
+    });
+
+    const response = await POST(
+      request(
+        scheduleBody(
+          createScheduleTriggerNode(cronExpressions.everyMinute, "Mars/Olympus")
+        )
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.id).toBe("wf-1");
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/integration/workflow-schedule-validation-route.test.ts
+++ b/tests/integration/workflow-schedule-validation-route.test.ts
@@ -149,6 +149,24 @@ function scheduleTriggerNode(
   };
 }
 
+// KEEP-1216: the shape the public API docs show - outer `type: "trigger"`,
+// no `data.type`. Only the sanitizer writes `data.type`, and
+// extractScheduleConfig keys on it, so this is the shape that exposes any
+// place the route still reads the raw request body.
+function docsShapedScheduleNode(
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    id: "trigger-1",
+    type: "trigger",
+    position: { x: 0, y: 0 },
+    data: {
+      label: "Schedule",
+      config: { triggerType: "Schedule", scheduleTimezone: "UTC", ...config },
+    },
+  };
+}
+
 function existingWorkflow(): Record<string, unknown> {
   return {
     id: "wf-1",
@@ -245,5 +263,88 @@ describe("KEEP-581: PATCH /api/workflows/[workflowId] schedule interval guard", 
     });
 
     expect(response.status).toBe(200);
+  });
+});
+
+// KEEP-1216: PATCH persists the sanitized nodes but used to sync the schedule
+// from the raw body. A docs-shaped trigger therefore resolved to "no schedule
+// trigger", which takes the delete branch in syncWorkflowSchedule and silently
+// removed the row - returning {synced:true}, so not even a warning. Harmless
+// while create never registered a schedule; destructive once it does.
+describe("KEEP-1216: PATCH syncs from the sanitized nodes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockWorkflowsFindFirst.mockResolvedValue(existingWorkflow());
+    mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "m-1" }]);
+    mockSyncWorkflowSchedule.mockResolvedValue({ synced: true });
+    mockUpdateReturning.mockResolvedValue([existingWorkflow()]);
+  });
+
+  it("syncs a docs-shaped Schedule trigger instead of erasing it", async () => {
+    const response = await PATCH(
+      makeRequest({
+        nodes: [docsShapedScheduleNode({ scheduleCron: "0 9 * * *" })],
+      }),
+      { params }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+
+    // The nodes handed to the sync must carry data.type, which is what makes
+    // extractScheduleConfig resolve the trigger rather than return null.
+    const [, syncedNodes] = mockSyncWorkflowSchedule.mock.calls[0];
+    expect(syncedNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: "trigger",
+            config: expect.objectContaining({
+              triggerType: "Schedule",
+              scheduleCron: "0 9 * * *",
+            }),
+          }),
+        }),
+      ])
+    );
+  });
+
+  it("rejects a docs-shaped sub-minute interval with 400", async () => {
+    const response = await PATCH(
+      makeRequest({
+        nodes: [docsShapedScheduleNode({ scheduleIntervalSeconds: 30 })],
+      }),
+      { params }
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("SCHEDULE_INTERVAL_TOO_SMALL");
+    expect(mockSyncWorkflowSchedule).not.toHaveBeenCalled();
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("still passes sanitized nodes when the trigger already carries data.type", async () => {
+    const response = await PATCH(
+      makeRequest({ nodes: [scheduleTriggerNode(null)] }),
+      { params }
+    );
+
+    expect(response.status).toBe(200);
+    const [, syncedNodes] = mockSyncWorkflowSchedule.mock.calls[0];
+    expect(syncedNodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({ type: "trigger" }),
+        }),
+      ])
+    );
   });
 });

--- a/tests/integration/workflow-schedule-validation-route.test.ts
+++ b/tests/integration/workflow-schedule-validation-route.test.ts
@@ -118,6 +118,10 @@ vi.mock("next/cache", () => ({
 }));
 
 import { PATCH } from "@/app/api/workflows/[workflowId]/route";
+// Real, not mocked: the vi.mock above spreads importActual and replaces
+// only syncWorkflowSchedule. Using it here asserts what the sync would
+// have decided, which is what selects the delete branch.
+import { extractScheduleConfig } from "@/lib/schedule-service";
 
 function makeRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost:3000/api/workflows/wf-1", {
@@ -164,6 +168,15 @@ function docsShapedScheduleNode(
       label: "Schedule",
       config: { triggerType: "Schedule", scheduleTimezone: "UTC", ...config },
     },
+  };
+}
+
+function docsShapedWebhookNode(): Record<string, unknown> {
+  return {
+    id: "trigger-1",
+    type: "trigger",
+    position: { x: 0, y: 0 },
+    data: { label: "Webhook", config: { triggerType: "Webhook" } },
   };
 }
 
@@ -346,5 +359,67 @@ describe("KEEP-1216: PATCH syncs from the sanitized nodes", () => {
         }),
       ])
     );
+  });
+});
+
+// KEEP-1216 review follow-up: pin the delete branch. The risk in switching the
+// sync to sanitized nodes is over-correcting, so that a trigger which really
+// did stop being a Schedule no longer clears its row. These two cases fix the
+// boundary in both directions.
+describe("KEEP-1216: the schedule delete branch still fires when it should", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-1",
+      organizationId: "org-1",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+    mockWorkflowsFindFirst.mockResolvedValue(existingWorkflow());
+    mockSelectFrom.mockResolvedValue([]);
+    mockMemberLimit.mockResolvedValue([{ id: "m-1" }]);
+    mockSyncWorkflowSchedule.mockResolvedValue({ synced: true });
+    mockUpdateReturning.mockResolvedValue([existingWorkflow()]);
+  });
+
+  it("Schedule to Webhook still resolves to no schedule, so the row is erased", async () => {
+    const response = await PATCH(
+      makeRequest({ nodes: [docsShapedWebhookNode()] }),
+      { params }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSyncWorkflowSchedule).toHaveBeenCalledTimes(1);
+
+    const [, syncedNodes] = mockSyncWorkflowSchedule.mock.calls[0];
+    // A null config is exactly what sends syncWorkflowSchedule down its
+    // "delete any existing schedule" path.
+    expect(
+      extractScheduleConfig(
+        syncedNodes as Parameters<typeof extractScheduleConfig>[0]
+      )
+    ).toBeNull();
+  });
+
+  it("Schedule to Schedule with a new cron upserts rather than erasing", async () => {
+    const response = await PATCH(
+      makeRequest({
+        nodes: [docsShapedScheduleNode({ scheduleCron: "30 2 * * *" })],
+      }),
+      { params }
+    );
+
+    expect(response.status).toBe(200);
+
+    const [, syncedNodes] = mockSyncWorkflowSchedule.mock.calls[0];
+    expect(
+      extractScheduleConfig(
+        syncedNodes as Parameters<typeof extractScheduleConfig>[0]
+      )
+    ).toEqual({
+      mode: "cron",
+      cronExpression: "30 2 * * *",
+      timezone: "UTC",
+    });
   });
 });


### PR DESCRIPTION
Closes [KEEP-1216](https://linear.app/keeperhubapp/issue/KEEP-1216/schedule-workflows-created-through-the-api-never-schedule).

## Problem

`POST /api/workflows/create` stored a schedule workflow, reported `enabled: true`, and never wrote the `workflow_schedules` row the dispatcher reads. The workflow never fired, and no surface showed the problem.

`syncWorkflowSchedule` ran only from the PATCH handler (`app/api/workflows/[workflowId]/route.ts:341`) and from the staging-only admin route. The create route never called it.

The editor escapes this because it saves nodes through PATCH. Direct API consumers do not:

- the MCP `create_workflow` tool posts straight to this route (`lib/mcp/tools.ts:915`), and its own description promises that `enabled=true` makes schedule triggers fire
- the `kh` CLI posts once and never patches (`cli/cmd/workflow/create.go:131`)
- `docs/api/workflows.md` documented create with a `Schedule` trigger example and never mentioned a follow-up PATCH

Hit on all three evaluation clusters during the M0 acceptance run.

## Change

The create route reads the schedule config before the insert and writes the schedule row after it.

Two points worth keeping in review:

- The config is read from the **sanitized** nodes. `extractScheduleConfig` keys on `data.type`, and only `sanitizeNode` writes that field, so a request shaped the way the public API docs show it would be missed by a check against the raw body. The PATCH handler checks the raw body; create deliberately does not copy that.
- The read runs before `db.insert`, for the KEEP-581 reason. A sub-60s interval is rejected with `400 SCHEDULE_INTERVAL_TOO_SMALL` and nothing is stored, rather than landing as a workflow with a schedule the dispatcher cannot honour.

The sync runs whatever `enabled` says. `syncWorkflowSchedule` writes `workflow_schedules.enabled = true`, and the scheduler select gates on `workflows.enabled` through `workflowExecutableConditions()`. So a workflow created with `enabled: false` gets a dormant row, and a later `PATCH {enabled: true}` starts it. Soft failures (bad timezone, invalid cron) warn and let the create stand, matching PATCH.

The call is guarded on the pre-check result. A null config means "delete any existing schedule", and a freshly generated id has no row to delete, so an unguarded call would add a wasted DELETE to every workflow create.

Also documented the schedule contract under Create Workflow, and corrected the comment in the scan funnel that recorded the two-step as a requirement. The scan funnel's PATCH is now a no-op re-save; it stays because that path is UAT-sensitive.

## Tests

Seven cases in `tests/integration/workflow-create-route.test.ts`. `extractScheduleConfig` runs for real so the interval floor is exercised rather than stubbed. Five of the seven fail on the unpatched route; the other two are negative assertions that guard the opposite regression.

- a cron trigger registers the schedule, with no PATCH
- a trigger shaped the way the API docs show it (no `data.type`) still registers
- `enabled: false` registers a dormant schedule
- `scheduleIntervalSeconds: 30` returns 400 and stores nothing
- `scheduleIntervalSeconds: 60` is accepted
- a manual trigger does not touch the schedule table
- a soft sync failure still returns the created workflow

## Checks run locally

`pnpm check`, `pnpm type-check`, `pnpm type-check:executor`, `pnpm check:api-docs` (`specs/api-coverage.json` regenerated and committed - the docs insert shifted recorded line numbers), `pnpm test:integration` (970 passed), `pnpm test:unit __tests__ keeperhub-metrics-collector` (21337 passed).

Not run locally: the Docker build job needs AWS ECR credentials, and the sandbox job builds an image. Neither is affected - no Dockerfile, compose or dependency changes.

## Proof against a real database

Mocked route tests show the call happens. This shows the row lands and the dispatcher picks it up.

I ran the real route against a throwaway clone of a migrated Postgres, with only auth stubbed. The sanitizer, the validators, drizzle and `syncWorkflowSchedule` all ran for real.

- one `POST /api/workflows/create` with the docs-shaped trigger and no PATCH returned 200 and logged `[Schedule] Created schedule for workflow ...`. The row carried `cron_expression = "* * * * *"`, `enabled = true`, `next_run_at` on the next minute.
- `GET /api/internal/schedules`, which is the dispatcher's own source of truth, listed that workflow.
- the `enabled: false` twin got its dormant row and was correctly absent from that same listing.
- `scheduleIntervalSeconds: 30` returned 400 `SCHEDULE_INTERVAL_TOO_SMALL` and the workflow count did not move.
- a manual trigger wrote no schedule row.

The probe database was dropped afterwards. The probe file is not part of this branch.

## Out of scope, follow-up filed separately

Three verified gaps of the same class, deliberately not fixed here:

- the PATCH handler syncs only when the body carries `nodes`, and the editor's enable toggle sends `{ enabled }` alone (`components/workflow/workflow-toolbar.tsx:1311`)
- the duplicate, import and current routes insert workflows and never sync
- so duplicating or importing a schedule workflow and pressing Enable still never fires it

