### PR TITLE
fix(executor): let a branch loop back and re-run an earlier node

### DIFF
--- a/lib/workflow/editor/auto-layout.ts
+++ b/lib/workflow/editor/auto-layout.ts
@@ -1,3 +1,5 @@
+import { partitionByBackEdges } from "@/lib/workflow/editor/back-edges";
+
 // Local structural types instead of importing @xyflow/react, so this pure
 // layout helper can also run server-side (e.g. seeding onboarding workflow
 // fixtures). Real @xyflow/react Node/Edge are structural supersets, so editor
@@ -501,12 +503,17 @@ export function computeAutoLayout(
   const realNodes = nodes.filter((n) => n.type !== "add");
   const realNodeIds = new Set(realNodes.map((n) => n.id));
 
-  const forwardEdges = edges.filter(
+  // Loop-back edges are dropped along with the For Each `loop` handle: both
+  // point at a node the layout has already placed, and counting them toward its
+  // in-degree leaves it waiting on an arrival the sweep never makes, so it and
+  // everything behind it fall out of the columns into the disconnected pile.
+  const layoutEdges = edges.filter(
     (e) =>
       realNodeIds.has(e.source) &&
       realNodeIds.has(e.target) &&
       e.sourceHandle !== "loop"
   );
+  const { forwardEdges } = partitionByBackEdges(realNodes, layoutEdges);
 
   const graph = buildGraph(realNodes, forwardEdges);
   const roots = findRoots(realNodes, graph.inDegree);

--- a/lib/workflow/editor/back-edges.ts
+++ b/lib/workflow/editor/back-edges.ts
@@ -1,0 +1,193 @@
+/**
+ * Back-edge classification for workflow graphs.
+ *
+ * A workflow is authored as a DAG plus, optionally, edges that point back at an
+ * ancestor so a branch can run an earlier part of the graph again. Those back
+ * edges are the loop primitive. Everything else in the engine (convergence
+ * barriers, orphan detection, For Each body identification, auto-layout column
+ * assignment) reasons over the forward DAG and must not see them: a node whose
+ * only extra predecessor is the back edge would otherwise wait for an arrival
+ * that cannot happen until after it has run, and the branch stalls there.
+ *
+ * An edge u -> v is a back edge when v is still on the depth-first stack while u
+ * is being explored. Removing every classified back edge always leaves an
+ * acyclic graph. Nodes with no incoming edge are visited first so the trigger
+ * side anchors the traversal and the edge classified is the one the author drew
+ * backwards, not an arbitrary member of the cycle.
+ */
+
+export type BackEdgeNode = {
+  id: string;
+};
+
+export type BackEdgeLike = {
+  source: string;
+  target: string;
+};
+
+/** Source node ID -> the loop-entry nodes its back edges point at. */
+export type BackEdgesBySource = ReadonlyMap<string, ReadonlySet<string>>;
+
+const UNVISITED = 0;
+const ON_STACK = 1;
+const EXPLORED = 2;
+
+function buildOutgoing<E extends BackEdgeLike>(edges: E[]): Map<string, E[]> {
+  const outgoing = new Map<string, E[]>();
+  for (const edge of edges) {
+    const existing = outgoing.get(edge.source);
+    if (existing) {
+      existing.push(edge);
+    } else {
+      outgoing.set(edge.source, [edge]);
+    }
+  }
+  return outgoing;
+}
+
+/**
+ * Order the DFS roots: nodes with no incoming edge first (in declaration
+ * order), then every remaining node so a cycle unreachable from any root is
+ * still classified.
+ */
+function startOrder(nodes: BackEdgeNode[], edges: BackEdgeLike[]): string[] {
+  const hasIncoming = new Set<string>();
+  for (const edge of edges) {
+    hasIncoming.add(edge.target);
+  }
+  const roots: string[] = [];
+  const rest: string[] = [];
+  for (const node of nodes) {
+    if (hasIncoming.has(node.id)) {
+      rest.push(node.id);
+    } else {
+      roots.push(node.id);
+    }
+  }
+  return [...roots, ...rest];
+}
+
+function record(
+  map: Map<string, Set<string>>,
+  source: string,
+  target: string
+): void {
+  const targets = map.get(source);
+  if (targets) {
+    targets.add(target);
+    return;
+  }
+  map.set(source, new Set([target]));
+}
+
+/** True when `source -> target` was classified as a back edge. */
+export function isBackEdge(
+  backEdgesBySource: BackEdgesBySource,
+  source: string,
+  target: string
+): boolean {
+  return backEdgesBySource.get(source)?.has(target) === true;
+}
+
+/** Every edge that closes a cycle. Empty for an acyclic graph. */
+export function findBackEdges(
+  nodes: BackEdgeNode[],
+  edges: BackEdgeLike[]
+): Map<string, Set<string>> {
+  const outgoing = buildOutgoing(edges);
+  const state = new Map<string, number>();
+  const backEdges = new Map<string, Set<string>>();
+
+  for (const start of startOrder(nodes, edges)) {
+    if ((state.get(start) ?? UNVISITED) !== UNVISITED) {
+      continue;
+    }
+    state.set(start, ON_STACK);
+    const stack: Array<{ id: string; nextEdge: number }> = [
+      { id: start, nextEdge: 0 },
+    ];
+
+    while (stack.length > 0) {
+      const frame = stack.at(-1) as { id: string; nextEdge: number };
+      const outEdges = outgoing.get(frame.id) ?? [];
+      if (frame.nextEdge >= outEdges.length) {
+        state.set(frame.id, EXPLORED);
+        stack.pop();
+        continue;
+      }
+      const edge = outEdges[frame.nextEdge];
+      frame.nextEdge += 1;
+
+      const targetState = state.get(edge.target) ?? UNVISITED;
+      if (targetState === ON_STACK) {
+        record(backEdges, edge.source, edge.target);
+        continue;
+      }
+      if (targetState === EXPLORED) {
+        continue;
+      }
+      state.set(edge.target, ON_STACK);
+      stack.push({ id: edge.target, nextEdge: 0 });
+    }
+  }
+
+  return backEdges;
+}
+
+export type BackEdgePartition<E extends BackEdgeLike> = {
+  forwardEdges: E[];
+  backEdges: E[];
+  backEdgesBySource: BackEdgesBySource;
+};
+
+/**
+ * Split a workflow's edges into the forward DAG and the loop-back edges.
+ * Parallel edges between the same pair are classified together, since the loop
+ * entry is the same node whichever handle they leave from.
+ */
+export function partitionByBackEdges<E extends BackEdgeLike>(
+  nodes: BackEdgeNode[],
+  edges: E[]
+): BackEdgePartition<E> {
+  const backEdgesBySource = findBackEdges(nodes, edges);
+  if (backEdgesBySource.size === 0) {
+    return { forwardEdges: edges, backEdges: [], backEdgesBySource };
+  }
+
+  const forwardEdges: E[] = [];
+  const backEdges: E[] = [];
+  for (const edge of edges) {
+    if (isBackEdge(backEdgesBySource, edge.source, edge.target)) {
+      backEdges.push(edge);
+    } else {
+      forwardEdges.push(edge);
+    }
+  }
+  return { forwardEdges, backEdges, backEdgesBySource };
+}
+
+/**
+ * Every node reachable from `startId` over the given adjacency, including
+ * `startId` itself. Called with the forward map it gives a loop's re-run scope:
+ * re-entering the loop entry runs it and everything it feeds.
+ */
+export function collectReachable(
+  startId: string,
+  edgesBySource: ReadonlyMap<string, string[]>
+): Set<string> {
+  const reachable = new Set<string>([startId]);
+  const queue: string[] = [startId];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    for (const next of edgesBySource.get(current) ?? []) {
+      if (reachable.has(next)) {
+        continue;
+      }
+      reachable.add(next);
+      queue.push(next);
+    }
+  }
+
+  return reachable;
+}

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -7,6 +7,7 @@ import {
   applyBigIntConversion,
   needsBigIntMode,
 } from "@/lib/bigint-condition-utils";
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 import {
   ErrorCategory,
   logSystemError,
@@ -30,6 +31,11 @@ import {
   type StepImporter,
 } from "@/lib/step-registry";
 import { deserializeTriggerInput, getErrorMessageAsync } from "@/lib/utils";
+import {
+  collectReachable,
+  isBackEdge,
+  partitionByBackEdges,
+} from "@/lib/workflow/editor/back-edges";
 import {
   BUILTIN_NODE_ID,
   BUILTIN_NODE_LABEL,
@@ -59,6 +65,11 @@ import {
   getCompletedStepOutput,
 } from "@/lib/workflow/executor/get-completed-step-output";
 import { awaitCompletedStepOutputStep } from "@/lib/workflow/executor/get-completed-step-output.step";
+import {
+  createLoopBackTracker,
+  findUnsupportedBackEdges,
+  resetLoopBodyState,
+} from "@/lib/workflow/executor/loop-back";
 import { createPendingTracker } from "@/lib/workflow/executor/pending-tasks";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
@@ -1890,11 +1901,22 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
   // Build node and edge maps
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+
+  // Edges that point back at an ancestor are the loop primitive and are held
+  // apart from the forward DAG. `edgesBySource` keeps them so routing still
+  // finds the loop entry; every map that answers "what has to happen before
+  // this node runs" is built from the forward edges only, or the loop entry
+  // waits on an arrival that its own execution has to produce first.
+  const { forwardEdges, backEdges, backEdgesBySource } = partitionByBackEdges(
+    nodes,
+    edges
+  );
   const edgesBySource = buildEdgesBySource(edges);
+  const forwardEdgesBySource = buildEdgesBySource(forwardEdges);
   const edgesBySourceHandle = buildEdgesBySourceHandle(edges);
   const conditionDecisions = new Map<string, ConditionDecision>();
 
-  const edgesByTarget = buildEdgesByTarget(edges);
+  const edgesByTarget = buildEdgesByTarget(forwardEdges);
   const convergenceArrivals = new Map<string, Set<string>>();
   // Skip-arrivals tracked apart from real arrivals so an OR-join whose every
   // incoming edge was skipped is itself skipped rather than executed.
@@ -1934,7 +1956,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     }
     const body = identifyLoopBody(
       node.id,
-      edgesBySource,
+      forwardEdgesBySource,
       nodeMap,
       edgesBySourceHandle
     );
@@ -1945,6 +1967,34 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       loopBodyNodeIds.add(body.collectNodeId);
     }
   }
+
+  // Re-run scope of each loop entry, computed once: the entry plus everything it
+  // feeds over the forward DAG. Re-entering the entry runs all of it again.
+  const loopBodyCache = new Map<string, Set<string>>();
+  const loopBodyOf = (loopEntryNodeId: string): Set<string> => {
+    const cached = loopBodyCache.get(loopEntryNodeId);
+    if (cached) {
+      return cached;
+    }
+    const body = collectReachable(loopEntryNodeId, forwardEdgesBySource);
+    loopBodyCache.set(loopEntryNodeId, body);
+    return body;
+  };
+
+  const loopTracker = createLoopBackTracker({
+    labelOf: (nodeId: string) => {
+      const node = nodeMap.get(nodeId);
+      return node ? getNodeName(node) : nodeId;
+    },
+  });
+
+  // A back edge that touches a For Each body would be dropped in silence by the
+  // body runner's own dispatcher. Refuse the run rather than execute a graph
+  // that does not match what the canvas shows.
+  const unsupportedBackEdges = findUnsupportedBackEdges(
+    backEdges,
+    loopBodyNodeIds
+  );
 
   // Must complete before the first step runs: it invokes no steps itself, and
   // once it has, every step call downstream is reached synchronously, so the
@@ -2321,7 +2371,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       bodyEdgesBySourceHandle,
     } = identifyLoopBody(
       forEachNodeId,
-      edgesBySource,
+      forwardEdgesBySource,
       nodeMap,
       edgesBySourceHandle
     );
@@ -2605,9 +2655,19 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     nextNodeIds: string[],
     visited: Set<string>
   ): Promise<void> {
+    const forwardTargets: string[] = [];
+    const loopEntryTargets: string[] = [];
+    for (const nextId of nextNodeIds) {
+      if (isBackEdge(backEdgesBySource, fromNodeId, nextId)) {
+        loopEntryTargets.push(nextId);
+      } else {
+        forwardTargets.push(nextId);
+      }
+    }
+
     const readyIds = getReadyDownstreamIds(
       fromNodeId,
-      nextNodeIds,
+      forwardTargets,
       edgesByTarget,
       convergenceArrivals,
       visited
@@ -2619,6 +2679,62 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       );
       processSettledResults(settled, readyIds);
     }
+
+    for (const loopEntryId of loopEntryTargets) {
+      await runLoopIteration(fromNodeId, loopEntryId, visited);
+    }
+  }
+
+  /**
+   * Re-enter a loop entry so it and everything downstream of it runs again.
+   *
+   * The previous pass's traversal state for the loop body is cleared first --
+   * without that the entry reads as already visited and the loop is a no-op,
+   * which is what a back edge did before loops were supported. Refusing a pass
+   * on a cap records the failure against the node that asked to loop, so the run
+   * ends in error with a message naming the loop instead of quietly stopping
+   * with whichever pass happened to be last.
+   */
+  async function runLoopIteration(
+    fromNodeId: string,
+    loopEntryId: string,
+    visited: Set<string>
+  ): Promise<void> {
+    const bodyNodeIds = loopBodyOf(loopEntryId);
+    const admission = loopTracker.admit(fromNodeId, loopEntryId, bodyNodeIds);
+
+    if (!admission.admitted) {
+      logUserError(
+        ErrorCategory.WORKFLOW_ENGINE,
+        "[Workflow Executor] Loop iteration limit reached",
+        undefined,
+        { ...baseLogLabels, node_id: fromNodeId }
+      );
+      results[fromNodeId] = {
+        success: false,
+        error: admission.error,
+        errorClass: ExecutionErrorType.USER,
+      };
+      return;
+    }
+
+    console.log("[Workflow Executor] Looping back:", {
+      from: fromNodeId,
+      to: loopEntryId,
+      iteration: admission.iteration,
+    });
+
+    resetLoopBodyState(bodyNodeIds, {
+      visited,
+      convergenceArrivals,
+      convergenceSkipArrivals,
+      skippedNodes,
+    });
+
+    const settled = await pendingTasks.track(
+      Promise.allSettled([executeNode(loopEntryId, visited)])
+    );
+    processSettledResults(settled, [loopEntryId]);
   }
 
   /**
@@ -2672,7 +2788,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       const unblockedIds = propagateConvergenceSkips(
         nodeId,
         skippedTargets,
-        edgesBySource,
+        forwardEdgesBySource,
         edgesByTarget,
         convergenceArrivals,
         convergenceSkipArrivals,
@@ -3079,10 +3195,17 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       // whose tracker is empty, leaving the in-catch branch unable to
       // recover and forcing reliance on post-drain. Reading the DB-backed
       // authority here makes the recovery uniform across both paths.
+      //
+      // A node the loop has already re-entered is excluded: the tracker and the
+      // log row are keyed by node, so every pass overwrites the last one and the
+      // recovery would hand back an earlier pass's output as if it were this
+      // one's. For a loop that moves value that is worse than failing, so a
+      // second or later pass takes the normal failure path.
       const isSpuriousMaxRetries =
-        EXCEEDED_MAX_RETRIES_REGEX.test(errorMessage) ||
-        FAILED_AFTER_RETRIES_REGEX.test(errorMessage) ||
-        NO_STEP_COMPLETION_REGEX.test(errorMessage);
+        (EXCEEDED_MAX_RETRIES_REGEX.test(errorMessage) ||
+          FAILED_AFTER_RETRIES_REGEX.test(errorMessage) ||
+          NO_STEP_COMPLETION_REGEX.test(errorMessage)) &&
+        loopTracker.iterationOf(nodeId) === 0;
       let recordedOutput =
         isSpuriousMaxRetries && executionId
           ? (await getCompletedStepOutput(executionId, nodeId))?.output
@@ -3236,7 +3359,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           ? (node.data.config?.actionType as string | undefined)
           : undefined;
       if (failedActionType !== "Condition") {
-        const nextNodes = edgesBySource.get(nodeId) ?? [];
+        const nextNodes = forwardEdgesBySource.get(nodeId) ?? [];
         const unblockedIds = signalConvergenceArrival(
           nodeId,
           nextNodes,
@@ -3258,6 +3381,18 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
   try {
     console.log("[Workflow Executor] Starting execution from trigger nodes");
     const workflowStartTime = Date.now();
+
+    if (unsupportedBackEdges.length > 0) {
+      const [{ source, target }] = unsupportedBackEdges;
+      const sourceNode = nodeMap.get(source);
+      const targetNode = nodeMap.get(target);
+      throw new Error(
+        `The connection from "${sourceNode ? getNodeName(sourceNode) : source}" back to ` +
+          `"${targetNode ? getNodeName(targetNode) : target}" crosses a For Each loop body. ` +
+          "Looping back into or out of a For Each body is not supported. Move the " +
+          "connection outside the For Each, or use the For Each iteration itself to repeat the work."
+      );
+    }
 
     const triggerType = detectTriggerType(nodes);
     const metrics = getMetricsCollector();

--- a/lib/workflow/executor/loop-back.ts
+++ b/lib/workflow/executor/loop-back.ts
@@ -1,0 +1,152 @@
+/**
+ * Loop-back iteration accounting for the workflow executor.
+ *
+ * A back edge (see `lib/workflow/editor/back-edges.ts`) sends control from a
+ * node to one of its ancestors so the graph from that ancestor down runs again.
+ * Nothing in the graph itself bounds how often that can happen: a condition that
+ * never flips its branch loops forever, burning steps, gas and quota. Two caps
+ * bound it.
+ *
+ * The per-loop cap is what an author hits when their exit condition is wrong.
+ * The per-execution cap is the backstop for topologies where the per-loop cap
+ * alone is not enough: nested loops multiply, so two loops capped at 100 each
+ * would otherwise allow 10,000 traversals.
+ *
+ * Hitting either cap fails the run. Stopping quietly and carrying on would hand
+ * back the partial state of whichever iteration happened to be last, which for a
+ * loop that moves value is worse than a loud failure.
+ */
+
+/** Times one back edge may re-enter its loop entry within a single execution. */
+export const MAX_LOOP_ITERATIONS = 100;
+
+/** Loop-back traversals allowed across one execution, whatever the topology. */
+export const MAX_LOOP_TRAVERSALS_PER_EXECUTION = 1000;
+
+export type LoopAdmission =
+  | { admitted: true; iteration: number }
+  | { admitted: false; error: string };
+
+export type LoopBackTrackerOptions = {
+  maxIterationsPerLoop?: number;
+  maxTraversalsPerExecution?: number;
+  /** Node ID -> display label, for readable cap messages. */
+  labelOf?: (nodeId: string) => string;
+};
+
+export type LoopBackTracker = {
+  /**
+   * Account for one traversal of `sourceNodeId -> loopEntryNodeId`. On success
+   * the returned iteration number is the pass the loop body is about to make
+   * (1 for the first re-entry), and every node in `bodyNodeIds` is recorded as
+   * running that pass.
+   */
+  admit(
+    sourceNodeId: string,
+    loopEntryNodeId: string,
+    bodyNodeIds: Iterable<string>
+  ): LoopAdmission;
+  /** Pass a node is on: 0 until a loop has re-entered it. */
+  iterationOf(nodeId: string): number;
+  /** Total admitted traversals, for run-completion logging. */
+  totalTraversals(): number;
+};
+
+export function createLoopBackTracker(
+  options: LoopBackTrackerOptions = {}
+): LoopBackTracker {
+  const maxPerLoop = options.maxIterationsPerLoop ?? MAX_LOOP_ITERATIONS;
+  const maxPerExecution =
+    options.maxTraversalsPerExecution ?? MAX_LOOP_TRAVERSALS_PER_EXECUTION;
+  const labelOf = options.labelOf ?? ((nodeId: string): string => nodeId);
+
+  const iterationsPerLoop = new Map<string, number>();
+  const iterationPerNode = new Map<string, number>();
+  let traversals = 0;
+
+  return {
+    admit(sourceNodeId, loopEntryNodeId, bodyNodeIds) {
+      const loopKey = `${sourceNodeId}::${loopEntryNodeId}`;
+      const nextIteration = (iterationsPerLoop.get(loopKey) ?? 0) + 1;
+
+      if (nextIteration > maxPerLoop) {
+        return {
+          admitted: false,
+          error:
+            `Loop back to "${labelOf(loopEntryNodeId)}" stopped after ${maxPerLoop} ` +
+            "iterations. Add a condition that leaves the loop, or move the work " +
+            "into a For Each step.",
+        };
+      }
+      if (traversals + 1 > maxPerExecution) {
+        return {
+          admitted: false,
+          error:
+            `This run reached its limit of ${maxPerExecution} loop iterations across ` +
+            `all loops while looping back to "${labelOf(loopEntryNodeId)}". Reduce how ` +
+            "many times the nested loops repeat.",
+        };
+      }
+
+      traversals += 1;
+      iterationsPerLoop.set(loopKey, nextIteration);
+      for (const bodyNodeId of bodyNodeIds) {
+        iterationPerNode.set(bodyNodeId, nextIteration);
+      }
+      return { admitted: true, iteration: nextIteration };
+    },
+
+    iterationOf(nodeId) {
+      return iterationPerNode.get(nodeId) ?? 0;
+    },
+
+    totalTraversals() {
+      return traversals;
+    },
+  };
+}
+
+export type LoopBodyState = {
+  visited: Set<string>;
+  convergenceArrivals: Map<string, Set<string>>;
+  convergenceSkipArrivals: Map<string, Set<string>>;
+  skippedNodes: Set<string>;
+};
+
+/**
+ * Clear the per-pass traversal state for a loop body so the next pass runs it
+ * from scratch: the nodes become unvisited, and convergence barriers inside the
+ * body re-arm instead of counting the previous pass's arrivals as this one's.
+ *
+ * `results` and `outputs` are deliberately left alone. They are keyed by node
+ * and each pass overwrites them, so downstream templates and the run panel read
+ * the newest pass, which is what a step that ran twice should report.
+ */
+export function resetLoopBodyState(
+  bodyNodeIds: Iterable<string>,
+  state: LoopBodyState
+): void {
+  for (const nodeId of bodyNodeIds) {
+    state.visited.delete(nodeId);
+    state.convergenceArrivals.delete(nodeId);
+    state.convergenceSkipArrivals.delete(nodeId);
+    state.skippedNodes.delete(nodeId);
+  }
+}
+
+/**
+ * Back edges that touch a For Each loop body, in either direction.
+ *
+ * Body nodes run through the body runner's own dispatcher, which has no
+ * loop-back handling, so such an edge would be silently ignored rather than
+ * looping. The executor refuses the run instead of running a workflow that does
+ * not do what the canvas shows.
+ */
+export function findUnsupportedBackEdges<
+  E extends { source: string; target: string },
+>(backEdges: E[], forEachBodyNodeIds: ReadonlySet<string>): E[] {
+  return backEdges.filter(
+    (edge) =>
+      forEachBodyNodeIds.has(edge.source) || forEachBodyNodeIds.has(edge.target)
+  );
+}

--- a/tests/unit/auto-layout-loop-back.test.ts
+++ b/tests/unit/auto-layout-loop-back.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+
+const at = (x: number, y: number): { x: number; y: number } => ({ x, y });
+
+describe("computeAutoLayout with a loop-back edge", () => {
+  const nodes = [
+    { id: "T", type: "trigger", position: at(0, 0) },
+    { id: "A", type: "action", position: at(0, 0) },
+    { id: "B", type: "action", position: at(0, 0) },
+    { id: "C", type: "action", position: at(0, 0) },
+    { id: "D", type: "action", position: at(0, 0) },
+  ];
+  const edges = [
+    { source: "T", target: "A" },
+    { source: "A", target: "B" },
+    { source: "B", target: "C" },
+    { source: "B", target: "D" },
+    { source: "D", target: "B" },
+  ];
+
+  it("lays the loop out in graph order rather than stacking it as disconnected", () => {
+    const positions = computeAutoLayout(nodes, edges);
+    const xOf = (id: string): number => positions.get(id)?.x ?? Number.NaN;
+
+    expect(xOf("T")).toBeLessThan(xOf("A"));
+    expect(xOf("A")).toBeLessThan(xOf("B"));
+    expect(xOf("B")).toBeLessThan(xOf("C"));
+    expect(xOf("B")).toBeLessThan(xOf("D"));
+  });
+
+  it("places the loop body on the same columns as the plain chain", () => {
+    const withLoop = computeAutoLayout(nodes, edges);
+    const withoutLoop = computeAutoLayout(
+      nodes,
+      edges.filter((e) => !(e.source === "D" && e.target === "B"))
+    );
+
+    for (const id of ["T", "A", "B", "C", "D"]) {
+      expect(withLoop.get(id)?.x).toBe(withoutLoop.get(id)?.x);
+    }
+  });
+});

--- a/tests/unit/back-edges.test.ts
+++ b/tests/unit/back-edges.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  collectReachable,
+  findBackEdges,
+  isBackEdge,
+  partitionByBackEdges,
+} from "@/lib/workflow/editor/back-edges";
+import {
+  buildEdgesBySource,
+  buildEdgesByTarget,
+  getReadyDownstreamIds,
+} from "@/lib/workflow/executor/convergence-barrier";
+
+const nodes = (...ids: string[]): Array<{ id: string }> =>
+  ids.map((id) => ({ id }));
+
+describe("findBackEdges", () => {
+  it("finds nothing in a plain chain", () => {
+    const found = findBackEdges(nodes("T", "A", "B"), [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+    ]);
+    expect(found.size).toBe(0);
+  });
+
+  it("finds nothing in a fork-join diamond", () => {
+    const found = findBackEdges(nodes("T", "A", "B", "C", "D"), [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+      { source: "A", target: "C" },
+      { source: "B", target: "D" },
+      { source: "C", target: "D" },
+    ]);
+    expect(found.size).toBe(0);
+  });
+
+  it("classifies the edge that points back at an ancestor", () => {
+    const found = findBackEdges(nodes("T", "A", "B", "C", "D"), [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "B", target: "D" },
+      { source: "D", target: "B" },
+    ]);
+    expect(isBackEdge(found, "D", "B")).toBe(true);
+    expect(isBackEdge(found, "A", "B")).toBe(false);
+    expect(found.size).toBe(1);
+  });
+
+  it("classifies a self edge", () => {
+    const found = findBackEdges(nodes("A"), [{ source: "A", target: "A" }]);
+    expect(isBackEdge(found, "A", "A")).toBe(true);
+  });
+
+  it("classifies one edge per nested loop", () => {
+    const found = findBackEdges(nodes("T", "A", "B", "C"), [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "C", target: "B" },
+      { source: "C", target: "A" },
+    ]);
+    expect(isBackEdge(found, "C", "B")).toBe(true);
+    expect(isBackEdge(found, "C", "A")).toBe(true);
+  });
+
+  it("classifies a cycle no root reaches", () => {
+    const found = findBackEdges(nodes("T", "A", "X", "Y"), [
+      { source: "T", target: "A" },
+      { source: "X", target: "Y" },
+      { source: "Y", target: "X" },
+    ]);
+    expect(found.size).toBe(1);
+    expect(isBackEdge(found, "Y", "X")).toBe(true);
+  });
+
+  it("is stable across repeated calls on the same graph", () => {
+    const graph = nodes("T", "A", "B", "C");
+    const edges = [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "C", target: "A" },
+    ];
+    const first = findBackEdges(graph, edges);
+    const second = findBackEdges(graph, edges);
+    expect([...second.keys()]).toEqual([...first.keys()]);
+  });
+});
+
+describe("partitionByBackEdges", () => {
+  it("returns the original array when the graph is acyclic", () => {
+    const edges = [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+    ];
+    const partition = partitionByBackEdges(nodes("T", "A", "B"), edges);
+    expect(partition.forwardEdges).toBe(edges);
+    expect(partition.backEdges).toEqual([]);
+  });
+
+  it("separates the loop edge and keeps the rest forward", () => {
+    const { forwardEdges, backEdges } = partitionByBackEdges(
+      nodes("T", "A", "B", "C"),
+      [
+        { source: "T", target: "A" },
+        { source: "A", target: "B" },
+        { source: "B", target: "C" },
+        { source: "C", target: "B" },
+      ]
+    );
+    expect(backEdges).toEqual([{ source: "C", target: "B" }]);
+    expect(forwardEdges).toHaveLength(3);
+  });
+
+  it("keeps both parallel edges between a pair together", () => {
+    const { backEdges } = partitionByBackEdges(nodes("A", "B"), [
+      { source: "A", target: "B" },
+      { source: "B", target: "A", sourceHandle: "true" },
+      { source: "B", target: "A", sourceHandle: "false" },
+    ]);
+    expect(backEdges).toHaveLength(2);
+  });
+});
+
+describe("convergence barrier over the forward DAG", () => {
+  // The bug the loop support exists to fix: a back edge into B raises B's
+  // in-degree to 2, so the barrier holds B for an arrival only B can produce.
+  const graph = nodes("T", "A", "B", "C", "D");
+  const edges = [
+    { source: "T", target: "A" },
+    { source: "A", target: "B" },
+    { source: "B", target: "C" },
+    { source: "B", target: "D" },
+    { source: "D", target: "B" },
+  ];
+
+  it("stalls at the loop entry when back edges count toward in-degree", () => {
+    const ready = getReadyDownstreamIds(
+      "A",
+      ["B"],
+      buildEdgesByTarget(edges),
+      new Map(),
+      new Set()
+    );
+    expect(ready).toEqual([]);
+  });
+
+  it("releases the loop entry once back edges are excluded", () => {
+    const { forwardEdges } = partitionByBackEdges(graph, edges);
+    const ready = getReadyDownstreamIds(
+      "A",
+      ["B"],
+      buildEdgesByTarget(forwardEdges),
+      new Map(),
+      new Set()
+    );
+    expect(ready).toEqual(["B"]);
+  });
+
+  it("still holds a genuine fan-in join that also carries a back edge", () => {
+    const joinNodes = nodes("T", "A", "B", "J", "E");
+    const joinEdges = [
+      { source: "T", target: "A" },
+      { source: "T", target: "B" },
+      { source: "A", target: "J" },
+      { source: "B", target: "J" },
+      { source: "J", target: "E" },
+      { source: "E", target: "J" },
+    ];
+    const { forwardEdges } = partitionByBackEdges(joinNodes, joinEdges);
+    const byTarget = buildEdgesByTarget(forwardEdges);
+    const arrivals = new Map<string, Set<string>>();
+    const visited = new Set<string>();
+
+    expect(
+      getReadyDownstreamIds("A", ["J"], byTarget, arrivals, visited)
+    ).toEqual([]);
+    expect(
+      getReadyDownstreamIds("B", ["J"], byTarget, arrivals, visited)
+    ).toEqual(["J"]);
+  });
+});
+
+describe("collectReachable", () => {
+  it("returns the start node and everything it feeds", () => {
+    const { forwardEdges } = partitionByBackEdges(
+      nodes("T", "A", "B", "C", "D"),
+      [
+        { source: "T", target: "A" },
+        { source: "A", target: "B" },
+        { source: "B", target: "C" },
+        { source: "B", target: "D" },
+        { source: "D", target: "B" },
+      ]
+    );
+    const reachable = collectReachable("B", buildEdgesBySource(forwardEdges));
+    expect([...reachable].sort()).toEqual(["B", "C", "D"]);
+  });
+
+  it("terminates on a graph whose forward map still holds a cycle", () => {
+    const edgesBySource = buildEdgesBySource([
+      { source: "A", target: "B" },
+      { source: "B", target: "A" },
+    ]);
+    expect([...collectReachable("A", edgesBySource)].sort()).toEqual([
+      "A",
+      "B",
+    ]);
+  });
+});

--- a/tests/unit/loop-back-dispatch.test.ts
+++ b/tests/unit/loop-back-dispatch.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Drives the executor's dispatch shape (forward barrier, back-edge routing,
+ * body reset) over the real primitives, so the loop is exercised end to end
+ * without standing up the step registry the full executor pulls in.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  collectReachable,
+  isBackEdge,
+  partitionByBackEdges,
+} from "@/lib/workflow/editor/back-edges";
+import {
+  buildEdgesBySource,
+  buildEdgesByTarget,
+  getReadyDownstreamIds,
+} from "@/lib/workflow/executor/convergence-barrier";
+import {
+  createLoopBackTracker,
+  resetLoopBodyState,
+} from "@/lib/workflow/executor/loop-back";
+
+type Edge = { source: string; target: string };
+
+type RunOutcome = {
+  /** Node IDs in execution order, one entry per pass. */
+  ran: string[];
+  /** Cap refusals, as [node that asked to loop, message]. */
+  refusals: [string, string][];
+};
+
+type RunOptions = {
+  /** Returns the targets a node routes to, given how many times it has run. */
+  route?: (nodeId: string, runCount: number) => string[] | undefined;
+  maxIterationsPerLoop?: number;
+  maxTraversalsPerExecution?: number;
+};
+
+function runGraph(
+  nodeIds: string[],
+  edges: Edge[],
+  startId: string,
+  options: RunOptions = {}
+): RunOutcome {
+  const nodes = nodeIds.map((id) => ({ id }));
+  const { forwardEdges, backEdgesBySource } = partitionByBackEdges(
+    nodes,
+    edges
+  );
+  const edgesBySource = buildEdgesBySource(edges);
+  const forwardEdgesBySource = buildEdgesBySource(forwardEdges);
+  const edgesByTarget = buildEdgesByTarget(forwardEdges);
+
+  const state = {
+    visited: new Set<string>(),
+    convergenceArrivals: new Map<string, Set<string>>(),
+    convergenceSkipArrivals: new Map<string, Set<string>>(),
+    skippedNodes: new Set<string>(),
+  };
+  const tracker = createLoopBackTracker({
+    maxIterationsPerLoop: options.maxIterationsPerLoop,
+    maxTraversalsPerExecution: options.maxTraversalsPerExecution,
+  });
+
+  const ran: string[] = [];
+  const refusals: [string, string][] = [];
+  const runCounts = new Map<string, number>();
+
+  const executeNode = (nodeId: string): void => {
+    if (state.visited.has(nodeId)) {
+      return;
+    }
+    state.visited.add(nodeId);
+    ran.push(nodeId);
+    const runCount = (runCounts.get(nodeId) ?? 0) + 1;
+    runCounts.set(nodeId, runCount);
+
+    const targets =
+      options.route?.(nodeId, runCount) ?? edgesBySource.get(nodeId) ?? [];
+    dispatch(nodeId, targets);
+  };
+
+  const dispatch = (fromNodeId: string, targets: string[]): void => {
+    const forwardTargets: string[] = [];
+    const loopEntryTargets: string[] = [];
+    for (const target of targets) {
+      if (isBackEdge(backEdgesBySource, fromNodeId, target)) {
+        loopEntryTargets.push(target);
+      } else {
+        forwardTargets.push(target);
+      }
+    }
+
+    for (const readyId of getReadyDownstreamIds(
+      fromNodeId,
+      forwardTargets,
+      edgesByTarget,
+      state.convergenceArrivals,
+      state.visited
+    )) {
+      executeNode(readyId);
+    }
+
+    for (const loopEntryId of loopEntryTargets) {
+      const body = collectReachable(loopEntryId, forwardEdgesBySource);
+      const admission = tracker.admit(fromNodeId, loopEntryId, body);
+      if (!admission.admitted) {
+        refusals.push([fromNodeId, admission.error]);
+        continue;
+      }
+      resetLoopBodyState(body, state);
+      executeNode(loopEntryId);
+    }
+  };
+
+  executeNode(startId);
+  return { ran, refusals };
+}
+
+describe("loop-back dispatch", () => {
+  // T -> A -> B -> {C, D}; D routes back to B until its third pass.
+  const nodeIds = ["T", "A", "B", "C", "D"];
+  const edges: Edge[] = [
+    { source: "T", target: "A" },
+    { source: "A", target: "B" },
+    { source: "B", target: "C" },
+    { source: "B", target: "D" },
+    { source: "D", target: "B" },
+  ];
+
+  it("reaches the loop entry instead of stalling in front of it", () => {
+    const { ran } = runGraph(nodeIds, edges, "T", {
+      route: (nodeId) => (nodeId === "D" ? [] : undefined),
+    });
+    expect(ran).toEqual(["T", "A", "B", "C", "D"]);
+  });
+
+  it("runs the loop entry and everything below it again on each pass", () => {
+    const { ran, refusals } = runGraph(nodeIds, edges, "T", {
+      route: (nodeId, runCount) => {
+        if (nodeId !== "D") {
+          return;
+        }
+        return runCount < 3 ? ["B"] : [];
+      },
+    });
+
+    expect(refusals).toEqual([]);
+    expect(ran).toEqual([
+      "T",
+      "A",
+      "B",
+      "C",
+      "D",
+      "B",
+      "C",
+      "D",
+      "B",
+      "C",
+      "D",
+    ]);
+    // The nodes above the loop entry run once, whatever the loop does.
+    expect(ran.filter((id) => id === "T")).toHaveLength(1);
+    expect(ran.filter((id) => id === "A")).toHaveLength(1);
+  });
+
+  it("stops a loop that never exits, and says which loop it was", () => {
+    const { ran, refusals } = runGraph(nodeIds, edges, "T", {
+      route: (nodeId) => (nodeId === "D" ? ["B"] : undefined),
+      maxIterationsPerLoop: 4,
+    });
+
+    expect(refusals).toHaveLength(1);
+    expect(refusals[0][0]).toBe("D");
+    expect(refusals[0][1]).toContain("4 iterations");
+    expect(ran.filter((id) => id === "B")).toHaveLength(5);
+  });
+
+  it("keeps a fan-in join inside the loop working on every pass", () => {
+    // B forks to P and Q, which join at J; J loops back to B.
+    const joinNodeIds = ["T", "B", "P", "Q", "J"];
+    const joinEdges: Edge[] = [
+      { source: "T", target: "B" },
+      { source: "B", target: "P" },
+      { source: "B", target: "Q" },
+      { source: "P", target: "J" },
+      { source: "Q", target: "J" },
+      { source: "J", target: "B" },
+    ];
+
+    const { ran, refusals } = runGraph(joinNodeIds, joinEdges, "T", {
+      route: (nodeId, runCount) => {
+        if (nodeId !== "J") {
+          return;
+        }
+        return runCount < 2 ? ["B"] : [];
+      },
+    });
+
+    expect(refusals).toEqual([]);
+    // J is a real join: it runs once per pass, after both branches arrive.
+    expect(ran.filter((id) => id === "J")).toHaveLength(2);
+    expect(ran).toEqual(["T", "B", "P", "Q", "J", "B", "P", "Q", "J"]);
+  });
+
+  it("bounds nested loops with the per-execution cap", () => {
+    // Inner loop C -> B, outer loop D -> A, neither exits on its own.
+    const nestedNodeIds = ["T", "A", "B", "C", "D"];
+    const nestedEdges: Edge[] = [
+      { source: "T", target: "A" },
+      { source: "A", target: "B" },
+      { source: "B", target: "C" },
+      { source: "C", target: "B" },
+      { source: "C", target: "D" },
+      { source: "D", target: "A" },
+    ];
+
+    const { refusals } = runGraph(nestedNodeIds, nestedEdges, "T", {
+      route: (nodeId, runCount) => {
+        if (nodeId === "C") {
+          return runCount % 2 === 1 ? ["B"] : ["D"];
+        }
+        return;
+      },
+      maxIterationsPerLoop: 1000,
+      maxTraversalsPerExecution: 12,
+    });
+
+    expect(refusals.length).toBeGreaterThan(0);
+    expect(refusals.at(-1)?.[1]).toContain("12 loop iterations");
+  });
+});

--- a/tests/unit/loop-back.test.ts
+++ b/tests/unit/loop-back.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  createLoopBackTracker,
+  findUnsupportedBackEdges,
+  MAX_LOOP_ITERATIONS,
+  MAX_LOOP_TRAVERSALS_PER_EXECUTION,
+  resetLoopBodyState,
+} from "@/lib/workflow/executor/loop-back";
+
+describe("createLoopBackTracker", () => {
+  it("numbers the passes of one loop from 1", () => {
+    const tracker = createLoopBackTracker();
+    expect(tracker.admit("D", "B", ["B", "C", "D"])).toEqual({
+      admitted: true,
+      iteration: 1,
+    });
+    expect(tracker.admit("D", "B", ["B", "C", "D"])).toEqual({
+      admitted: true,
+      iteration: 2,
+    });
+  });
+
+  it("counts each loop separately", () => {
+    const tracker = createLoopBackTracker();
+    tracker.admit("D", "B", ["B", "D"]);
+    tracker.admit("D", "B", ["B", "D"]);
+    expect(tracker.admit("F", "E", ["E", "F"])).toEqual({
+      admitted: true,
+      iteration: 1,
+    });
+  });
+
+  it("refuses the pass past the per-loop cap and names the loop entry", () => {
+    const tracker = createLoopBackTracker({
+      maxIterationsPerLoop: 2,
+      labelOf: (id) => (id === "B" ? "Check Balance" : id),
+    });
+    tracker.admit("D", "B", ["B", "D"]);
+    tracker.admit("D", "B", ["B", "D"]);
+
+    const refused = tracker.admit("D", "B", ["B", "D"]);
+    expect(refused.admitted).toBe(false);
+    if (refused.admitted) {
+      throw new Error("expected the third pass to be refused");
+    }
+    expect(refused.error).toContain("Check Balance");
+    expect(refused.error).toContain("2 iterations");
+  });
+
+  it("refuses on the per-execution cap even when no single loop is over", () => {
+    const tracker = createLoopBackTracker({
+      maxIterationsPerLoop: 10,
+      maxTraversalsPerExecution: 3,
+    });
+    tracker.admit("D", "B", ["B", "D"]);
+    tracker.admit("D", "B", ["B", "D"]);
+    tracker.admit("F", "E", ["E", "F"]);
+
+    const refused = tracker.admit("F", "E", ["E", "F"]);
+    expect(refused.admitted).toBe(false);
+    if (refused.admitted) {
+      throw new Error("expected the fourth traversal to be refused");
+    }
+    expect(refused.error).toContain("3 loop iterations");
+  });
+
+  it("does not spend the execution budget on a refused pass", () => {
+    const tracker = createLoopBackTracker({ maxIterationsPerLoop: 1 });
+    tracker.admit("D", "B", ["B", "D"]);
+    tracker.admit("D", "B", ["B", "D"]);
+    expect(tracker.totalTraversals()).toBe(1);
+  });
+
+  it("reports the pass each body node is on", () => {
+    const tracker = createLoopBackTracker();
+    expect(tracker.iterationOf("C")).toBe(0);
+    tracker.admit("D", "B", ["B", "C", "D"]);
+    expect(tracker.iterationOf("C")).toBe(1);
+    expect(tracker.iterationOf("Z")).toBe(0);
+  });
+
+  it("ships caps that bound a runaway loop", () => {
+    expect(MAX_LOOP_ITERATIONS).toBeGreaterThan(0);
+    expect(MAX_LOOP_TRAVERSALS_PER_EXECUTION).toBeGreaterThanOrEqual(
+      MAX_LOOP_ITERATIONS
+    );
+  });
+});
+
+describe("resetLoopBodyState", () => {
+  it("re-arms only the loop body, leaving the rest of the run alone", () => {
+    const state = {
+      visited: new Set(["T", "A", "B", "C", "D"]),
+      convergenceArrivals: new Map([
+        ["C", new Set(["B"])],
+        ["J", new Set(["X"])],
+      ]),
+      convergenceSkipArrivals: new Map([["C", new Set(["B"])]]),
+      skippedNodes: new Set(["C", "Z"]),
+    };
+
+    resetLoopBodyState(["B", "C", "D"], state);
+
+    expect([...state.visited].sort()).toEqual(["A", "T"]);
+    expect(state.convergenceArrivals.has("C")).toBe(false);
+    expect(state.convergenceArrivals.has("J")).toBe(true);
+    expect(state.convergenceSkipArrivals.has("C")).toBe(false);
+    expect([...state.skippedNodes]).toEqual(["Z"]);
+  });
+});
+
+describe("findUnsupportedBackEdges", () => {
+  const forEachBody = new Set(["B1", "B2"]);
+
+  it("passes a back edge clear of every For Each body", () => {
+    expect(
+      findUnsupportedBackEdges([{ source: "D", target: "B" }], forEachBody)
+    ).toEqual([]);
+  });
+
+  it("flags a back edge leaving a For Each body", () => {
+    expect(
+      findUnsupportedBackEdges([{ source: "B2", target: "A" }], forEachBody)
+    ).toHaveLength(1);
+  });
+
+  it("flags a back edge entering a For Each body", () => {
+    expect(
+      findUnsupportedBackEdges([{ source: "D", target: "B1" }], forEachBody)
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
### Problem

Drawing an edge from a downstream node back to an earlier one produced a workflow that stopped at the node before the loop entry. The engine treats any node with more than one incoming edge as a fan-in join and holds it until every branch arrives; a back edge counts as one of those branches, and it can only arrive after the node it points at has run. The join waits forever.

Auto-layout had the mirror of the same bug: the loop entry never cleared its in-degree during the column sweep, so it and everything downstream were placed as disconnected nodes stacked below the graph.

### What changes

Back edges are classified once per run by a depth-first pass and kept apart from the forward DAG. Everything that reasons about what must happen before a node runs (convergence barrier, orphan detection, condition skip propagation, For Each body identification, layout columns) reads the forward edges only.

Routing keeps the back edges, so reaching one re-enters the loop entry: the loop body's traversal state is cleared and the entry plus every node below it runs again. Outputs are overwritten per pass, so templates and the run panel read the newest one.

### Guardrails

- 100 passes per loop, 1000 loop traversals per run. Either cap fails the run with a message naming the loop entry, so a loop that never exits stops loudly instead of returning a half-finished pass.
- A pass after the first skips the spurious-max-retries recovery: that recovery is keyed by node, and on a second pass it would hand back the previous pass's output as if it were this one's.
- A back edge that crosses a For Each body is refused before the first step runs; the body runner's dispatcher would drop it in silence.

### Coverage

33 new unit tests over back-edge classification, the caps, body-state reset, layout, and a harness that drives the executor's dispatch shape end to end. Full unit suite passes (21,719 tests).
