### PR TITLE
fix: KEEP-1242 re-seed the Solana signatures cursor when the RPC rejects it

### DIFF
--- a/keeperhub-events/solana-tracker/lib/config/environment.ts
+++ b/keeperhub-events/solana-tracker/lib/config/environment.ts
@@ -15,24 +15,49 @@ export const NODE_ENV: string = process.env.NODE_ENV || "development";
  * Solana mainnet, one query per program per poll), which is a large sustained
  * RPC bill for no latency gain that matters downstream of SQS.
  */
-export const SOLANA_SIGNATURES_POLL_INTERVAL_MS: number = parsePollIntervalMs(
+export const SOLANA_SIGNATURES_POLL_INTERVAL_MS: number = parseDurationMs(
+  "SOLANA_SIGNATURES_POLL_INTERVAL_MS",
   process.env.SOLANA_SIGNATURES_POLL_INTERVAL_MS,
+  2000,
+);
+
+/**
+ * How long a watched program may go without a poll that completes before the
+ * signatures source drops its cursor and re-seeds to head.
+ *
+ * The precise recovery keys off the RPC's "transaction not found" code, but an
+ * endpoint that reports an unresolvable cursor some other way would otherwise
+ * stall that program forever - the cursor is only ever advanced on success, so
+ * a rejected cursor is retried unchanged on every poll. This backstop bounds
+ * that by wall-clock instead of by error shape. Re-seeding skips the window, so
+ * the value trades event loss against how long a program may stay stuck. An
+ * explicit 0 is honoured and means "re-seed on the first failed poll"; it does
+ * not disable the backstop.
+ */
+export const SOLANA_SIGNATURES_STALL_RESET_MS: number = parseDurationMs(
+  "SOLANA_SIGNATURES_STALL_RESET_MS",
+  process.env.SOLANA_SIGNATURES_STALL_RESET_MS,
+  300_000,
 );
 
 /**
  * `Number(x) || fallback` would swallow an explicit `0` - the value an operator
- * uses to disable the floor - and would silently accept a typo as the default.
+ * uses to disable a floor - and would silently accept a typo as the default.
  * Honour any finite non-negative number, and say so when a value is rejected.
+ * The variable name is a parameter so the warning names the one that was wrong.
  */
-function parsePollIntervalMs(raw: string | undefined): number {
-  const fallback = 2000;
+function parseDurationMs(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+): number {
   if (raw === undefined || raw.trim() === "") {
     return fallback;
   }
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed < 0) {
     logger.warn(
-      `[env] SOLANA_SIGNATURES_POLL_INTERVAL_MS="${raw}" is not a non-negative number; using ${fallback}`,
+      `[env] ${name}="${raw}" is not a non-negative number; using ${fallback}`,
     );
     return fallback;
   }

--- a/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/signatures-source.ts
@@ -1,5 +1,11 @@
-import type { ConfirmedSignatureInfo } from "@solana/web3.js";
-import { SOLANA_SIGNATURES_POLL_INTERVAL_MS } from "../../lib/config/environment";
+import {
+  type ConfirmedSignatureInfo,
+  SolanaJSONRPCError,
+} from "@solana/web3.js";
+import {
+  SOLANA_SIGNATURES_POLL_INTERVAL_MS,
+  SOLANA_SIGNATURES_STALL_RESET_MS,
+} from "../../lib/config/environment";
 import { logger } from "../../lib/utils/logger";
 import { formatError } from "../format-error";
 import type { NormalizedBlock } from "../match/types";
@@ -29,10 +35,39 @@ import { type ConnectionHealth, SolanaConnection } from "./solana-connection";
 const MAX_SIGNATURES_PER_TICK = 1_000;
 /** Bounds one poll's paging at 10k signatures per program. */
 const MAX_SIGNATURE_PAGES = 10;
+/**
+ * The code the RPC returns for an `until`/`before` signature it cannot resolve,
+ * alongside "Transaction <sig> not found". Verified identical on both gateway
+ * routes and on api.testnet.solana.com, so it is the validator's behaviour
+ * rather than one provider's. web3.js 1.98.4 exports SolanaJSONRPCErrorCode but
+ * that table stops at -32016, so there is no constant to import.
+ */
+const RPC_TRANSACTION_NOT_FOUND = -32020;
+
+/**
+ * Whether the RPC rejected our cursor itself, as opposed to failing the query.
+ * A malformed signature is a different code (-32602 "Invalid param: WrongSize"),
+ * so this does not fire on one - and must not, because dropping a cursor skips
+ * the window.
+ */
+function isUnknownCursorError(err: unknown): boolean {
+  return (
+    err instanceof SolanaJSONRPCError &&
+    typeof err.code === "number" &&
+    err.code === RPC_TRANSACTION_NOT_FOUND
+  );
+}
 
 export class SignaturesSource implements BlockSource {
   private connection: SolanaConnection | null = null;
   private readonly cursors = new Map<string, string>();
+  /**
+   * When each program last completed a poll without throwing, which includes a
+   * poll that found nothing - a quiet program is the normal case and must never
+   * look stalled. Only programs holding a cursor are tracked, because a program
+   * without one is already re-seeding on every poll.
+   */
+  private readonly lastSuccessAt = new Map<string, number>();
   private isProcessing = false;
   private pendingTick = false;
   private lastPollAt = 0;
@@ -41,6 +76,7 @@ export class SignaturesSource implements BlockSource {
   constructor(
     private readonly opts: BlockSourceOptions,
     private readonly pollIntervalMs: number = SOLANA_SIGNATURES_POLL_INTERVAL_MS,
+    private readonly stallResetMs: number = SOLANA_SIGNATURES_STALL_RESET_MS,
   ) {}
 
   async start(): Promise<void> {
@@ -59,7 +95,7 @@ export class SignaturesSource implements BlockSource {
           limit: 1,
         });
         if (seed[0]) {
-          this.cursors.set(programId, seed[0].signature);
+          this.setCursor(programId, seed[0].signature);
         }
       } catch (err) {
         logger.warn(
@@ -133,43 +169,122 @@ export class SignaturesSource implements BlockSource {
       });
   }
 
+  /**
+   * One pass over every watched program.
+   *
+   * Each program is isolated: the query and its follow-up fetches are one
+   * round trip per program, so letting a rejection escape the loop would skip
+   * every program after it - one unreachable program would silently stop the
+   * rest of the chain's workflows, not just its own.
+   */
   private async poll(): Promise<void> {
+    for (const programId of this.opts.watchedProgramIds) {
+      if (!this.connection) {
+        return;
+      }
+      try {
+        await this.pollProgram(programId);
+        // Success means the query returned, empty included. A program with
+        // nothing new is the normal case and must not read as stalled.
+        if (this.cursors.has(programId)) {
+          this.lastSuccessAt.set(programId, Date.now());
+        }
+      } catch (err) {
+        this.handleProgramError(programId, err);
+      }
+    }
+  }
+
+  private async pollProgram(programId: string): Promise<void> {
     if (!this.connection) {
       return;
     }
-    for (const programId of this.opts.watchedProgramIds) {
-      const until = this.cursors.get(programId);
-      if (!until) {
-        // Not seeded yet (seed failed at start); seed now, process nothing.
-        const seed = await this.connection.getSignaturesForAddress(programId, {
-          limit: 1,
-        });
-        if (seed[0]) {
-          this.cursors.set(programId, seed[0].signature);
-        }
-        continue;
+    const until = this.cursors.get(programId);
+    if (!until) {
+      // Not seeded yet (seed failed at start, or a rejected cursor was
+      // dropped); seed now, process nothing.
+      const seed = await this.connection.getSignaturesForAddress(programId, {
+        limit: 1,
+      });
+      if (seed[0]) {
+        this.setCursor(programId, seed[0].signature);
       }
-      const sigs = await this.collectSignaturesSince(programId, until);
-      if (sigs.length === 0) {
-        continue;
-      }
-      // Newest-first from the RPC; advance the cursor to the newest, process
-      // oldest-first so downstream ordering matches on-chain ordering.
-      const newest = sigs[0].signature;
-      for (let i = sigs.length - 1; i >= 0; i--) {
-        const info = sigs[i];
-        if (info.err) {
-          continue; // failed tx emits no meaningful events
-        }
-        if (!this.connection) {
-          // stop() ran mid-window; drop the rest rather than dispatching for a
-          // chain the reconciler has already torn down.
-          return;
-        }
-        await this.processSignature(info.signature, info.slot);
-      }
-      this.cursors.set(programId, newest);
+      return;
     }
+    const sigs = await this.collectSignaturesSince(programId, until);
+    if (sigs.length === 0) {
+      return;
+    }
+    // Newest-first from the RPC; advance the cursor to the newest, process
+    // oldest-first so downstream ordering matches on-chain ordering.
+    const newest = sigs[0].signature;
+    for (let i = sigs.length - 1; i >= 0; i--) {
+      const info = sigs[i];
+      if (info.err) {
+        continue; // failed tx emits no meaningful events
+      }
+      if (!this.connection) {
+        // stop() ran mid-window; drop the rest rather than dispatching for a
+        // chain the reconciler has already torn down.
+        return;
+      }
+      await this.processSignature(info.signature, info.slot);
+    }
+    this.setCursor(programId, newest);
+  }
+
+  /**
+   * A failed poll either invalidates the cursor or does not. Getting this wrong
+   * in either direction costs events: keeping a cursor the endpoint will never
+   * resolve stalls the program forever, because the cursor only advances on
+   * success and so the same rejected value is retried on every poll; dropping a
+   * usable cursor re-seeds to head and skips the window.
+   */
+  private handleProgramError(programId: string, err: unknown): void {
+    const cursor = this.cursors.get(programId);
+    if (cursor && isUnknownCursorError(err)) {
+      this.dropCursor(programId);
+      logger.warn(
+        `[signatures] chain ${this.opts.chainId} program ${programId} cursor ${cursor} is unknown to the endpoint; re-seeding to head and skipping that window. An endpoint serving a different cluster than the cursor came from does this (KEEP-1202).`,
+      );
+      return;
+    }
+    if (cursor && this.hasStalled(programId)) {
+      this.dropCursor(programId);
+      logger.error(
+        `[signatures] chain ${this.opts.chainId} program ${programId} completed no poll for ${this.stallResetMs}ms; dropping cursor ${cursor} and re-seeding to head, skipping that window. Last error: ${formatError(err)}`,
+      );
+      return;
+    }
+    logger.warn(
+      `[signatures] chain ${this.opts.chainId} program ${programId} poll error: ${formatError(err)}`,
+    );
+  }
+
+  /**
+   * True once a program holding a cursor has gone `stallResetMs` without a poll
+   * that completed. The clock starts when the cursor is set, so a program that
+   * has never succeeded still trips it rather than waiting forever for a first
+   * success that may never come.
+   */
+  private hasStalled(programId: string): boolean {
+    const since = this.lastSuccessAt.get(programId);
+    return since !== undefined && Date.now() - since >= this.stallResetMs;
+  }
+
+  /**
+   * Keeps the cursor and its stall clock in lockstep - they are only ever set
+   * and cleared together, including across stop()/start(), so a cursor can
+   * never end up without a clock and so unable to trip the backstop.
+   */
+  private setCursor(programId: string, signature: string): void {
+    this.cursors.set(programId, signature);
+    this.lastSuccessAt.set(programId, Date.now());
+  }
+
+  private dropCursor(programId: string): void {
+    this.cursors.delete(programId);
+    this.lastSuccessAt.delete(programId);
   }
 
   /**

--- a/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/signatures-source.test.ts
@@ -1,3 +1,4 @@
+import { SolanaJSONRPCError } from "@solana/web3.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 type SignatureInfo = { signature: string; slot: number };
@@ -7,7 +8,16 @@ type SignatureQuery = { until?: string; before?: string; limit?: number };
 // poll cadence and paging can be driven deterministically without any network.
 const hooks = vi.hoisted(() => ({
   onSlot: null as null | ((slot: number) => void),
-  signatureCalls: [] as { address: string; until?: string; before?: string }[],
+  signatureCalls: [] as {
+    address: string;
+    until?: string;
+    before?: string;
+    limit?: number;
+  }[],
+  // When set, decides whether a given query rejects. Rejecting (rather than
+  // throwing synchronously) is what the real connection does, and it is the
+  // path the source's error handling actually takes in production.
+  failWith: null as null | ((options: SignatureQuery) => Error | null),
   signatures: (
     _address: string,
     _options: { until?: string; before?: string; limit?: number },
@@ -35,7 +45,12 @@ vi.mock("@/src/ingest/solana-connection", () => ({
         address,
         until: options.until,
         before: options.before,
+        limit: options.limit,
       });
+      const failure = hooks.failWith?.(options) ?? null;
+      if (failure) {
+        return Promise.reject(failure);
+      }
       const result = hooks.signatures(address, options);
       if (hooks.delayMs === 0) {
         return Promise.resolve(result);
@@ -56,8 +71,54 @@ vi.mock("@/src/ingest/solana-connection", () => ({
 const { SignaturesSource } = await import("@/src/ingest/signatures-source");
 
 const PROGRAM = "So11111111111111111111111111111111111111112";
+const OTHER_PROGRAM = "Vote111111111111111111111111111111111111111";
 const POLL_INTERVAL_MS = 1000;
+const STALL_RESET_MS = 5000;
 const PAGE_SIZE = 1000;
+
+/**
+ * The error the RPC returns for an `until`/`before` signature it cannot
+ * resolve. Code -32020 with "Transaction <sig> not found", verified identical
+ * on both gateway routes and on api.testnet.solana.com.
+ */
+function unknownCursorError(signature: string): Error {
+  return new SolanaJSONRPCError(
+    { code: -32020, message: `Transaction ${signature} not found` },
+    "failed to get signatures for address",
+  );
+}
+
+/** A malformed signature, which must NOT be read as a rejected cursor. */
+function invalidParamError(): Error {
+  return new SolanaJSONRPCError(
+    { code: -32602, message: "Invalid param: WrongSize" },
+    "failed to get signatures for address",
+  );
+}
+
+function sourceWith(
+  programs: string[],
+  onBlock: () => Promise<void> = () => Promise.resolve(),
+): InstanceType<typeof SignaturesSource> {
+  return new SignaturesSource(
+    {
+      chainId: 101,
+      endpoints: [{ rpcUrl: "r", wssUrl: "w" }],
+      commitment: "confirmed",
+      watchedProgramIds: programs,
+      onBlock,
+    },
+    POLL_INTERVAL_MS,
+    STALL_RESET_MS,
+  );
+}
+
+/** Queries that carry no cursor are seeds; the source sends them with limit 1. */
+function seedCalls(): typeof hooks.signatureCalls {
+  return hooks.signatureCalls.filter(
+    (c) => c.until === undefined && c.before === undefined,
+  );
+}
 
 function source(
   onBlock: () => Promise<void> = () => Promise.resolve(),
@@ -85,6 +146,7 @@ afterEach(() => {
   vi.useRealTimers();
   hooks.signatureCalls = [];
   hooks.signatures = () => [];
+  hooks.failWith = null;
   hooks.delayMs = 0;
 });
 
@@ -232,6 +294,211 @@ describe("SignaturesSource windowing", () => {
     hooks.onSlot?.(1);
     await vi.waitFor(() => expect(processed).toBe(2));
     expect(hooks.signatureCalls.slice(1)).toHaveLength(1);
+
+    await src.stop();
+  });
+});
+
+describe("SignaturesSource cursor recovery", () => {
+  it("re-seeds when the endpoint rejects the cursor", async () => {
+    // The cursor only advances on success, so a cursor the endpoint will never
+    // resolve is retried unchanged on every poll - the source stalls for good
+    // and logs the same rejection forever. Observed on staging chain 103, where
+    // the cursor was seeded from one cluster and polled against another.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = sourceWith([PROGRAM]);
+    await src.start();
+    expect(seedCalls()).toHaveLength(1);
+
+    hooks.failWith = (options) =>
+      options.until === "seed-sig" ? unknownCursorError("seed-sig") : null;
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    // The rejected cursor is dropped, so the next poll seeds afresh rather than
+    // asking for the same unresolvable signature again.
+    hooks.failWith = null;
+    hooks.signatures = () => [{ signature: "reseed-sig", slot: 9 }];
+    hooks.onSlot?.(2);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    expect(seedCalls()).toHaveLength(2);
+    expect(seedCalls()[1].limit).toBe(1);
+    expect(hooks.signatureCalls.some((c) => c.until === "reseed-sig")).toBe(
+      false,
+    );
+
+    await src.stop();
+  });
+
+  it("re-seeds when the rejection comes from a paging query", async () => {
+    // Paging asks with `before`, and the endpoint rejects an unresolvable
+    // `before` with the same code. Recovery must not depend on which parameter
+    // the endpoint objected to.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = sourceWith([PROGRAM]);
+    await src.start();
+
+    // A full page forces a second, `before`-carrying request; that one fails.
+    hooks.signatures = () => page("new", PAGE_SIZE);
+    hooks.failWith = (options) =>
+      options.before === undefined
+        ? null
+        : unknownCursorError(String(options.before));
+
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    expect(hooks.signatureCalls.some((c) => c.before !== undefined)).toBe(true);
+
+    hooks.failWith = null;
+    hooks.signatures = () => [];
+    hooks.onSlot?.(2);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    expect(seedCalls()).toHaveLength(2);
+
+    await src.stop();
+  });
+
+  it("keeps the cursor when the failure is not a cursor rejection", async () => {
+    // Dropping a usable cursor re-seeds to head and skips the window, so a
+    // malformed-parameter error or an ordinary failure must leave it alone.
+    vi.useFakeTimers();
+    for (const failure of [invalidParamError(), new Error("socket hang up")]) {
+      hooks.signatureCalls = [];
+      hooks.failWith = null;
+      hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+      const src = sourceWith([PROGRAM]);
+      await src.start();
+
+      hooks.failWith = () => failure;
+      hooks.onSlot?.(1);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+      hooks.failWith = null;
+      hooks.signatures = () => [];
+      hooks.onSlot?.(2);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+      // Still asking from the same cursor; no re-seed happened.
+      expect(seedCalls()).toHaveLength(1);
+      expect(hooks.signatureCalls.at(-1)?.until).toBe("seed-sig");
+
+      await src.stop();
+    }
+  });
+
+  it("drops a cursor that has completed no poll for the stall window", async () => {
+    // The backstop for an endpoint that reports an unresolvable cursor some
+    // other way. Without it, only the codes we already know about recover.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = sourceWith([PROGRAM]);
+    await src.start();
+
+    hooks.failWith = () => new Error("upstream unavailable");
+    // Poll repeatedly, staying inside the window.
+    for (let i = 0; i < 3; i++) {
+      hooks.onSlot?.(i);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    }
+    expect(seedCalls()).toHaveLength(1);
+    expect(hooks.signatureCalls.at(-1)?.until).toBe("seed-sig");
+
+    // Cross the window; the next failing poll gives the cursor up.
+    await vi.advanceTimersByTimeAsync(STALL_RESET_MS);
+    hooks.onSlot?.(99);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    hooks.failWith = null;
+    hooks.signatures = () => [];
+    hooks.onSlot?.(100);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    expect(seedCalls()).toHaveLength(2);
+
+    await src.stop();
+  });
+
+  it("never treats a quiet program as stalled", async () => {
+    // A program with nothing new returns an empty window, which is the normal
+    // case. Reading that as a stall would re-seed - and so skip events - on
+    // every quiet chain, which is most of them.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    const src = sourceWith([PROGRAM]);
+    await src.start();
+
+    hooks.signatures = () => [];
+    for (let i = 0; i < STALL_RESET_MS / POLL_INTERVAL_MS + 5; i++) {
+      hooks.onSlot?.(i);
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    }
+
+    expect(seedCalls()).toHaveLength(1);
+    expect(hooks.signatureCalls.at(-1)?.until).toBe("seed-sig");
+
+    await src.stop();
+  });
+
+  it("keeps polling later programs when one rejects", async () => {
+    // One request per program, so an escaping rejection would skip every
+    // program after it - one unreachable program silently stopping the rest of
+    // the chain's workflows.
+    vi.useFakeTimers();
+    hooks.signatures = (address) => [{ signature: `seed-${address}`, slot: 1 }];
+
+    const src = sourceWith([PROGRAM, OTHER_PROGRAM]);
+    await src.start();
+    hooks.signatureCalls = [];
+
+    hooks.failWith = (options) =>
+      options.until === `seed-${PROGRAM}` ? new Error("first is down") : null;
+    hooks.signatures = () => [];
+
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    expect(hooks.signatureCalls.some((c) => c.address === OTHER_PROGRAM)).toBe(
+      true,
+    );
+
+    await src.stop();
+  });
+
+  it("does not replay history after a re-seed", async () => {
+    // Re-seeding jumps to head. It must not walk the backlog, which on a busy
+    // program would be a flood of duplicate workflow fires.
+    vi.useFakeTimers();
+    hooks.signatures = () => [{ signature: "seed-sig", slot: 1 }];
+
+    let processed = 0;
+    const src = sourceWith([PROGRAM], () => {
+      processed++;
+      return Promise.resolve();
+    });
+    await src.start();
+
+    hooks.failWith = () => unknownCursorError("seed-sig");
+    hooks.onSlot?.(1);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    hooks.failWith = null;
+    hooks.signatures = () => page("history", 25);
+    hooks.onSlot?.(2);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    const reseed = seedCalls()[1];
+    expect(reseed).toBeDefined();
+    expect(reseed.limit).toBe(1);
+    expect(processed).toBe(0);
 
     await src.stop();
   });


### PR DESCRIPTION
Follow-up to #2156, same ticket (KEEP-1242).

## The defect

`SignaturesSource` advances a program's cursor only after a poll succeeds. So a cursor the endpoint cannot resolve is retried unchanged on every poll: the program stalls permanently and logs the same rejection every few seconds. Nothing clears the cursor, ever.

Staging chain 103 has been in exactly that state:

```
[signatures] chain 103 poll error: SolanaJSONRPCError: failed to get signatures for
address: Transaction 4wriNdQ7CuPtfZ8CCLFQS4EoMXTpQNHWewwtjxX943Yz6wUW... not found
```

8926 of those in one 6h bucket. I traced the signature: it exists **only on real devnet** (slot 483156748, invoking `4dtq...`) and is absent from testnet and mainnet, while the staging route currently serves testnet 30/30 samples. The cursor was seeded while the Aetherlay `solana-devnet` route was on its dRPC devnet fallback, and the route now serves its QuickNode testnet primary. KEEP-1202 covers the split route.

The error history shows the route really does flip: near-zero errors on 08-27 and 08-28, a burst of 2374 on 08-29 that cleared **without a pod restart**, quiet for two days, then 5989 and 8926.

`GetBlockSource` never showed this because its cursor is a slot number, which is valid on any cluster. A signature is cluster-specific. #2156 moving testnet event chains onto the signatures source is what turned a silent wrong-chain read into a hard stop, so the recovery belongs here.

## The change

Two independent recovery paths, because one error code is a narrow thing to depend on.

**Precise.** An unresolvable `until` or `before` comes back as JSON-RPC `-32020` with `Transaction <sig> not found`. I verified that code is identical on `chain.techops.live`, `chain.techops.services` and the reference `api.testnet.solana.com`, for both parameters, so it is validator behaviour rather than a provider quirk. A malformed signature is `-32602 Invalid param: WrongSize`, a different code, so the two stay distinguishable and a bad-parameter error never drops a usable cursor.

**Backstop.** Any program holding a cursor that completes no poll for `SOLANA_SIGNATURES_STALL_RESET_MS` (default 5 min) drops it regardless of error shape. An endpoint that reports an unresolvable cursor some other way, or strips the code, cannot stall us again. "Completed" means the query returned, empty included, so a quiet program is never mistaken for a stalled one.

**Isolation.** Each program now polls inside its own try/catch. One request goes out per program, so a rejection previously escaped the loop and skipped every program after it, stopping the rest of the chain's workflows rather than only its own. Prod chain 101 watches two programs today.

Re-seeding jumps to head and skips the window. That is a real loss, so both paths log it rather than recovering quietly. The unknown-cursor message names KEEP-1202, because a route serving a different cluster than the cursor came from is what produces it.

Note `-32020` is written as a documented literal: web3.js 1.98.4 exports `SolanaJSONRPCErrorCode`, but that table stops at `-32016`, so there is no constant to import.

## Tests

Seven cases added to `tests/unit/signatures-source.test.ts`, with the mock extended so a chosen query rejects rather than throwing synchronously, which is the path production takes.

Recovery, all five failing against the pre-change source and passing after:

- `-32020` on the `until` query drops the cursor and the next poll re-seeds with `limit: 1`.
- `-32020` raised on a paging (`before`) query does the same, so recovery does not depend on which parameter was rejected.
- The stall backstop drops a cursor after the window when the errors are ordinary.
- A rejection on the first of two programs still lets the second be queried on the same tick.
- A re-seed does not replay history: the seed is `limit: 1` and `onBlock` is never called.

Two are invariant guards on the new behaviour rather than recovery proofs, so they pass before and after by construction. Stated plainly rather than counted as coverage:

- `-32602` and a plain `Error` both leave the cursor intact.
- A quiet program returning empty windows never trips the backstop, however long it runs.

## Local checks

`pnpm lint`, `pnpm typecheck`, `pnpm -r test:unit` all green (281 unit tests, up from 274). solana-tracker's own integration suite passes too; it is fully mocked and needs no services.

I could **not** run the `test-integration` CI job locally: it needs `LOCALSTACK_AUTH_TOKEN`, which comes from the staging GitHub environment and is not in my local config. That job runs `--filter @techops/events-tracker`, and this change is entirely in solana-tracker, but flagging it rather than implying it was covered.

## Verification after deploy

Staging is the live reproduction:

1. The repeating `poll error: ... not found` stack traces stop. Compare against the current 8926 per 6h bucket.
2. One re-seed warning per flip, naming the rejected cursor, replaces a stack trace every 2.7s.
3. `[ingestor] chain 103 enqueued block ...` keeps flowing at ~1322/h and CPU stays near 30m. The block path must not regress while the event path is fixed.
4. Prod chain 101 keeps its 0 poll errors per hour. Two watched programs makes it the real test of the isolation change.

## This does not close KEEP-1242 on its own

It makes the tracker survive the split route; it does not make chain 103 read the right cluster. **KEEP-1202 remains a hard prerequisite**, and re-enabling prod workflow `njxry0ryroltvgx6mleo7` stays gated on it.
