### PR TITLE
ci: KEEP-1259 stop the per-commit sandbox tag in the pipeline bake

### DIFF
--- a/.github/actions/start-sandbox/action.yml
+++ b/.github/actions/start-sandbox/action.yml
@@ -1,9 +1,10 @@
 # Builds and starts the code-execution sandbox container for e2e jobs that
 # exercise the remote sandbox backend (SANDBOX_BACKEND=remote). Mirrors the
 # build+run+health pattern used by pr-checks.yml:test-unit-sandbox-remote.
-# On staging pushes the image is prebuilt by build-images.yml and passed via
-# image_ref, so this pulls instead of rebuilding (~72s/job); PRs (no prebuilt
-# image) and any pull failure fall back to the local build.
+# On staging and prod pushes the image is prebuilt and passed via image_ref, so
+# this pulls instead of rebuilding (~72s/job). PRs pass an empty image_ref and
+# build locally. A NON-EMPTY image_ref that fails to pull is a hard error, not a
+# fallback: see the step below. KEEP-1259.
 name: Start Sandbox
 description: Build and start the code-execution sandbox container for e2e tests
 
@@ -13,7 +14,7 @@ inputs:
     required: false
     default: "8787"
   image_ref:
-    description: Full ECR ref of a prebuilt sandbox image to pull. Empty builds locally.
+    description: Full ECR ref of a prebuilt sandbox image to pull, normally a digest ref. Empty builds locally; a non-empty ref that fails to pull fails the job.
     required: false
     default: ""
   aws_role_arn:
@@ -30,7 +31,8 @@ runs:
   steps:
     # Authenticate to ECR ourselves rather than relying on a prior start-app
     # step - the playwright job starts the sandbox before the app, so an
-    # ordering assumption would silently fall back to a local build there.
+    # ordering assumption would leave the pull unauthenticated there. Since
+    # KEEP-1259 that fails the job rather than falling back to a local build.
     # Skipped when image_ref is empty (PRs), which build locally anyway.
     - name: Configure AWS credentials for sandbox pull
       if: inputs.image_ref != '' && inputs.aws_role_arn != ''
@@ -43,19 +45,26 @@ runs:
       if: inputs.image_ref != '' && inputs.aws_role_arn != ''
       uses: aws-actions/amazon-ecr-login@v2
 
+    # KEEP-1259: a failed pull no longer falls back to a local build. The caller
+    # resolves image_ref from an ECR digest it has already confirmed exists, so a
+    # failure here is a permission or resolution fault, never a missing image. The
+    # old fallback cost ~72s in each of three e2e jobs and, worse, quietly tested a
+    # locally built sandbox instead of the one that ships. The empty-ref PR path is
+    # unchanged and still builds locally.
     - name: Provide sandbox image (pull prebuilt, else build)
       shell: bash
       env:
         IMAGE_REF: ${{ inputs.image_ref }}
       run: |
-        if [ -n "$IMAGE_REF" ] && docker pull "$IMAGE_REF"; then
+        if [ -z "$IMAGE_REF" ]; then
+          echo "no prebuilt image supplied; building sandbox locally"
+          docker build -f sandbox/Dockerfile -t keeperhub-sandbox:ci .
+        elif docker pull "$IMAGE_REF"; then
           echo "using prebuilt sandbox image $IMAGE_REF"
           docker tag "$IMAGE_REF" keeperhub-sandbox:ci
         else
-          if [ -n "$IMAGE_REF" ]; then
-            echo "pull of $IMAGE_REF failed; building sandbox locally"
-          fi
-          docker build -f sandbox/Dockerfile -t keeperhub-sandbox:ci .
+          echo "::error::Could not pull $IMAGE_REF. The caller resolved this ref from a digest it already confirmed in ECR, so this is a pull permission or registry fault, not a missing image. Refusing to build the sandbox locally, because that would test a different image than the one that ships. Check the AWS role and the ECR login in this job."
+          exit 1
         fi
 
     - name: Start sandbox container

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -39,7 +39,7 @@ jobs:
     environment: ${{ github.ref_name == 'prod' && 'prod' || 'staging' }}
     outputs:
       image_tag: ${{ steps.vars.outputs.sha_short }}
-      sandbox_image: ${{ steps.vars.outputs.sandbox_image }}
+      sandbox_image: ${{ steps.sandbox-image.outputs.sandbox_image }}
       ecr_registry: ${{ steps.login-ecr.outputs.registry }}
       ecr_repo: ${{ steps.vars.outputs.ecr_repo }}
       ecr_region: ${{ steps.vars.outputs.ecr_region }}
@@ -135,7 +135,6 @@ jobs:
             echo "sha_short=${SHA}"
             echo "ecr_repo=${AWS_ECR_NAME}"
             echo "ecr_region=${REGION}"
-            echo "sandbox_image=${{ steps.login-ecr.outputs.registry }}/${SANDBOX_ECR_NAME}:sandbox-${SHA}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check if images already exist
@@ -144,6 +143,11 @@ jobs:
           IMAGE_TAG="${{ steps.vars.outputs.sha_short }}"
           ALL_EXIST=true
           # repo:prefix pairs for every image in the pipeline bake group.
+          # KEEP-1259: the sandbox is deliberately absent. The bake no longer
+          # writes a per-commit sandbox tag, so there is nothing SHA-keyed to
+          # look for. Its sandbox-latest tag is re-put onto the same digest on
+          # every push, so a skipped rerun still leaves the right image in place,
+          # and the "Resolve the sandbox image" step below reads it either way.
           for pair in \
             "${{ env.AWS_ECR_NAME }}:app" \
             "${{ env.AWS_ECR_NAME }}:migrator" \
@@ -151,8 +155,7 @@ jobs:
             "${{ env.EXECUTOR_ECR_NAME }}:executor" \
             "${{ env.SCHEDULER_ECR_NAME }}:schedule" \
             "${{ env.SCHEDULER_ECR_NAME }}:block" \
-            "${{ env.COLLECTOR_ECR_NAME }}:collector" \
-            "${{ env.SANDBOX_ECR_NAME }}:sandbox"; do
+            "${{ env.COLLECTOR_ECR_NAME }}:collector"; do
             repo="${pair%%:*}"; prefix="${pair##*:}"
             if aws ecr describe-images \
               --repository-name "${repo}" \
@@ -234,7 +237,13 @@ jobs:
           # sandbox baked in the same session so it pushes under the app-compile
           # shadow instead of adding a serial ~72s to every e2e job. It has its
           # own Dockerfile/context and cache scope, so it builds independently
-          # of the shared app builder stage.
+          # of the shared app builder stage, and from warm cache it costs about
+          # 11 seconds beside a 17-19 minute app compile.
+          #
+          # KEEP-1259: this bake does NOT set SANDBOX_COMMIT_TAG, so it pushes
+          # the sandbox under sandbox-latest and the environment tag only. Baking
+          # it here is what lets the resolve step below hand e2e the digest this
+          # very run produced, so e2e can never pull a stale sandbox.
           targets: |
             pipeline
             sandbox
@@ -273,6 +282,39 @@ jobs:
           fi
           echo "::error title=Image build failed twice::Both bake attempts failed. Do not assume a cause. Open the Build and push all images to ECR step and read the last BuildKit error. Three signatures are known. 1. cannot allocate memory or ResourceExhausted means the runner ran out of memory, and a re-run does not reliably help because this job needs more memory than a standard runner has. 2. denied, the subject of your artifact has the maximum number of artifacts, means ECR refused an attestation push. Every re-run fails the same way until the attestation is disabled or the referrers are removed, so stop retrying. 3. any other denied or unauthorized is an ECR authentication or repository policy problem. Re-run only when the log shows a fault that is really transient."
           exit 1
+
+      # e2e pulls the sandbox by digest, not by tag. KEEP-1259.
+      #
+      # The bake above pushes the sandbox under sandbox-latest and the environment
+      # tag, and no longer under a per-commit tag, because the sandbox digest does
+      # not change between commits and ECR caps one image at 1000 tags. Resolving
+      # the digest here rather than passing "sandbox-latest" down matters for two
+      # reasons. Three e2e jobs read this output in parallel, so a floating tag
+      # could be re-pointed under them by a concurrent deploy-sandbox push. And a
+      # tag that does not resolve fails HERE, once, instead of failing three times
+      # inside the e2e jobs.
+      #
+      # This step runs even when the bake was skipped by [skip build] or by the
+      # rerun guard. sandbox-latest is idempotent, so the image is already correct
+      # in those cases and e2e still needs a ref for it.
+      - name: Resolve the sandbox image for e2e
+        id: sandbox-image
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          DIGEST=$(aws ecr describe-images \
+            --repository-name "${SANDBOX_ECR_NAME}" \
+            --image-ids imageTag=sandbox-latest \
+            --region "${REGION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null || true)
+          if [[ -z "${DIGEST}" || "${DIGEST}" == "None" ]]; then
+            echo "::error::Could not resolve ${SANDBOX_ECR_NAME}:sandbox-latest to a digest. Every sandbox bake pushes that tag, so its absence means the repository was emptied or this job cannot read it. e2e cannot start a sandbox without it. Run the deploy-sandbox workflow to republish the image, then re-run this pipeline."
+            exit 1
+          fi
+          echo "sandbox-latest resolves to ${DIGEST}"
+          echo "sandbox_image=${REGISTRY}/${SANDBOX_ECR_NAME}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       # Sentry source-map upload moved out to its own sentry-upload.yml job,
       # fanned out from build-images in ci-pipeline.yml so it runs parallel to

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -137,27 +137,43 @@ jobs:
           # staging. It is derived from APP_ECR_NAME so the account and prefix
           # still come from the environment.
           SANDBOX_ECR_NAME="keeperhub-sandbox-${APP_ECR_NAME##*-}"
-          MISSING=false
-          for pair in "${APP_ECR_NAME}:app" "${SANDBOX_ECR_NAME}:sandbox"; do
-            repo="${pair%%:*}"; prefix="${pair##*:}"
-            if aws ecr describe-images \
-                 --repository-name "${repo}" \
-                 --image-ids "imageTag=${prefix}-${SHA}" \
+          if ! aws ecr describe-images \
+                 --repository-name "${APP_ECR_NAME}" \
+                 --image-ids "imageTag=app-${SHA}" \
                  --region "${REGION}" >/dev/null 2>&1; then
-              echo "${repo}:${prefix}-${SHA} found"
-            else
-              echo "::error::${repo}:${prefix}-${SHA} is absent. e2e cannot reuse the staging build for this release. Re-run the staging pipeline for ${SHA} so the image is rebuilt, then re-run this release."
-              MISSING=true
-            fi
-          done
-          if [[ "${MISSING}" == "true" ]]; then
+            echo "::error::${APP_ECR_NAME}:app-${SHA} is absent. e2e cannot reuse the staging build for this release. Re-run the staging pipeline for ${SHA} so the image is rebuilt, then re-run this release."
             exit 1
           fi
+          echo "${APP_ECR_NAME}:app-${SHA} found"
+          # The sandbox resolves by digest from sandbox-latest, NOT by a
+          # per-commit tag. KEEP-1259 stopped the pipeline bake writing
+          # sandbox-<sha>, because the sandbox digest does not change between
+          # commits and ECR caps one image at 1000 tags.
+          #
+          # This is the one place the release reads a moving tag, so state the
+          # trade-off plainly. The app half above stays pinned to the exact
+          # staging commit this release merges. The sandbox half is whatever
+          # sandbox-latest points at when this job runs, which differs from the
+          # release commit's sandbox only when a sandbox change lands on staging
+          # between the release merge and this run. deploy-sandbox fires once or
+          # twice a month, so that window is small, and the gate below still
+          # fails closed rather than falling through to a local build.
+          SANDBOX_DIGEST=$(aws ecr describe-images \
+            --repository-name "${SANDBOX_ECR_NAME}" \
+            --image-ids imageTag=sandbox-latest \
+            --region "${REGION}" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null || true)
+          if [[ -z "${SANDBOX_DIGEST}" || "${SANDBOX_DIGEST}" == "None" ]]; then
+            echo "::error::Could not resolve ${SANDBOX_ECR_NAME}:sandbox-latest to a digest. Every sandbox bake pushes that tag, so its absence means the repository was emptied or this job cannot read it. Run the deploy-sandbox workflow on staging to republish the image, then re-run this release."
+            exit 1
+          fi
+          echo "${SANDBOX_ECR_NAME}:sandbox-latest resolves to ${SANDBOX_DIGEST}"
           {
             echo "image_tag=${SHA}"
             echo "ecr_repo=${APP_ECR_NAME}"
             echo "ecr_region=${REGION}"
-            echo "sandbox_image=${REGISTRY}/${SANDBOX_ECR_NAME}:sandbox-${SHA}"
+            echo "sandbox_image=${REGISTRY}/${SANDBOX_ECR_NAME}@${SANDBOX_DIGEST}"
           } >> "$GITHUB_OUTPUT"
 
   # Ephemeral e2e tests.

--- a/.github/workflows/deploy-sandbox.yaml
+++ b/.github/workflows/deploy-sandbox.yaml
@@ -96,6 +96,13 @@ jobs:
           fi
           echo "sandbox-${IMAGE_TAG} exists in ${SANDBOX_ECR_NAME}"
 
+      # SANDBOX_COMMIT_TAG is set HERE and nowhere else. This workflow deploys the
+      # sandbox by its per-commit tag, because the Helm step below substitutes
+      # ${IMAGE_TAG} into deploy/keeperhub-sandbox/<env>/values.yaml. It runs only
+      # when the sandbox inputs really change, about once or twice a month, so the
+      # tag count on the image stays bounded. The pipeline bake in build-images.yml
+      # runs on every push and must NOT set it. See the comment on the variable in
+      # docker-bake.hcl for what happens when it does. KEEP-1259.
       - name: Build and push sandbox image
         if: steps.skip.outputs.skip_build != 'true'
         uses: docker/bake-action@v7
@@ -103,6 +110,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           SANDBOX_ECR_REPO: ${{ env.SANDBOX_ECR_NAME }}
           IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+          SANDBOX_COMMIT_TAG: sandbox-${{ steps.vars.outputs.sha_short }}
           ENVIRONMENT_TAG: ${{ env.ENVIRONMENT_TAG }}
         with:
           files: docker-bake.hcl

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,19 @@ variable "EXECUTOR_ECR_REPO" { default = "" }
 variable "SANDBOX_ECR_REPO" { default = "" }
 variable "METRICS_COLLECTOR_ECR_REPO" { default = "" }
 
+# The per-commit sandbox tag, for example "sandbox-1a2b3c4". Empty by default, so
+# only a caller that really needs the tag creates it. deploy-sandbox.yaml sets it,
+# because its Helm values reference the image by that tag. The pipeline bake in
+# build-images.yml leaves it empty and resolves the image by digest instead.
+#
+# Do not set this from a workflow that runs on every push. The sandbox Dockerfile
+# copies a small, stable set of inputs, so the image digest does not change between
+# commits, and since KEEP-1257 removed the attestation wrapper every push lands on
+# the SAME image object. A per-commit tag there adds one more tag to that one image
+# on every push. ECR allows 1000 tags per image and does not adjust that limit, so
+# the push starts to fail once the count is reached. KEEP-1259.
+variable "SANDBOX_COMMIT_TAG" { default = "" }
+
 group "default" {
   targets = ["app", "migrator", "workflow-runner"]
 }
@@ -285,7 +298,7 @@ target "sandbox" {
   context    = "."
   dockerfile = "sandbox/Dockerfile"
   tags = compact([
-    "${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:sandbox-${IMAGE_TAG}",
+    SANDBOX_COMMIT_TAG != "" ? "${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:${SANDBOX_COMMIT_TAG}" : "",
     "${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:sandbox-latest",
     ENVIRONMENT_TAG != "" ? "${ECR_REGISTRY}/${SANDBOX_ECR_REPO}:${ENVIRONMENT_TAG}" : "",
   ])


### PR DESCRIPTION
Closes KEEP-1259.

## Why this is not the ticket's own reason

KEEP-1259 says the cost is "a wasted bake and a tag write" and sets Low priority. I measured
both and they are close to free, so that reason does not hold:

* The sandbox target builds in **11 seconds** from warm registry cache (measured on
  `deploy-sandbox` run 33398776305, step "Build and push sandbox image", 13:46:53 to 13:47:04
  UTC on 2026-08-31). In the pipeline bake it runs beside a 17 to 19 minute app compile, so it
  adds no wall-clock.
* The tag write costs nothing. Blobs are shared and the digest is stable.

## The reason it does need doing

KEEP-1257 removed the attestation wrapper. The sandbox digest was already stable, so every
push now lands on the **same image object** rather than creating a new one. Verified in live
ECR on 2026-08-31: `keeperhub-sandbox-staging` image `sha256:1bb660b5de7e` carries
`sandbox-78eda00`, `sandbox-d704b5b`, `sandbox-latest` and `staging`, and the repository still
holds 31 images with a `sandbox-` tag across two pushes since the fix landed.

AWS caps an image at **1,000 tags and does not adjust that limit**
([ECR service quotas](https://docs.aws.amazon.com/AmazonECR/latest/userguide/service-quotas.html)).
Staging merges 6.93 distinct commits a day, measured over 194 `ci-pipeline` push runs on
`staging` between 2026-08-04 and 2026-08-31, and each one adds one unique `sandbox-<sha>` tag
to that single image. From 4 tags today that reaches the limit in about 144 days, so late
January 2027. At that point `PutImage` refuses the sandbox push and every staging deploy
blocks, in the same shape as KEEP-1257 with a different error string and no useful retry.

## What changed

**`docker-bake.hcl`** gains `SANDBOX_COMMIT_TAG`, empty by default. The `sandbox` target emits
the per-commit tag only when a caller sets it. Default off, so a future caller cannot silently
re-create the growth.

**`deploy-sandbox.yaml`** sets it. It deploys the sandbox by that tag, because its Helm step
substitutes the tag into `deploy/keeperhub-sandbox/<env>/values.yaml`, and it runs only when
the sandbox inputs change: 18 runs between 2026-06-12 and 2026-08-31.

**`build-images.yml`** keeps baking the sandbox and does not set the variable. Keeping the bake
is deliberate. It costs 11 cached seconds under a 17 minute compile, and it means the job that
resolves the e2e image is the job that just built it, so e2e can never pull a stale sandbox. A
new step resolves `sandbox-latest` to a digest and outputs `<repo>@sha256:...`. The sandbox is
dropped from the "Check if images already exist" rerun guard, because there is no longer a
SHA-keyed tag to look for and `sandbox-latest` is idempotent.

**`ci-pipeline.yml`** does the same digest resolution in `resolve-e2e-image` for a prod
release, still reading the staging repository on purpose. The app half stays pinned to the
exact staging commit the release merges. Both halves still fail the job when they do not
resolve.

**`start-sandbox`** no longer falls back to a local build when a supplied ref fails to pull.
KEEP-1259 asks for this decision explicitly. The caller resolved that ref from a digest it
already confirmed, so a failure is a permission or registry fault. The old fallback cost about
72 seconds in each of three e2e jobs and quietly tested a locally built sandbox instead of the
one that ships. Pull requests still pass an empty ref and still build locally.

## Why a digest and not the `sandbox-latest` tag

Three e2e jobs read this output in parallel, so a floating tag could be re-pointed under them
by a concurrent `deploy-sandbox` push. A tag that does not resolve also fails once, in the
resolve step, instead of three times inside the e2e jobs.

## Out of scope, deliberately

The ticket proposes a path filter on the `sandbox` bake target copied from
`deploy-sandbox.yaml`. I dropped that. Removing an 11 second cached build buys nothing
measurable, and gating it forces two new fallback paths onto the release-gating route,
including a loosening of the `resolve-e2e-image` hard gate that KEEP-1206 put there on purpose.

The self-hosted overlay in `deploy/keeperhub-stack/self-hosted/docker-bake.hcl` keeps its
per-commit tag. It replaces the sandbox tag list completely, verified with `bake --print`, and
it targets a single-install registry.

## One behaviour narrows

A `[skip build]` run of `deploy-sandbox` now finds `sandbox-<sha>` only for a commit that
`deploy-sandbox` itself built, not for any staging commit. The existing guard already names
the fix in its error message.

## Checks run locally

| Check | Result |
| -- | -- |
| `actionlint -shellcheck=""` (the maintainability job's exact command) | clean |
| "Bake Provenance Disabled" job, run verbatim | all 11 targets disable provenance |
| `bake --print sandbox`, no variables set | `sandbox-latest`, `staging`. No per-commit tag |
| `bake --print sandbox` with `SANDBOX_COMMIT_TAG` | all three tags present |
| `bake --print sandbox` through the self-hosted overlay | still `:sandbox-<sha>`, unchanged |
| `dockerfile-sources`, `fork-markers` (always-on jobs) | pass |
| YAML parse plus `bash -n` on both new run blocks | pass |

`pr-checks.yml` (Biome, `tsc --noEmit`, `next build`, Vitest) was not run. The diff holds only
`.yml`, `.yaml` and `.hcl` files, and Biome 2.4.10 reports `files/missingHandler` and
"Checked 0 files" for both types, so none of those checks can read this diff.

## Verification after merge

The real proof is post-merge, since a PR does not run `build-images`:

1. `build-images` logs a resolved digest, and all three e2e sandbox jobs log `using prebuilt
   sandbox image ...@sha256:...` rather than building locally.
2. The tag count on `sha256:1bb660b5de7e` stops rising across the next several staging pushes.
   That is the whole point, so check it over at least three pushes.
3. A `workflow_dispatch` of `deploy-sandbox` on staging still pushes a `sandbox-<sha>` tag and
   still deploys, which proves the opt-in path.

Not done until it is verified live in prod, which needs the separate staging to prod promotion.

## Separate finding, not fixed here

`keeperhub-sandbox-staging` now holds 31 images carrying a `sandbox-` tag against a lifecycle
rule that keeps 30, and the oldest by `imagePushedAt` (2026-08-13T18:00:25+02:00) is the image
the live staging deployment runs. A stable digest never gets a fresh push date, so the live
image became and stays the repository's oldest. That belongs to KEEP-1258, which owns every
`ecr.tf` lifecycle policy, and I am reporting it there.
