### PR TITLE
fix(editor): show a clipped badge's full reference on hover

### DIFF
--- a/components/ui/template-badge-editor.tsx
+++ b/components/ui/template-badge-editor.tsx
@@ -42,12 +42,36 @@ export function caretOffsetForBadgeEdit(rawTemplate: string): number {
 const EDIT_BADGE_HINT = "Double-click to edit this reference";
 
 /**
- * Tooltip text for a badge. Narrow hosts clip the badge -- the condition
- * builder's operand fields scroll horizontally with the scrollbar hidden --
- * so the full reference leads, and the edit hint keeps its own line below.
+ * Tooltip text for a badge whose reference the field cuts off: the full
+ * reference leads, and the edit hint keeps its own line below.
  */
 export function badgeTooltip(displayText: string): string {
   return displayText ? `${displayText}\n${EDIT_BADGE_HINT}` : EDIT_BADGE_HINT;
+}
+
+/**
+ * Geometry of one badge inside the field that holds it, measured in the
+ * field's content box so a scrolled field gives the same answer as an
+ * unscrolled one.
+ */
+export type BadgeExtent = {
+  /** Right edge of the badge, from the start of the field's content. */
+  right: number;
+  /** Width the field actually shows. */
+  visibleWidth: number;
+};
+
+/**
+ * Whether the field cuts the badge off. A badge never truncates itself -- it
+ * sits at full width inside a wrapper that scrolls -- so the test is its right
+ * edge against the visible width, where `TruncatedTooltip` asks the same
+ * question of text that truncates against its own box.
+ *
+ * A badge that fits keeps the edit hint alone, so hovering a reference you can
+ * already read in full does not repeat it back.
+ */
+export function isBadgeClipped({ right, visibleWidth }: BadgeExtent): boolean {
+  return visibleWidth > 0 && right > visibleWidth;
 }
 
 export type TemplateBadgeEditorMultilineOptions = {
@@ -370,6 +394,31 @@ export function TemplateBadgeEditor({
     container.appendChild(document.createTextNode(text));
   };
 
+  // Give the full reference only to the badges the field cuts off, measuring
+  // each against the content box so the answer does not move when the field is
+  // scrolled. Mirrors TruncatedTooltip: measure, gate, re-measure on resize.
+  const syncBadgeTooltips = (): void => {
+    const container = contentRef.current;
+    if (!container) {
+      return;
+    }
+
+    const visibleWidth = container.clientWidth;
+    const containerLeft = container.getBoundingClientRect().left;
+
+    for (const badge of container.querySelectorAll<HTMLElement>(
+      "[data-template]"
+    )) {
+      const right =
+        badge.getBoundingClientRect().right -
+        containerLeft +
+        container.scrollLeft;
+      badge.title = isBadgeClipped({ right, visibleWidth })
+        ? badgeTooltip(badge.textContent ?? "")
+        : EDIT_BADGE_HINT;
+    }
+  };
+
   // Parse text and render with badges
   const updateDisplay = (): void => {
     if (!contentRef.current || !shouldUpdateDisplay.current) return;
@@ -421,9 +470,10 @@ export function TemplateBadgeEditor({
       badge.contentEditable = "false";
       badge.setAttribute("data-template", fullMatch);
       // Use current node label for display
-      const displayText = getDisplayTextForTemplate(fullMatch, nodes);
-      badge.textContent = displayText;
-      badge.title = badgeTooltip(displayText);
+      badge.textContent = getDisplayTextForTemplate(fullMatch, nodes);
+      // Upgraded to the full reference by syncBadgeTooltips once the badge has
+      // been laid out and its width against the field is known.
+      badge.title = EDIT_BADGE_HINT;
       container.appendChild(badge);
 
       lastIndex = pattern.lastIndex;
@@ -441,6 +491,8 @@ export function TemplateBadgeEditor({
     }
 
     shouldUpdateDisplay.current = false;
+
+    syncBadgeTooltips();
 
     // Restore cursor position after updating
     if (cursorPos) {
@@ -775,6 +827,18 @@ export function TemplateBadgeEditor({
       updateDisplay();
     }
   }, [internalValue, isFocused]);
+
+  // A field that grows or shrinks changes which badges are cut off, and the
+  // panel holding these fields is resizable.
+  useEffect(() => {
+    const container = contentRef.current;
+    if (!container || typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver(() => syncBadgeTooltips());
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
 
   // Hint 2: clicking the "@" chip focuses the editor, inserts an "@" at the
   // cursor (or at the end if none), and lets handleInput open the dropdown.

--- a/components/ui/template-badge-editor.tsx
+++ b/components/ui/template-badge-editor.tsx
@@ -41,6 +41,15 @@ export function caretOffsetForBadgeEdit(rawTemplate: string): number {
 
 const EDIT_BADGE_HINT = "Double-click to edit this reference";
 
+/**
+ * Tooltip text for a badge. Narrow hosts clip the badge -- the condition
+ * builder's operand fields scroll horizontally with the scrollbar hidden --
+ * so the full reference leads, and the edit hint keeps its own line below.
+ */
+export function badgeTooltip(displayText: string): string {
+  return displayText ? `${displayText}\n${EDIT_BADGE_HINT}` : EDIT_BADGE_HINT;
+}
+
 export type TemplateBadgeEditorMultilineOptions = {
   rows: number;
   /** When set, limits visible height to this many rows and makes content scrollable */
@@ -411,9 +420,10 @@ export function TemplateBadgeEditor({
         : "inline-flex items-center gap-1 rounded bg-red-500/10 px-1.5 py-0.5 text-red-600 dark:text-red-400 font-mono text-xs border border-red-500/20 mx-0.5";
       badge.contentEditable = "false";
       badge.setAttribute("data-template", fullMatch);
-      badge.title = EDIT_BADGE_HINT;
       // Use current node label for display
-      badge.textContent = getDisplayTextForTemplate(fullMatch, nodes);
+      const displayText = getDisplayTextForTemplate(fullMatch, nodes);
+      badge.textContent = displayText;
+      badge.title = badgeTooltip(displayText);
       container.appendChild(badge);
 
       lastIndex = pattern.lastIndex;

--- a/tests/unit/template-badge-tooltip.test.ts
+++ b/tests/unit/template-badge-tooltip.test.ts
@@ -51,7 +51,7 @@ describe("badgeTooltip over a rendered reference", () => {
     expect(badgeTooltip(displayText)).toBe(`${displayText}\n${EDIT_HINT}`);
   });
 
-  it("follows a renamed node rather than the label stored in the token", () => {
+  it("uses the node's current label, not the one stored in the token", () => {
     const template = "{{@JRY0lGfsvlwszZ797lIFz:Old label.result.timestamp}}";
     const displayText = getDisplayTextForTemplate(template, nodes);
 

--- a/tests/unit/template-badge-tooltip.test.ts
+++ b/tests/unit/template-badge-tooltip.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { badgeTooltip } from "@/components/ui/template-badge-editor";
+import {
+  getDisplayTextForTemplate,
+  type TemplateNode,
+} from "@/lib/workflow/editor/template-utils";
+
+const EDIT_HINT = "Double-click to edit this reference";
+
+const nodes: TemplateNode[] = [
+  {
+    id: "JRY0lGfsvlwszZ797lIFz",
+    data: { label: "Get hat execution", type: "action" },
+  },
+  { id: "sT1lFq2xKmA9dPn4vBc0e", data: { label: "Manual", type: "trigger" } },
+];
+
+describe("badgeTooltip", () => {
+  it("leads with the reference and keeps the hint on its own line", () => {
+    const tooltip = badgeTooltip("Get hat execution.result.timestamp");
+
+    expect(tooltip.split("\n")).toEqual([
+      "Get hat execution.result.timestamp",
+      EDIT_HINT,
+    ]);
+  });
+
+  it("keeps a long path whole, since the badge itself is clipped", () => {
+    const long = "Get hat execution.result.receipt.logs.0.args.tokenId";
+
+    expect(badgeTooltip(long).startsWith(`${long}\n`)).toBe(true);
+  });
+
+  it("falls back to the hint alone when there is no display text", () => {
+    expect(badgeTooltip("")).toBe(EDIT_HINT);
+  });
+});
+
+describe("badgeTooltip over a rendered reference", () => {
+  it("shows the full text of a reference the field clips", () => {
+    const template =
+      "{{@JRY0lGfsvlwszZ797lIFz:Get hat execution.result.timestamp}}";
+    const displayText = getDisplayTextForTemplate(template, nodes);
+
+    // The badge renders this text and the operand field clips it; the first
+    // tooltip line has to carry the same text in full.
+    expect(displayText).toBe("Get hat execution.result.timestamp");
+    expect(badgeTooltip(displayText)).toBe(`${displayText}\n${EDIT_HINT}`);
+  });
+
+  it("follows a renamed node rather than the label stored in the token", () => {
+    const template = "{{@JRY0lGfsvlwszZ797lIFz:Old label.result.timestamp}}";
+    const displayText = getDisplayTextForTemplate(template, nodes);
+
+    expect(badgeTooltip(displayText).split("\n")[0]).toBe(
+      "Get hat execution.result.timestamp"
+    );
+  });
+
+  it("carries the reference of a badge whose node is gone", () => {
+    const template = "{{@deletedNodeId:Deleted step.result.value}}";
+    const displayText = getDisplayTextForTemplate(template, nodes);
+
+    expect(badgeTooltip(displayText).split("\n")[0]).toBe(
+      "Deleted step.result.value"
+    );
+  });
+
+  it("covers a reference with no field path", () => {
+    const template = "{{@sT1lFq2xKmA9dPn4vBc0e:Manual}}";
+    const displayText = getDisplayTextForTemplate(template, nodes);
+
+    expect(badgeTooltip(displayText)).toBe(`Manual\n${EDIT_HINT}`);
+  });
+});

--- a/tests/unit/template-badge-tooltip.test.ts
+++ b/tests/unit/template-badge-tooltip.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { badgeTooltip } from "@/components/ui/template-badge-editor";
+import {
+  badgeTooltip,
+  isBadgeClipped,
+} from "@/components/ui/template-badge-editor";
 import {
   getDisplayTextForTemplate,
   type TemplateNode,
@@ -71,5 +74,32 @@ describe("badgeTooltip over a rendered reference", () => {
     const displayText = getDisplayTextForTemplate(template, nodes);
 
     expect(badgeTooltip(displayText)).toBe(`Manual\n${EDIT_HINT}`);
+  });
+});
+
+describe("isBadgeClipped", () => {
+  it("gates the tooltip off for a badge the field shows in full", () => {
+    // "Manual.data" inside a 240px operand field.
+    expect(isBadgeClipped({ right: 88, visibleWidth: 240 })).toBe(false);
+  });
+
+  it("catches a badge whose right edge runs past the field", () => {
+    // "Get hat execution.result.timestamp" needs about 250px in the same field.
+    expect(isBadgeClipped({ right: 250, visibleWidth: 240 })).toBe(true);
+  });
+
+  it("treats a badge ending exactly at the edge as shown in full", () => {
+    expect(isBadgeClipped({ right: 240, visibleWidth: 240 })).toBe(false);
+  });
+
+  it("follows the field width, not the length of the reference", () => {
+    // The same short "Manual.data" badge, in a field narrowed until it no
+    // longer fits.
+    expect(isBadgeClipped({ right: 88, visibleWidth: 240 })).toBe(false);
+    expect(isBadgeClipped({ right: 88, visibleWidth: 60 })).toBe(true);
+  });
+
+  it("stays quiet before layout, when nothing has a width yet", () => {
+    expect(isBadgeClipped({ right: 0, visibleWidth: 0 })).toBe(false);
   });
 });


### PR DESCRIPTION
## Issue

No issue. Per ISSUES.md this is a behaviour change and would normally need one first; flagging it rather than claiming an exemption, since the fix shape is not in question. Close this and route it through an issue if you would rather hold the line.

## What this changes

A template badge carries its whole reference as text, but the host clips it. The condition builder wraps each operand in `max-h-9 overflow-x-auto whitespace-nowrap` with `scrollbar-width: none`, so `Get hat execution.result.timestamp` renders as `Get hat executio` with a scroll track underneath and no way to read the rest without dragging inside the field.

Hovering did not help. The badge's `title` was the constant `EDIT_BADGE_HINT`, so the tooltip explained the edit gesture and never named the reference. Two badges pointing at different fields of the same node were indistinguishable on screen.

A clipped badge now gets the full reference on the first line of its tooltip, with the edit hint kept below it. A badge the field shows in full keeps the bare hint, exactly as today — hovering a reference you can already read does not repeat it back at you.

**Prior art, and why the component is not reused.** `components/ui/truncated-tooltip.tsx` gates on measured clipping for the same reason, and is used for workflow, project and tag names in `navigation-sidebar.tsx` and for organization names in `org-switcher.tsx`. The badge cannot be that component. `TruncatedTooltip` owns its markup — it is a `truncate` span inside a Radix `TooltipTrigger` — whereas the badge is a `contentEditable="false"` span built with `createElement` inside a `contentEditable` whose `innerHTML` is rewritten on every value change with caret positions restored by hand. Its measurement is a different question too: it asks whether an element truncates against its own box, while the badge sits at full width inside a wrapper that scrolls, so the badge's own `scrollWidth` always equals its `clientWidth`. What carries over is the contract — measure, gate, re-measure on resize.

- `isBadgeClipped({ right, visibleWidth })` is pure and exported: true when the badge's right edge runs past the width the field shows.
- `syncBadgeTooltips` measures each badge in the field's content box (`getBoundingClientRect().right - containerLeft + scrollLeft`), so a scrolled field answers the same as an unscrolled one, and runs at the end of `updateDisplay` once layout exists.
- A `ResizeObserver` on the content element re-measures when the field changes width. Its effect closure reads only the ref, so the empty dependency array holds nothing stale.

Nothing a reader would not predict from the title: no new dependency, no config or CI change, no touched auth or validation path. `TemplateBadgeInput` and `TemplateBadgeTextarea` are thin wrappers over `TemplateBadgeEditor`, and it is the only badge renderer in the codebase, so this reaches the condition builder, the condition expression field, and every action config. Red missing-node badges get the same treatment.

This stays on the browser's native `title`: roughly a second of hover delay, OS styling rather than our tokens, and no visual match with the Radix tooltips elsewhere. Rendering the real thing needs a portal and a virtual trigger positioned over the hovered badge, since the badge cannot take a React wrapper. Deliberately not attempted here.

## Scope

One change. Nothing else ships with it.

## How it was verified

`tests/unit/template-badge-tooltip.test.ts`, 12 cases.

Seven on tooltip composition: line order, a 52-character path kept whole, empty display text, and four composing `badgeTooltip` with `getDisplayTextForTemplate` to pin that the first tooltip line equals the badge's own text — across a clipped reference, a node renamed since the token was written, a deleted node, and a reference with no field path.

Five on gating: a short badge that fits, a long one that overruns, a badge ending exactly at the edge (not clipped), the same short badge in a field narrowed until it no longer fits, and zero geometry before layout.

```
npx vitest run tests/unit/template-badge-tooltip.test.ts
  Tests  12 passed (12)

# isBadgeClipped forced to true (ungated, the first pass on this branch)
  Tests  4 failed | 8 passed (12)

# badgeTooltip reverted to the bare hint
  Tests  6 failed | 6 passed (12)
```

`pnpm check` clean across 2118 files. `pnpm type-check` clean.

Not verified in a browser. The pure predicate is tested; the geometry that feeds it has never run against real layout, and jsdom reports zero widths so a DOM test would assert nothing. Worth a hover in the PR environment against both a long and a short reference.

**Adjacent, and not fixed here.** `updateDisplay` is marked stale when `nodes` change (`template-badge-editor.tsx:235`), but the effect that actually runs it depends only on `[internalValue, isFocused]`, so renaming a node does not repaint its badges until the next keystroke or focus change. The label test above is named for what it asserts — that `badgeTooltip` composes the node's current label rather than the one frozen in the token — and does not claim the badge repaints. Pre-existing, found by reading the code rather than by running it, and out of scope for this PR.

## Screenshots

No image. The change is a native `title` tooltip, which the browser paints outside the page, so it cannot appear in a screenshot — a capture would show only the unchanged row. What a reviewer needs is the hover text, so here it is literally.

A long reference, clipped by the field to `Get hat executio`:

```
before        Double-click to edit this reference

after         Get hat execution.result.timestamp
              Double-click to edit this reference
```

A short reference the field shows in full, such as `Manual.data`:

```
before        Double-click to edit this reference

after         Double-click to edit this reference
```

The row itself is untouched: same layout, same badge colours, same clipping. This makes a cut-off reference readable on hover rather than removing the clipping.

---

- [x] Targets `staging`
- [ ] Title carries the issue number, or an exemption applies — see the Issue section
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
