### PR TITLE
fix(analytics): show Composed only for runs that actually spent gas

### DIFF
--- a/components/analytics/kpi-cards.tsx
+++ b/components/analytics/kpi-cards.tsx
@@ -33,7 +33,7 @@ import { cn } from "@/lib/utils";
 
 function formatDuration(ms: number | null): string {
   if (ms === null) {
-    return "--";
+    return "-";
   }
   if (ms < 1000) {
     return `${Math.round(ms)}ms`;

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -53,9 +53,12 @@ const LEADING_ZEROS_RE = /^0+(?=\d)/;
 const TRAILING_ZEROS_RE = /0+$/;
 const NON_DIGIT_RE = /\D/;
 
+/** Placeholder for a cell whose value does not apply to this row. */
+const NO_VALUE = "-";
+
 function formatNetworks(networks: string[], chains: ChainDisplay): string {
   if (networks.length === 0) {
-    return "--";
+    return NO_VALUE;
   }
   const names = networks.map(chains.name);
   if (names.length <= 2) {
@@ -73,7 +76,7 @@ function formatGasNative(
 ): string {
   const value = Number(wei);
   if (!wei || Number.isNaN(value) || value === 0) {
-    return "--";
+    return NO_VALUE;
   }
   const amount = new Intl.NumberFormat("en-US", {
     minimumFractionDigits: 2,
@@ -97,14 +100,14 @@ function formatGasNativeExact(
   chains: ChainDisplay
 ): string {
   if (!wei || wei === "0" || NON_DIGIT_RE.test(wei)) {
-    return "--";
+    return NO_VALUE;
   }
   return `${formatWeiToDecimal(wei)} ${chains.gasSymbol(network)}`.trimEnd();
 }
 
 function formatDuration(ms: number | null): string {
   if (ms === null) {
-    return "--";
+    return NO_VALUE;
   }
   if (ms < 1000) {
     return `${Math.round(ms)}ms`;
@@ -117,21 +120,15 @@ function formatDuration(ms: number | null): string {
   return `${minutes}m ${seconds}s`;
 }
 
-function formatGasAsEth(weiString: string | null): string {
-  if (!weiString) {
-    return "--";
-  }
-  const wei = Number(weiString);
-  if (Number.isNaN(wei) || wei === 0) {
-    return "0 ETH";
-  }
-  const eth = wei / 1e18;
-  return `${eth.toFixed(4)} ETH`;
-}
-
 // Run-level gas: a run that spent on more than one chain can't sum into one
 // token, so it renders as "Composed" (per-network amounts live in the expanded
 // steps). A single chain shows its total in that chain's token.
+//
+// A run that paid nothing renders as no value no matter how many chains it
+// touched. "Composed" answers which chains the spend was split across, so a
+// read-only run has nothing to compose - `networks` counts every chain the run
+// reached, reads included, and reading that count as a spend put the word on
+// runs with an empty gas column in every step.
 //
 // The question is which chains the gas landed on, not which chains the run
 // touched - `networks` carries the second and answers the first only for a run
@@ -141,7 +138,8 @@ function formatGasAsEth(weiString: string | null): string {
 //
 // Ledger-only gas (a sponsored leg with no step rollup) names no chain of its
 // own, so it borrows the run's, which is unambiguous only when the run touched
-// a single one.
+// a single one. Sponsored wei counts as spend here: the org drew on gas credit
+// for it, and `gasCostWei` is the ledger total.
 //
 // The step rollup wins over the sponsorship ledger because it covers every
 // transaction the run made. A run that starts sponsored and falls back to
@@ -151,21 +149,21 @@ export function runGasDisplay(
   run: UnifiedRun,
   chains: ChainDisplay = FALLBACK_CHAIN_DISPLAY
 ): ReactNode {
+  const wei = run.gasUsedWei ?? run.gasCostWei;
+  if (!wei) {
+    return NO_VALUE;
+  }
   const spentAcrossChains =
     run.gasNetworks.length > 1 ||
     (run.gasNetworks.length === 0 && run.networks.length > 1);
   if (spentAcrossChains) {
     return "Composed";
   }
-  const wei = run.gasUsedWei ?? run.gasCostWei;
-  if (wei) {
-    return formatGasNative(
-      wei,
-      run.gasNetworks[0] ?? run.networks[0] ?? run.network,
-      chains
-    );
-  }
-  return formatGasAsEth(run.gasUsedWei);
+  return formatGasNative(
+    wei,
+    run.gasNetworks[0] ?? run.networks[0] ?? run.network,
+    chains
+  );
 }
 
 function formatTimeAgo(dateString: string): string {
@@ -363,7 +361,7 @@ function StepLogRow({ step }: StepLogRowProps): ReactNode {
         {formatDuration(step.durationMs)}
       </td>
       <td className="whitespace-nowrap py-1.5 pr-3 text-xs text-muted-foreground">
-        {step.network ? chains.name(step.network) : "--"}
+        {step.network ? chains.name(step.network) : NO_VALUE}
       </td>
       <td className="whitespace-nowrap py-1.5 pr-3 text-xs text-muted-foreground">
         <span className="inline-flex items-center gap-1.5">

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -56,6 +56,16 @@ const NON_DIGIT_RE = /\D/;
 /** Placeholder for a cell whose value does not apply to this row. */
 const NO_VALUE = "-";
 
+// The default tooltip surface inverts the page; run details read better on the
+// same panel the rest of the table uses. The arrow goes with it.
+const TOOLTIP_SURFACE =
+  "border bg-popover text-popover-foreground shadow-md [&>span]:hidden";
+
+const CHAIN_LIST = new Intl.ListFormat("en-US", {
+  style: "long",
+  type: "conjunction",
+});
+
 function formatNetworks(networks: string[], chains: ChainDisplay): string {
   if (networks.length === 0) {
     return NO_VALUE;
@@ -140,7 +150,46 @@ function formatDuration(ms: number | null): string {
 // own, so it borrows the run's, which is unambiguous only when the run touched
 // a single one. Sponsored wei counts as spend here: the org drew on gas credit
 // for it, and `gasCostWei` is the ledger total.
-//
+export function runGasComposed(run: UnifiedRun): boolean {
+  if (!(run.gasUsedWei ?? run.gasCostWei)) {
+    return false;
+  }
+  return (
+    run.gasNetworks.length > 1 ||
+    (run.gasNetworks.length === 0 && run.networks.length > 1)
+  );
+}
+
+// The chains a composed run split its gas across. `gasNetworks` names them
+// outright; a ledger-only sponsored leg names none of its own, so it falls back
+// to every chain the run touched, which is the ambiguity that composed it.
+function composedGasNetworks(run: UnifiedRun): string[] {
+  return run.gasNetworks.length > 0 ? run.gasNetworks : run.networks;
+}
+
+/** "Composed" carries no meaning alone, so the tooltip names the chains. */
+function ComposedGasCell({
+  chains,
+  run,
+}: {
+  chains: ChainDisplay;
+  run: UnifiedRun;
+}): ReactNode {
+  const names = CHAIN_LIST.format(composedGasNetworks(run).map(chains.name));
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="cursor-help underline decoration-dotted underline-offset-4">
+          Composed
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className={cn(TOOLTIP_SURFACE, "max-w-xs text-left")}>
+        {`This run spent gas on ${names}. Those networks have different native tokens, so there is no single total to show. Expand the run for the amount on each.`}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 // The step rollup wins over the sponsorship ledger because it covers every
 // transaction the run made. A run that starts sponsored and falls back to
 // direct signing has only its sponsored leg in the ledger, so preferring the
@@ -153,11 +202,8 @@ export function runGasDisplay(
   if (!wei) {
     return NO_VALUE;
   }
-  const spentAcrossChains =
-    run.gasNetworks.length > 1 ||
-    (run.gasNetworks.length === 0 && run.networks.length > 1);
-  if (spentAcrossChains) {
-    return "Composed";
+  if (runGasComposed(run)) {
+    return <ComposedGasCell chains={chains} run={run} />;
   }
   return formatGasNative(
     wei,
@@ -271,11 +317,6 @@ function getStepStatusColor(status: string): string {
 
 const COPIED_FOR_MS = 1500;
 
-// The default tooltip surface inverts the page; an error blob reads better on
-// the same panel the rest of the run details use. The arrow goes with it.
-const ERROR_TOOLTIP_SURFACE =
-  "border bg-popover text-popover-foreground shadow-md [&>span]:hidden";
-
 function CopyErrorButton({ text }: { text: string }): ReactNode {
   const [copied, setCopied] = useState(false);
 
@@ -301,7 +342,7 @@ function CopyErrorButton({ text }: { text: string }): ReactNode {
           {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
         </button>
       </TooltipTrigger>
-      <TooltipContent className={ERROR_TOOLTIP_SURFACE}>
+      <TooltipContent className={TOOLTIP_SURFACE}>
         {copied ? "Copied" : "Copy error"}
       </TooltipContent>
     </Tooltip>
@@ -320,7 +361,7 @@ function StepErrorMessage({ message }: { message: string }): ReactNode {
         </TooltipTrigger>
         <TooltipContent
           className={cn(
-            ERROR_TOOLTIP_SURFACE,
+            TOOLTIP_SURFACE,
             "max-w-sm text-left font-mono text-[11px] leading-relaxed wrap-anywhere"
           )}
         >
@@ -433,7 +474,7 @@ function ExpandedStepRows({
               </TooltipTrigger>
               <TooltipContent
                 className={cn(
-                  ERROR_TOOLTIP_SURFACE,
+                  TOOLTIP_SURFACE,
                   "max-w-sm text-left font-mono text-[11px] leading-relaxed wrap-anywhere"
                 )}
               >

--- a/lib/analytics/format-gas.ts
+++ b/lib/analytics/format-gas.ts
@@ -64,7 +64,7 @@ export function formatGasAsEth(
 ): string {
   const wei = parseWei(weiString);
   if (wei === null) {
-    return "--";
+    return "-";
   }
   if (wei === ZERO) {
     return "0 ETH";
@@ -88,7 +88,7 @@ export function formatGasExactEth(
 ): string {
   const wei = parseWei(weiString);
   if (wei === null) {
-    return "--";
+    return "-";
   }
   if (wei === ZERO) {
     return "0 ETH";

--- a/tests/unit/analytics-format-gas.test.ts
+++ b/tests/unit/analytics-format-gas.test.ts
@@ -99,7 +99,7 @@ describe("formatGasAsEth", () => {
   });
 
   it("returns -- for missing input and 0 ETH for zero", () => {
-    expect(formatGasAsEth(null)).toBe("--");
+    expect(formatGasAsEth(null)).toBe("-");
     expect(formatGasAsEth("0")).toBe("0 ETH");
   });
 });
@@ -132,9 +132,9 @@ describe("formatGasExactEth", () => {
   });
 
   it("returns -- for missing input and 0 ETH for zero", () => {
-    expect(formatGasExactEth(null)).toBe("--");
-    expect(formatGasExactEth("")).toBe("--");
-    expect(formatGasExactEth("nonsense")).toBe("--");
+    expect(formatGasExactEth(null)).toBe("-");
+    expect(formatGasExactEth("")).toBe("-");
+    expect(formatGasExactEth("nonsense")).toBe("-");
     expect(formatGasExactEth("0")).toBe("0 ETH");
   });
 });

--- a/tests/unit/analytics-run-gas-display.test.ts
+++ b/tests/unit/analytics-run-gas-display.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { runGasDisplay } from "@/components/analytics/runs-table";
+import {
+  runGasComposed,
+  runGasDisplay,
+} from "@/components/analytics/runs-table";
 import type { UnifiedRun } from "@/lib/analytics/types";
 import { createChainDisplay } from "@/lib/hooks/use-chain-display";
 
@@ -69,7 +72,7 @@ describe("runGasDisplay", () => {
 
   it("composes a run that genuinely spent on two chains", () => {
     expect(
-      runGasDisplay(
+      runGasComposed(
         run({
           networks: [BASE, POLYGON],
           gasNetworks: [BASE, POLYGON],
@@ -77,14 +80,14 @@ describe("runGasDisplay", () => {
           network: BASE,
         })
       )
-    ).toBe("Composed");
+    ).toBe(true);
   });
 
   it("composes ledger-only gas that cannot be attributed to one chain", () => {
     // No step rollup names a chain, and the run touched two, so there is no
     // token to render the sponsored amount in.
     expect(
-      runGasDisplay(
+      runGasComposed(
         run({
           networks: [BASE, POLYGON],
           gasNetworks: [],
@@ -92,7 +95,20 @@ describe("runGasDisplay", () => {
           network: BASE,
         })
       )
-    ).toBe("Composed");
+    ).toBe(true);
+  });
+
+  it("does not compose a run whose gas landed on one chain", () => {
+    expect(
+      runGasComposed(
+        run({
+          networks: [BASE, POLYGON],
+          gasNetworks: [BASE],
+          gasUsedWei: ONE_TENTH,
+          network: BASE,
+        })
+      )
+    ).toBe(false);
   });
 
   it("borrows the run's chain for ledger-only gas on a single-chain run", () => {
@@ -111,15 +127,13 @@ describe("runGasDisplay", () => {
   it("renders no amount for a read-only run that touched several chains", () => {
     // The bug this guards: reading three targeted chains as a multi-chain
     // spend labelled every read-only cross-chain run "Composed".
-    expect(
-      runGasDisplay(
-        run({
-          networks: [BASE, POLYGON, AVALANCHE],
-          gasNetworks: [],
-          network: BASE,
-        })
-      )
-    ).toBe("-");
+    const readOnly = run({
+      networks: [BASE, POLYGON, AVALANCHE],
+      gasNetworks: [],
+      network: BASE,
+    });
+    expect(runGasComposed(readOnly)).toBe(false);
+    expect(runGasDisplay(readOnly)).toBe("-");
   });
 
   it("renders no amount for a run that failed before broadcast", () => {

--- a/tests/unit/analytics-run-gas-display.test.ts
+++ b/tests/unit/analytics-run-gas-display.test.ts
@@ -108,6 +108,20 @@ describe("runGasDisplay", () => {
     ).toBe("0.10 POL");
   });
 
+  it("renders no amount for a read-only run that touched several chains", () => {
+    // The bug this guards: reading three targeted chains as a multi-chain
+    // spend labelled every read-only cross-chain run "Composed".
+    expect(
+      runGasDisplay(
+        run({
+          networks: [BASE, POLYGON, AVALANCHE],
+          gasNetworks: [],
+          network: BASE,
+        })
+      )
+    ).toBe("-");
+  });
+
   it("renders no amount for a run that failed before broadcast", () => {
     expect(
       runGasDisplay(
@@ -118,7 +132,7 @@ describe("runGasDisplay", () => {
           network: BASE,
         })
       )
-    ).toBe("--");
+    ).toBe("-");
   });
 
   it("denominates a run on a chain the sponsorship table does not cover", () => {

--- a/tests/unit/analytics-runs-response.test.ts
+++ b/tests/unit/analytics-runs-response.test.ts
@@ -49,7 +49,7 @@ describe("normalizeRunsResponse", () => {
   it("renders the gas cell of a normalized stale run without throwing", () => {
     const [run] = normalizeRunsResponse(LEGACY_RESPONSE).runs;
 
-    expect(runGasDisplay(run)).toBe("--");
+    expect(runGasDisplay(run)).toBe("-");
   });
 
   it("leaves a current response untouched", () => {


### PR DESCRIPTION
## Problem

The Gas column on the analytics runs table showed `Composed` for runs that spent no gas at all. Any read-only workflow touching more than one chain got the badge, with every one of its expanded steps showing an empty gas cell.

`runGasDisplay` decided from a chain count before it looked at the amount:

```ts
const spentAcrossChains =
  run.gasNetworks.length > 1 ||
  (run.gasNetworks.length === 0 && run.networks.length > 1);
if (spentAcrossChains) return "Composed";
```

`gasNetworks` is the subset of chains gas actually landed on. `networks` is every chain the run reached, reads included. The second clause was written for one narrow case, a sponsored leg that exists only in the sponsorship ledger and names no chain of its own, but nothing distinguished that from a run that simply spent nothing, so it fired for both.

## Fix

Read the gas total first and return no value when there is none. `Composed` now means what it was meant to mean: this run's gas was split across more than one chain, so the amounts do not sum into a single token.

```ts
const wei = run.gasUsedWei ?? run.gasCostWei;
if (!wei) return NO_VALUE;
```

Both fields are already normalised to `null` when zero at the query layer, so this is truthy exactly when the run burned wei from either source. Sponsored gas still counts as spend, since the ledger total is the fallback when no step rollup carries a chain, and the ledger-only path keeps its original behaviour behind the new guard.

The dead local `formatGasAsEth` went with it. It was only reachable on the no-gas path.

## Also

Replaces the two-character dash placeholder with a single `-` across the analytics page (runs table, KPI cards, gas formatting), behind one `NO_VALUE` constant in the runs table.

## Note on sponsored gas

Sponsorship is surfaced correctly on the KPI card (wallet and sponsored split, with a tooltip) and on expanded step rows (green `sponsored` badge). The collapsed run row has no marker, so a fully sponsored run prints a bare amount indistinguishable from wallet spend. Left as-is here since it is a design decision, not a regression.
