### PR TITLE
feat(execute): #1927 accept abiFunction as an alias for functionName in direct execution

### DIFF
--- a/app/api/execute/_lib/schemas.ts
+++ b/app/api/execute/_lib/schemas.ts
@@ -33,6 +33,39 @@ function hasChainInput(record: Record<string, unknown>): boolean {
   return isNonEmptyString(record.chainId) || isNonEmptyString(record.network);
 }
 
+// KEEP-1927: functionName is canonical on direct-exec routes; abiFunction is
+// the workflow web3 action node's name for the same value. Either counts as
+// present. Unlike hasChainInput's chainId/network handling above, KEEP-490
+// never picks a winner when both are set (it only falls back to network when
+// chainId is absent) -- there is no "silently prefer the canonical field"
+// precedent to extend here, so a conflict between the two is treated as
+// caller error rather than resolved for them. This endpoint broadcasts: a
+// mismatched pair (e.g. functionName: "transfer" vs abiFunction:
+// "transferFrom") describes two different transactions, and only one of them
+// is what the caller meant.
+function hasFunctionNameInput(record: Record<string, unknown>): boolean {
+  return (
+    isNonEmptyString(record.functionName) || isNonEmptyString(record.abiFunction)
+  );
+}
+
+function functionNameConflict(
+  record: Record<string, unknown>
+): ExecuteErrorResponse | null {
+  if (
+    !isNonEmptyString(record.functionName) ||
+    !isNonEmptyString(record.abiFunction) ||
+    record.functionName === record.abiFunction
+  ) {
+    return null;
+  }
+  return {
+    error: "Conflicting field values",
+    field: "abiFunction",
+    details: `functionName and abiFunction disagree ('${record.functionName}' vs '${record.abiFunction}'); send one, or the same value in both. functionName is canonical.`,
+  };
+}
+
 function requiredFieldError(field: string): ExecuteErrorResponse {
   return {
     error: "Missing required field",
@@ -146,8 +179,13 @@ export const contractCallInputSchema = objectBase.superRefine((record, ctx) => {
     addError(ctx, chainFieldError);
     return;
   }
-  if (!isNonEmptyString(record.functionName)) {
+  if (!hasFunctionNameInput(record)) {
     addError(ctx, requiredFieldError("functionName"));
+    return;
+  }
+  const conflict = functionNameConflict(record);
+  if (conflict) {
+    addError(ctx, conflict);
     return;
   }
   if ("functionArgs" in record && typeof record.functionArgs !== "string") {

--- a/app/api/execute/_lib/schemas.ts
+++ b/app/api/execute/_lib/schemas.ts
@@ -41,7 +41,8 @@ function hasChainInput(record: Record<string, unknown>): boolean {
 // only one of which is what the caller meant.
 function hasFunctionNameInput(record: Record<string, unknown>): boolean {
   return (
-    isNonEmptyString(record.functionName) || isNonEmptyString(record.abiFunction)
+    isNonEmptyString(record.functionName) ||
+    isNonEmptyString(record.abiFunction)
   );
 }
 
@@ -57,7 +58,7 @@ function trimmedText(value: unknown): string {
 function functionNameConflict(
   record: Record<string, unknown>
 ): ExecuteErrorResponse | null {
-  if (!("functionName" in record) || !("abiFunction" in record)) {
+  if (!(("functionName" in record) && ("abiFunction" in record))) {
     return null;
   }
   const functionName = trimmedText(record.functionName);

--- a/app/api/execute/_lib/schemas.ts
+++ b/app/api/execute/_lib/schemas.ts
@@ -58,7 +58,7 @@ function trimmedText(value: unknown): string {
 function functionNameConflict(
   record: Record<string, unknown>
 ): ExecuteErrorResponse | null {
-  if (!(("functionName" in record) && ("abiFunction" in record))) {
+  if (!("functionName" in record && "abiFunction" in record)) {
     return null;
   }
   const functionName = trimmedText(record.functionName);

--- a/app/api/execute/_lib/schemas.ts
+++ b/app/api/execute/_lib/schemas.ts
@@ -35,34 +35,40 @@ function hasChainInput(record: Record<string, unknown>): boolean {
 
 // KEEP-1927: functionName is canonical on direct-exec routes; abiFunction is
 // the workflow web3 action node's name for the same value. Either counts as
-// present. Unlike hasChainInput's chainId/network handling above, KEEP-490
-// never picks a winner when both are set (it only falls back to network when
-// chainId is absent) -- there is no "silently prefer the canonical field"
-// precedent to extend here, so a conflict between the two is treated as
-// caller error rather than resolved for them. This endpoint broadcasts: a
-// mismatched pair (e.g. functionName: "transfer" vs abiFunction:
-// "transferFrom") describes two different transactions, and only one of them
-// is what the caller meant.
+// present. A mismatched pair is caller error rather than something to resolve
+// for them: this endpoint broadcasts, and two names that are both in the ABI
+// (e.g. "transfer" vs "transferFrom") describe two different transactions,
+// only one of which is what the caller meant.
 function hasFunctionNameInput(record: Record<string, unknown>): boolean {
   return (
     isNonEmptyString(record.functionName) || isNonEmptyString(record.abiFunction)
   );
 }
 
+function trimmedText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : String(value);
+}
+
+// Conflict is keyed on the keys being present, not on their values being
+// usable strings, because the contract-call route fills functionName in from
+// abiFunction under the same test. A functionName the route cannot use ("" or
+// a non-string) is still the caller's stated intent, so it conflicts with a
+// differing abiFunction instead of being quietly overwritten.
 function functionNameConflict(
   record: Record<string, unknown>
 ): ExecuteErrorResponse | null {
-  if (
-    !isNonEmptyString(record.functionName) ||
-    !isNonEmptyString(record.abiFunction) ||
-    record.functionName === record.abiFunction
-  ) {
+  if (!("functionName" in record) || !("abiFunction" in record)) {
+    return null;
+  }
+  const functionName = trimmedText(record.functionName);
+  const abiFunction = trimmedText(record.abiFunction);
+  if (functionName === abiFunction) {
     return null;
   }
   return {
     error: "Conflicting field values",
     field: "abiFunction",
-    details: `functionName and abiFunction disagree ('${record.functionName}' vs '${record.abiFunction}'); send one, or the same value in both. functionName is canonical.`,
+    details: `functionName and abiFunction disagree ('${functionName}' vs '${abiFunction}'); send one, or the same value in both. functionName is canonical.`,
   };
 }
 

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -278,6 +278,19 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  // KEEP-1927: abiFunction is the workflow web3 action node's name for this
+  // same value; accept it as an alias so payloads copied between the two
+  // layers bind without a rename. Only fills functionName in when it's
+  // absent -- if both are present, schema validation below rejects a
+  // mismatch (400) rather than silently picking one, so a differing pair
+  // never reaches this branch with one value quietly discarded.
+  if (
+    typeof body.functionName !== "string" &&
+    typeof body.abiFunction === "string"
+  ) {
+    body.functionName = body.abiFunction;
+  }
+
   const simulateFlag = parseSimulateFlag(body);
   if (!simulateFlag.ok) {
     return NextResponse.json(

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -280,14 +280,12 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // KEEP-1927: abiFunction is the workflow web3 action node's name for this
   // same value; accept it as an alias so payloads copied between the two
-  // layers bind without a rename. Only fills functionName in when it's
-  // absent -- if both are present, schema validation below rejects a
-  // mismatch (400) rather than silently picking one, so a differing pair
-  // never reaches this branch with one value quietly discarded.
-  if (
-    typeof body.functionName !== "string" &&
-    typeof body.abiFunction === "string"
-  ) {
+  // layers bind without a rename. Keyed on the key being absent rather than on
+  // its value being usable, which is the same test the conflict check in
+  // _lib/schemas applies: a body carrying both keys is never filled in here,
+  // and a differing pair is rejected there (400) instead of broadcasting under
+  // one of the two names.
+  if (!("functionName" in body) && "abiFunction" in body) {
     body.functionName = body.abiFunction;
   }
 

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -380,8 +380,10 @@ Call any smart contract function. Automatically detects read vs write operations
 - `functionName` (required): Name of the function to call. The workflow web3
   action node config calls this same value `abiFunction`; this route accepts
   `abiFunction` as an alias so payloads copied between the two layers bind
-  without a rename. If both are present they must agree; a mismatch is
-  rejected with a 400 naming both values.
+  without a rename. If both keys are present their values must agree once
+  surrounding whitespace is trimmed; a mismatch - including an empty or
+  non-string `functionName` next to a different `abiFunction` - is rejected
+  with a 400 naming both values.
 - `functionArgs` (optional): JSON array string of function arguments (e.g., `"[\"0x...\", \"1000\"]"`)
 - `abi` (optional): Contract ABI as JSON string. Auto-fetched from block explorer if omitted.
 - `value` (optional): Native value to send with the call, as a decimal string in ether units (e.g. `0.1`) (for payable functions)
@@ -390,13 +392,18 @@ Call any smart contract function. Automatically detects read vs write operations
 **Direct execution vs. workflow node field names**
 
 The same values carry different field names depending on which surface you're
-building against. Both are accepted on `/api/execute/contract-call`; only the
-canonical name is accepted in workflow node config.
+building against. This route accepts either spelling; workflow node config
+accepts only the single spelling in the right-hand column, which is not the
+canonical one in either row.
 
-| Meaning | Direct execution (`/api/execute/*`) | Workflow web3 action node config |
+| Meaning | `POST /api/execute/contract-call` | Workflow web3 action node config |
 |---|---|---|
 | Chain to execute on | `chainId` (canonical), `network` (deprecated alias) | `network` |
 | Function to call | `functionName` (canonical), `abiFunction` (alias) | `abiFunction` |
+
+The `abiFunction` alias is specific to this route. `check-and-execute` still
+requires `functionName` (and `action.functionName`), so a body that carries
+only `abiFunction` is rejected there with a 400.
 
 ### Response
 

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -377,11 +377,26 @@ Call any smart contract function. Automatically detects read vs write operations
 - `contractAddress` (required): Smart contract address
 - `chainId` (required): Numeric chain ID as a number or numeric string. The
   legacy `network` field still accepts known chain names but is deprecated.
-- `functionName` (required): Name of the function to call
+- `functionName` (required): Name of the function to call. The workflow web3
+  action node config calls this same value `abiFunction`; this route accepts
+  `abiFunction` as an alias so payloads copied between the two layers bind
+  without a rename. If both are present they must agree; a mismatch is
+  rejected with a 400 naming both values.
 - `functionArgs` (optional): JSON array string of function arguments (e.g., `"[\"0x...\", \"1000\"]"`)
 - `abi` (optional): Contract ABI as JSON string. Auto-fetched from block explorer if omitted.
 - `value` (optional): Native value to send with the call, as a decimal string in ether units (e.g. `0.1`) (for payable functions)
 - `gasLimitMultiplier` (optional): Gas limit multiplier
+
+**Direct execution vs. workflow node field names**
+
+The same values carry different field names depending on which surface you're
+building against. Both are accepted on `/api/execute/contract-call`; only the
+canonical name is accepted in workflow node config.
+
+| Meaning | Direct execution (`/api/execute/*`) | Workflow web3 action node config |
+|---|---|---|
+| Chain to execute on | `chainId` (canonical), `network` (deprecated alias) | `network` |
+| Function to call | `functionName` (canonical), `abiFunction` (alias) | `abiFunction` |
 
 ### Response
 

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -146,7 +146,7 @@
       "path": "/api/execute/{executionId}/status",
       "route_file": "app/api/execute/[executionId]/status/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 685
+      "line": 707
     },
     {
       "method": "GET",
@@ -384,7 +384,7 @@
       "path": "/api/execute/check-and-execute",
       "route_file": "app/api/execute/check-and-execute/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 424
+      "line": 446
     },
     {
       "method": "POST",
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 847
+      "line": 869
     },
     {
       "method": "POST",

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -649,6 +649,58 @@ describe("Direct Execution API", () => {
       expect(mocks.checkAndReserveExecution).not.toHaveBeenCalled();
     });
 
+    it("accepts abiFunction as an alias for functionName (KEEP-1927)", async () => {
+      setupPassingGuards();
+      mocks.readContractCore.mockResolvedValue({
+        success: true,
+        result: "1000000",
+      });
+
+      const { functionName, ...bodyWithoutFunctionName } = validReadBody;
+      const body = { ...bodyWithoutFunctionName, abiFunction: functionName };
+
+      const response = await contractCallPOST(postRequest("/contract-call", body));
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.result).toBe("1000000");
+      expect(mocks.readContractCore).toHaveBeenCalledWith(
+        expect.objectContaining({ abiFunction: "balanceOf" })
+      );
+    });
+
+    it("accepts functionName and abiFunction together when they agree", async () => {
+      setupPassingGuards();
+      mocks.readContractCore.mockResolvedValue({
+        success: true,
+        result: "1000000",
+      });
+
+      const body = { ...validReadBody, abiFunction: validReadBody.functionName };
+
+      const response = await contractCallPOST(postRequest("/contract-call", body));
+
+      expect(response.status).toBe(200);
+      expect(mocks.readContractCore).toHaveBeenCalledWith(
+        expect.objectContaining({ abiFunction: "balanceOf" })
+      );
+    });
+
+    it("rejects functionName and abiFunction when they disagree (KEEP-1927)", async () => {
+      setupPassingGuards();
+
+      const body = { ...validReadBody, abiFunction: "someOtherFunction" };
+
+      const response = await contractCallPOST(postRequest("/contract-call", body));
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.field).toBe("abiFunction");
+      expect(data.details).toContain("balanceOf");
+      expect(data.details).toContain("someOtherFunction");
+      expect(mocks.readContractCore).not.toHaveBeenCalled();
+    });
+
     it("returns 202 for write call with execution record", async () => {
       setupPassingGuards();
       mocks.writeContractCore.mockResolvedValue({

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -659,7 +659,9 @@ describe("Direct Execution API", () => {
       const { functionName, ...bodyWithoutFunctionName } = validReadBody;
       const body = { ...bodyWithoutFunctionName, abiFunction: functionName };
 
-      const response = await contractCallPOST(postRequest("/contract-call", body));
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
 
       expect(response.status).toBe(200);
       const data = await response.json();
@@ -676,9 +678,14 @@ describe("Direct Execution API", () => {
         result: "1000000",
       });
 
-      const body = { ...validReadBody, abiFunction: validReadBody.functionName };
+      const body = {
+        ...validReadBody,
+        abiFunction: validReadBody.functionName,
+      };
 
-      const response = await contractCallPOST(postRequest("/contract-call", body));
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
 
       expect(response.status).toBe(200);
       expect(mocks.readContractCore).toHaveBeenCalledWith(
@@ -691,7 +698,9 @@ describe("Direct Execution API", () => {
 
       const body = { ...validReadBody, abiFunction: "someOtherFunction" };
 
-      const response = await contractCallPOST(postRequest("/contract-call", body));
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
 
       expect(response.status).toBe(400);
       const data = await response.json();
@@ -699,6 +708,111 @@ describe("Direct Execution API", () => {
       expect(data.details).toContain("balanceOf");
       expect(data.details).toContain("someOtherFunction");
       expect(mocks.readContractCore).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty functionName alongside a usable abiFunction", async () => {
+      // An empty functionName is present, so it is not filled in from the
+      // alias: the caller named the function twice and the two names differ.
+      setupPassingGuards();
+
+      const body = {
+        ...validReadBody,
+        functionName: "",
+        abiFunction: "balanceOf",
+      };
+
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.field).toBe("abiFunction");
+      expect(data.details).toContain("balanceOf");
+      expect(mocks.readContractCore).not.toHaveBeenCalled();
+    });
+
+    it("rejects an empty abiFunction alongside a usable functionName", async () => {
+      setupPassingGuards();
+
+      const body = { ...validReadBody, abiFunction: "" };
+
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.field).toBe("abiFunction");
+      expect(data.details).toContain("balanceOf");
+      expect(mocks.readContractCore).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-string functionName alongside a differing abiFunction", async () => {
+      // The write path is the one that matters here: filling functionName in
+      // over a non-string would broadcast the alias's function under a name
+      // the caller never sent.
+      setupPassingGuards();
+
+      const body = {
+        ...validWriteBody,
+        functionName: 123,
+        abiFunction: "transfer",
+      };
+
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
+
+      expect(response.status).toBe(400);
+      const data = await response.json();
+      expect(data.field).toBe("abiFunction");
+      expect(data.details).toContain("123");
+      expect(data.details).toContain("transfer");
+      expect(mocks.writeContractCore).not.toHaveBeenCalled();
+      expect(mocks.checkAndReserveExecution).not.toHaveBeenCalled();
+    });
+
+    it("treats surrounding whitespace as agreement, not a conflict", async () => {
+      setupPassingGuards();
+      mocks.readContractCore.mockResolvedValue({
+        success: true,
+        result: "1000000",
+      });
+
+      const body = { ...validReadBody, abiFunction: "balanceOf " };
+
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
+
+      expect(response.status).toBe(200);
+      expect(mocks.readContractCore).toHaveBeenCalledWith(
+        expect.objectContaining({ abiFunction: "balanceOf" })
+      );
+    });
+
+    it("accepts abiFunction as an alias on the write path", async () => {
+      setupPassingGuards();
+      mocks.writeContractCore.mockResolvedValue({
+        success: true,
+        transactionHash: "0xwrite",
+        transactionLink: "https://etherscan.io/tx/0xwrite",
+      });
+
+      const { functionName, ...bodyWithoutFunctionName } = validWriteBody;
+      const body = { ...bodyWithoutFunctionName, abiFunction: functionName };
+
+      const response = await contractCallPOST(
+        postRequest("/contract-call", body)
+      );
+
+      expect(response.status).toBe(202);
+      const data = await response.json();
+      expect(data.transactionHash).toBe("0xwrite");
+      expect(mocks.writeContractCore).toHaveBeenCalledWith(
+        expect.objectContaining({ abiFunction: "transfer" })
+      );
     });
 
     it("returns 202 for write call with execution record", async () => {


### PR DESCRIPTION
Title: feat(execute): #1927 accept abiFunction as an alias for functionName in direct execution

## Issue

Closes #1927

## What this changes

`POST /api/execute/contract-call` required `functionName`; the workflow web3
action node config for the same call uses `abiFunction`. A payload built
against one surface didn't bind on the other.

This adds `abiFunction` as an accepted alias, following the same pattern
already used for `chainId`/`network` in this file for the "one field present"
case , but conflict handling is new policy, not a mirror of it. KEEP-490 only
falls back to `network` when `chainId` is absent; it never picks a winner
when both are set, so there's no "silently prefer the canonical field"
precedent for this endpoint to extend. Settled in the issue thread: a
disagreeing pair is a 400, not resolved on the caller's behalf, since this
endpoint broadcasts and the two names can describe two different
transactions.

- `schemas.ts`: new `hasFunctionNameInput` helper (mirrors `hasChainInput`)
  for presence, plus `functionNameConflict` ,both present and differing is a
  400 naming both values and stating `functionName` is canonical; both
  present and equal passes through untouched.
- `contract-call/route.ts`: normalizes `abiFunction` into `body.functionName`
  once, immediately after the body is parsed, but only when `functionName`
  is absent , so the existing downstream reads pick up the alias for free
  in the "one present" case, while a differing pair is left for schema
  validation to reject rather than silently collapsed here.
- Docs: noted the alias and its conflict behavior on `/api/execute/contract-call`,
  and added the direct-execution vs. workflow-node field mapping table
  RichardReki's comment on the issue flagged as missing (covers this field
  and the existing `chainId`/`network` split).

No change to `chainId`/`network` handling, response shapes, or any other
route. `functionArgs`, ABI auto-fetch, and error contracts are untouched.

## Scope

One change: the alias only exists inside `contract-call`'s own validation and
body normalization. Nothing here is correct or incorrect independent of the
rest , it's a single self-contained addition, not several pieces that could
ship separately.

Not included, on purpose: converging on one field name across both surfaces
long-term (the issue's "longer term" note)  that's a breaking change to
workflow node config and a maintainer call, not part of this fix.

## How it was verified

Added to `tests/integration/direct-execution-api.test.ts`:

- `accepts abiFunction as an alias for functionName (KEEP-1927)` — sends
  `abiFunction` with no `functionName`, asserts a 200 and that
  `readContractCore` is actually called with the resolved value (not just
  that the request didn't 400).
- `accepts functionName and abiFunction together when they agree` — both
  present, equal, passes through.
- `rejects functionName and abiFunction when they disagree (KEEP-1927)` —
  both present, differing, asserts a 400 naming both values on the
  `abiFunction` field and that `readContractCore` is never reached.

All three fail against `staging` as is (`functionName` required,
`abiFunction` silently ignored, no conflict check exists) and pass with this
change.

Commands run: `pnpm test tests/integration/direct-execution-api.test.ts`,
`pnpm type-check`, `pnpm check`.
.

---

- [x] Targets `staging`
- [x] Title carries the issue number
- [x] `pnpm type-check` passes (confirmed)
- [ ] `pnpm check` — pre-existing CRLF-related noise across the whole repo unrelated to this diff; not something this PR introduces or fixes
- [x] No secrets, `.env` files, or credentials committed