### PR TITLE
ci: KEEP-1220 hold docs-site bumps for the release-age gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,25 @@ updates:
       day: "monday"
     target-branch: "staging"
     open-pull-requests-limit: 5
+    # docs-site/.npmrc sets minimum-release-age=4320, which is 3 days, and lists
+    # no exclusions. docs-site/package.json pins next to an exact version, so a
+    # bump to a release younger than the gate leaves no version that satisfies
+    # the range. pnpm then fails the lockfile step outright:
+    #
+    #   ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 16.3.3 (released 21 hours
+    #   ago) of next does not meet the minimumReleaseAge constraint
+    #
+    # Dependabot ships the manifest edit alone when its lockfile step fails, and
+    # the docs image installs with --frozen-lockfile, so the build breaks. This
+    # cooldown holds a version back for the same 3 days the gate wants, so the
+    # two agree and Dependabot never proposes a release pnpm will refuse.
+    # default-days also supplies the major, minor and patch values, which are
+    # left unset here on purpose.
+    #
+    # Cooldown covers version updates only. A security update can still propose
+    # a release younger than 3 days and hit the gate.
+    cooldown:
+      default-days: 3
     groups:
       minor-and-patch:
         applies-to: version-updates


### PR DESCRIPTION
Follows [KEEP-1220](https://linear.app/keeperhubapp/issue/KEEP-1220). #2136 closed the workspace bug. This closes a second, separate hole that can still break the docs build.

## The hole

`docs-site/.npmrc` sets `minimum-release-age=4320`, which is 3 days, with no exclusions. `docs-site/package.json` pins `next` to an exact version. When Dependabot bumps that pin to a release younger than the gate, no version satisfies the range and pnpm fails the lockfile step outright rather than falling back to an older one.

Reproduced 2026-08-28 against `origin/prod` with the pinned pnpm 10.33.3. `next` 16.3.3 published 2026-08-25T15:32Z:

```
$ sed -i 's/"next": "16.3.2"/"next": "16.3.3"/' docs-site/package.json
$ cd docs-site && pnpm install --lockfile-only
ERR_PNPM_NO_MATURE_MATCHING_VERSION  Version 16.3.3 (released 21 hours ago) of next
does not meet the minimumReleaseAge constraint
exit code: 1
```

Dependabot ships the manifest edit alone when its lockfile step fails, and the docs image installs with `--frozen-lockfile`, so the build breaks. Same symptom as the workspace bug, different cause.

This is **not** what caused the historical failures. I checked those: 16.3.1 was 3 days 15 hours old at PR time and 16.3.2 was 3 days 4 hours, both past the gate, and both installs exited 0 with no lockfile diff. This one only became reachable now.

The exposure follows the weekly Monday schedule. Any release published in the 3 days before a run is too young for the gate, which is a recurring window rather than a one-off.

## The change

Nineteen lines on the `/docs-site` entry, eighteen of them comment:

```yaml
    cooldown:
      default-days: 3
```

Dependabot now holds a version back for the same period the gate wants, so the two agree and it never proposes a release pnpm will refuse. `default-days` also supplies the major, minor and patch values, so those stay unset on purpose.

No change to `docs-site/.npmrc`. The alternative was `minimum-release-age-exclude[]=next`, which also works but weakens a supply-chain control, so I did not take it.

## Known residual

Cooldown applies to **version updates only**. A security update can still propose a release younger than 3 days and hit the gate. That is a deliberate trade, since holding security fixes back for 3 days is worse than the build break they might cause. It is written into the file comment so the next person does not read this as full coverage.

## Verification

Schema is not guessed. `cooldown` with `default-days`, `semver-major-days`, `semver-minor-days`, `semver-patch-days`, `include` and `exclude` is confirmed against both the GitHub Dependabot options reference and `common/lib/dependabot/package/release_cooldown_options.rb` in dependabot-core, which shows `default_days` filling in for the unset semver-specific values.

Locally:

- the file parses, and `/docs-site` is the only entry carrying the block
- the whole config validates against the SchemaStore `dependabot-2.0` schema

The real test is the next scheduled run on Monday 2026-08-31 around 14:26Z. `next` 16.3.3 will be about 6 days old by then, so it passes the gate either way. This PR matters if `next` publishes again before then, which would otherwise leave Monday's bump too young.

Timing note: anything `next` publishes after 2026-08-28 14:26Z is under 3 days old on Monday. Worth merging today for that reason.
