### PR TITLE
ci: disable the bake provenance attestation on every image target

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -268,10 +268,10 @@ jobs:
             exit 0
           fi
           if [[ "${RETRY}" == "success" ]]; then
-            echo "::warning title=KEEP-1206 image build retried::The image build failed on its first attempt and succeeded on the retry. This is the known memory ceiling, not a random flake - the build needs up to 20 GiB and a standard runner has about 20 GiB including swap. Track how often this warning appears; if it becomes common the job needs more memory or the module graph needs to shrink."
+            echo "::warning title=Image build needed its retry::The first bake attempt failed and the retry passed. Open the failed Build and push all images to ECR step and read the last BuildKit error before you record a cause. A memory failure says cannot allocate memory or ResourceExhausted. That build needs up to 20 GiB and a standard runner has about 20 GiB including swap, so the retry resumes from the layers the first attempt finished. Any other error is a transient fault that the retry hid. Track how often this warning appears. If the memory case becomes common, give the job more memory or make the module graph smaller."
             exit 0
           fi
-          echo "::error title=KEEP-1206 image build failed twice::The image build failed on both attempts. If the logs show 'cannot allocate memory' or 'ResourceExhausted', the runner ran out of memory and re-running will not reliably help - this job needs more memory than a standard runner has."
+          echo "::error title=Image build failed twice::Both bake attempts failed. Do not assume a cause. Open the Build and push all images to ECR step and read the last BuildKit error. Three signatures are known. 1. cannot allocate memory or ResourceExhausted means the runner ran out of memory, and a re-run does not reliably help because this job needs more memory than a standard runner has. 2. denied, the subject of your artifact has the maximum number of artifacts, means ECR refused an attestation push. Every re-run fails the same way until the attestation is disabled or the referrers are removed, so stop retrying. 3. any other denied or unauthorized is an ECR authentication or repository policy problem. Re-run only when the log shows a fault that is really transient."
           exit 1
 
       # Sentry source-map upload moved out to its own sentry-upload.yml job,

--- a/.github/workflows/maintainability.yml
+++ b/.github/workflows/maintainability.yml
@@ -21,6 +21,7 @@ jobs:
       dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
       plugins: ${{ steps.filter.outputs.plugins }}
       selfhosted: ${{ steps.filter.outputs.selfhosted }}
+      bake: ${{ steps.filter.outputs.bake }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -41,6 +42,8 @@ jobs:
               - 'plugins/**'
             selfhosted:
               - 'deploy/keeperhub-stack/self-hosted/**'
+            bake:
+              - 'docker-bake.hcl'
 
   compose-validation:
     name: Docker Compose Validation
@@ -201,6 +204,49 @@ jobs:
             done < <(grep -E "^(COPY|ADD)" "$dockerfile" | grep -v "\-\-from=")
           done
           exit $failed
+
+  bake-provenance:
+    name: Bake Provenance Disabled
+    needs: changes
+    if: needs.changes.outputs.bake == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # docker/bake-action injects
+      # `--set <target>.attest=type=provenance,mode=max` for every target that
+      # declares no provenance entry. ECR indexes each pushed attestation as a
+      # referrer of the image and allows only 100 referrers per subject. The
+      # sandbox image digest does not change between commits, so its referrers
+      # reached 100 and every staging deploy failed for about 14 hours on
+      # 2026-08-29.
+      #
+      # A target that omits the entry re-enables the attestation for itself, and
+      # the two forms that look like a fix are silent no-ops. `attest = []`
+      # disappears from `bake --print`, and `provenance = false` is not a bake
+      # attribute at all. This check reads the resolved definition, so it sees
+      # what buildx sees rather than what the file appears to say.
+      - name: Every bake target disables the provenance attestation
+        run: |
+          set -euo pipefail
+          mapfile -t targets < <(grep -oP '^target "\K[^"]+' docker-bake.hcl)
+          echo "Bake targets declared: ${#targets[@]} (${targets[*]})"
+          docker buildx bake -f docker-bake.hcl --print "${targets[@]}" > /tmp/bake-def.json
+          printed=$(jq -r '.target | length' /tmp/bake-def.json)
+          if [ "$printed" -ne "${#targets[@]}" ]; then
+            echo "::error file=docker-bake.hcl::bake --print resolved $printed targets but the file declares ${#targets[@]}."
+            exit 1
+          fi
+          missing=$(jq -r '.target | to_entries[]
+            | select((.value.attest // []) | any(.type == "provenance" and .disabled == true) | not)
+            | .key' /tmp/bake-def.json)
+          if [ -n "$missing" ]; then
+            echo "::error file=docker-bake.hcl::These targets do not disable the provenance attestation: $(echo "$missing" | tr '\n' ' ')"
+            echo "Add this line to each one, and read the comment above the first target in docker-bake.hcl:"
+            echo '  attest = ["type=provenance,disabled=true"]'
+            exit 1
+          fi
+          echo "All $printed targets disable the provenance attestation."
 
   env-sync:
     name: Environment Variable Sync

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -66,6 +66,24 @@ group "all" {
   targets = ["app", "migrator", "workflow-runner", "event-tracker", "solana-tracker", "schedule-dispatcher", "block-dispatcher", "executor", "sandbox", "metrics-collector"]
 }
 
+# Every target below sets `attest` explicitly, and a new target must set it too.
+# docker/bake-action reads the resolved bake definition. For each target that
+# declares no provenance entry, the action appends
+# `--set <target>.attest=type=provenance,mode=max`. ECR indexes the pushed
+# attestation as a referrer of the image, and it allows only 100 referrers per
+# subject. The sandbox image digest does not change between commits, so its
+# referrers reached 100 and every staging deploy failed for about 14 hours on
+# 2026-08-29.
+#
+# Two forms look correct and do nothing. Do not use either one:
+#   * `attest = []` is omitempty, so the key disappears from `docker buildx bake
+#     --print`. The action then treats the target as undeclared and injects
+#     provenance for it.
+#   * `provenance = false` is not a bake attribute. Bake drops an unknown target
+#     field without an error, so the line parses and has no effect.
+# Only `attest = ["type=provenance,disabled=true"]` survives `--print`, which is
+# what the "Bake Provenance Disabled" check in maintainability.yml asserts.
+
 target "app" {
   context    = "."
   dockerfile = "Dockerfile"
@@ -89,6 +107,7 @@ target "app" {
   ]) : []
   cache-from = ECR_REGISTRY != "" ? ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"] : []
   cache-to   = ECR_REGISTRY != "" ? ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app,mode=max"] : []
+  attest     = ["type=provenance,disabled=true"]
 }
 
 target "sentry-upload" {
@@ -115,6 +134,7 @@ target "sentry-upload" {
   }
   tags       = []
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-app"]
+  attest     = ["type=provenance,disabled=true"]
 }
 
 target "migrator" {
@@ -130,6 +150,7 @@ target "migrator" {
     "type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator",
   ]
   cache-to = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-migrator,mode=max"]
+  attest   = ["type=provenance,disabled=true"]
 }
 
 target "workflow-runner" {
@@ -161,7 +182,7 @@ target "workflow-runner" {
     "type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-workflow-runner",
   ]
   cache-to = ["type=registry,ref=${ECR_REGISTRY}/${ECR_REPO}:cache-workflow-runner,mode=max"]
-  attest   = []
+  attest   = ["type=provenance,disabled=true"]
 }
 
 target "event-tracker" {
@@ -174,7 +195,7 @@ target "event-tracker" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache,mode=max"]
-  attest     = []
+  attest     = ["type=provenance,disabled=true"]
 }
 
 # Solana ingestion (event + block triggers). Shares the events ECR repo, so all
@@ -190,7 +211,7 @@ target "solana-tracker" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EVENTS_ECR_TRACKER_REPO}:cache-solana,mode=max"]
-  attest     = []
+  attest     = ["type=provenance,disabled=true"]
 }
 
 target "schedule-dispatcher" {
@@ -207,7 +228,7 @@ target "schedule-dispatcher" {
     "type=registry,ref=${ECR_REGISTRY}/${SCHEDULER_ECR_REPO}:cache-dispatcher",
   ]
   cache-to = ["type=registry,ref=${ECR_REGISTRY}/${SCHEDULER_ECR_REPO}:cache-dispatcher,mode=max"]
-  attest   = []
+  attest   = ["type=provenance,disabled=true"]
 }
 
 target "block-dispatcher" {
@@ -224,7 +245,7 @@ target "block-dispatcher" {
     "type=registry,ref=${ECR_REGISTRY}/${SCHEDULER_ECR_REPO}:cache-block-dispatcher",
   ]
   cache-to = ["type=registry,ref=${ECR_REGISTRY}/${SCHEDULER_ECR_REPO}:cache-block-dispatcher,mode=max"]
-  attest   = []
+  attest   = ["type=provenance,disabled=true"]
 }
 
 target "executor" {
@@ -253,7 +274,7 @@ target "executor" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${EXECUTOR_ECR_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${EXECUTOR_ECR_REPO}:cache,mode=max"]
-  attest     = []
+  attest     = ["type=provenance,disabled=true"]
 }
 
 # v1.9 Code Sandbox standalone HTTP service. Runs user-supplied JS in a
@@ -270,7 +291,7 @@ target "sandbox" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:cache,mode=max"]
-  attest     = []
+  attest     = ["type=provenance,disabled=true"]
 }
 
 # Metrics collector (TECH-6484). Context is repo root because the stage reuses
@@ -286,5 +307,5 @@ target "metrics-collector" {
   ])
   cache-from = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache"]
   cache-to   = ["type=registry,ref=${ECR_REGISTRY}/${METRICS_COLLECTOR_ECR_REPO}:cache,mode=max"]
-  attest     = []
+  attest     = ["type=provenance,disabled=true"]
 }


### PR DESCRIPTION
## What

Every target in `docker-bake.hcl` now sets `attest = ["type=provenance,disabled=true"]`. A
new `Bake Provenance Disabled` job in `maintainability.yml` fails the PR when a target does
not. The `Image build verdict` step no longer reports every bake failure as a memory
failure.

## Why

`docker/bake-action` reads the resolved bake definition. For each target that declares no
provenance entry, it appends `--set <target>.attest=type=provenance,mode=max`. ECR indexes
the pushed attestation as a referrer of the image, and it allows only 100 referrers per
subject.

The sandbox image digest does not change between commits, so every one of those
attestations landed on the same subject. The count reached 100, and every staging deploy
failed from 2026-08-29 18:01 UTC to 2026-08-30 08:38 UTC, over 7 retries:

```
denied: The subject of your artifact has the maximum number of artifacts (100)
referring to it.
```

Nothing reads these attestations. There is no cosign, no sigstore, no Kyverno and no
admission image policy in this repo, in the infrastructure repo or in the chart repo.

## Why `attest = []` did not already do this

`attest = []` is omitempty, so the key disappears from the resolved definition. The action
then treats the target as undeclared and injects provenance for it. On `staging` today all
11 targets resolve with no `attest` key:

```
$ git show origin/staging:docker-bake.hcl | docker buildx bake -f - --print sandbox
"sandbox": { "context": ".", "dockerfile": "sandbox/Dockerfile",
             "tags": [...], "cache-from": [...], "cache-to": [...] }
```

`provenance = false` is not a fix either. Bake has no `provenance` target attribute, and it
drops an unknown target field without an error, so the line parses and does nothing.

## Verification

Local, with buildx v0.33.0:

```
# before: 11 of 11 targets resolve without provenance disabled
# after:   0 of 11
$ docker buildx bake -f docker-bake.hcl --print <all 11 targets> | jq ...
All 11 targets disable the provenance attestation.

# the CI bake group resolves the same way
$ docker buildx bake -f docker-bake.hcl --print pipeline sandbox
app, block-dispatcher, executor, metrics-collector, migrator, sandbox,
schedule-dispatcher, workflow-runner  ->  [{"disabled": true, "type": "provenance"}]

# BuildKit accepts the form in a real build, not only at parse time
$ docker buildx bake --set probe.output=type=cacheonly probe   # exit 0
```

The new maintainability job was run against both revisions. It passes on this branch and
fails on `staging`, naming all 11 targets.

`actionlint` (with shellcheck), `pnpm check`, `pnpm type-check` and `pnpm test:unit` all
pass locally.

## Risk

Dropping the attestation changes the artifact shape, and the pushed image digest changes
once with it. Measured on a real build of the same Dockerfile both ways:

| | today | after this change |
| --- | --- | --- |
| top-level media type | `oci.image.index.v1+json` | `oci.image.manifest.v1+json` |
| children | 2, the image plus an attestation manifest | none, it is a plain manifest |

Nothing resolves our images by digest. Every deploy, existence check and Helm value uses a
tag, and the only digest-pinned references in the repo are the external `foundry` and
`distroless` base images.

This is a new shape, not a return to an old one. An earlier draft of this description said
the pipeline goes back to what it pushed before 2026-08-12. That is wrong. Index
`executor-9e9c1f2`, pushed 2026-08-11, carries the same attestation child that today's
images carry. What changed on 2026-08-12 is that ECR began to index those attestations as
referrers and count them against the 100 limit. The attestation itself is not new.

## Trade-off a reviewer should weigh

This removes the build record from every image we push from now on. Nothing reads it today:
a word-boundary search across `keeperhub`, `infrastructure`, `helm-charts`, `cli`,
`keeperhub-landing`, `keeperhub-feedback` and `raita-bot` for cosign, sigstore, Kyverno,
Gatekeeper, Connaisseur, ratify, slsa-verifier, in-toto and imagePolicyWebhook returns
nothing, and no policy controller is deployed from the infrastructure repo.

That proves no automated consumer. It does not prove the record is worthless. Provenance is
an incident-response artifact, read by hand after a supply-chain question. Against that, the
image tag already carries the commit SHA and the Actions run log holds the rest.

There may be a middle option. `type=provenance,mode=min,inline-only=true` produces no
separate attestation manifest, so it costs no referrer slot, and it is what bake-action
already uses for private repositories. It is NOT proposed here: when the exported image
config was inspected, no provenance was found in it either, so it is unproven that the form
retains anything useful. Investigate it against a real registry push before preferring it.

## Not in this change

- An untagged expiry rule on the sandbox ECR repos. That belongs in the infrastructure
  repo, and it needs a test first: an untagged rule must not delete an attestation manifest
  that a live tagged index still references.
- Reconciling the two sandbox designs. `deploy-sandbox.yaml` publishes only when the
  sandbox inputs change; commit `fe65b11cf` deliberately added the target to the always-on
  push bake so e2e can pull a prebuilt image. Both are intentional and they conflict.
- The `keeperhub-staging` and `keeperhub-prod` lifecycle rules, whose `tagPrefixList` is
  `["v"]` and matches none of our tags.

