### PR TITLE
fix(billing): stop charging the last execution the free plan includes

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -258,6 +258,7 @@ async function executeProtocolAction(
     network,
     input: redactInput(withRejectedSignerOverride(body, body)),
     reserved: { kind: "evm", valueWei: parsedValue.valueWei },
+    paygOverflow: executionGuard.limitResult?.paygOverflow === true,
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(

--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -37,6 +37,11 @@ type ReserveExecutionParams = {
   reserved:
     | { kind: "evm"; valueWei: string }
     | { kind: "solana"; valueLamports: string };
+  // The PAYG verdict this request was admitted on, taken from the guard the
+  // route ran before anything was written. It cannot be re-derived after the
+  // reservation below, because the execution row is committed by then and
+  // counts towards the org's monthly usage.
+  paygOverflow: boolean;
 };
 
 type ReserveResult =
@@ -196,6 +201,7 @@ export async function checkAndReserveExecution(
   const charge = await chargePaygIfBillable({
     organizationId: params.organizationId,
     executionId: reserve.executionId,
+    paygOverflow: params.paygOverflow,
   });
   if (charge.applicable && !charge.ok) {
     await db

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -239,7 +239,8 @@ async function executeConditionalWrite(
   apiKeyId: string,
   fullBody: Record<string, unknown>,
   conditionResult: ConditionResult,
-  idem: IdempotencyOutcome | null
+  idem: IdempotencyOutcome | null,
+  paygOverflow: boolean
 ): Promise<NextResponse> {
   const walletError = await requireWallet(organizationId);
   if (walletError) {
@@ -259,6 +260,7 @@ async function executeConditionalWrite(
     // The conditional write never forwards native value (writeContractCore is
     // called without ethValue), so nothing is charged to the value cap here.
     reserved: { kind: "evm", valueWei: "0" },
+    paygOverflow,
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(
@@ -569,7 +571,8 @@ export async function POST(request: Request): Promise<NextResponse> {
       apiKeyCtx.apiKeyId,
       body,
       conditionResult,
-      idem
+      idem,
+      executionGuard.limitResult?.paygOverflow === true
     ),
     rateLimit
   );

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -140,7 +140,8 @@ async function handleWriteCall(
   resolvedAbi: string,
   organizationId: string,
   apiKeyId: string,
-  idem: IdempotencyOutcome | null
+  idem: IdempotencyOutcome | null,
+  paygOverflow: boolean
 ): Promise<NextResponse> {
   const walletError = await requireWallet(organizationId);
   if (walletError) {
@@ -168,6 +169,7 @@ async function handleWriteCall(
     network: body.network as string,
     input: redactedInput,
     reserved: { kind: "evm", valueWei: parsedValue.valueWei },
+    paygOverflow,
   });
   if (!reserve.allowed) {
     return recordIdempotentResponse(
@@ -418,7 +420,8 @@ export async function POST(request: Request): Promise<NextResponse> {
       resolvedAbi,
       apiKeyCtx.organizationId,
       apiKeyCtx.apiKeyId,
-      idem
+      idem,
+      executionGuard.limitResult?.paygOverflow === true
     ),
     rateLimit
   );

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -682,6 +682,7 @@ export async function POST(request: Request): Promise<NextResponse> {
         parsedValue.kind === "solana"
           ? { kind: "solana", valueLamports: parsedValue.valueLamports }
           : { kind: "evm", valueWei: parsedValue.valueWei },
+      paygOverflow: executionGuard.limitResult?.paygOverflow === true,
     });
     if (!reserve.allowed) {
       return applyRateLimitHeaders(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -250,6 +250,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     reserved: isSolanaTransfer
       ? { kind: "solana", valueLamports: reservedValueLamports }
       : { kind: "evm", valueWei: reservedValueWei },
+    paygOverflow: executionGuard.limitResult?.paygOverflow === true,
   });
   if (!reserve.allowed) {
     // Pre-broadcast gating failure: release so the same key can be retried.

--- a/app/api/mcp/workflows/[slug]/call/route.ts
+++ b/app/api/mcp/workflows/[slug]/call/route.ts
@@ -186,6 +186,7 @@ async function prepareExecution(
     const paygCharge = await chargePaygIfBillable({
       organizationId: workflow.organizationId,
       executionId: execution.id,
+      paygOverflow: executionGuard.limitResult?.paygOverflow === true,
     });
     if (paygCharge.applicable && !paygCharge.ok) {
       await db

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -324,6 +324,7 @@ export async function POST(
     const paygCharge = await chargePaygIfBillable({
       organizationId: workflow.organizationId,
       executionId,
+      paygOverflow: executionGuard.limitResult?.paygOverflow === true,
     });
     if (paygCharge.applicable && !paygCharge.ok) {
       await db

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -429,6 +429,7 @@ export async function POST(
     const paygCharge = await chargePaygIfBillable({
       organizationId: workflow.organizationId,
       executionId: execution.id,
+      paygOverflow: executionGuard.limitResult?.paygOverflow === true,
     });
     if (paygCharge.applicable && !paygCharge.ok) {
       await db

--- a/lib/billing/execution-guard.ts
+++ b/lib/billing/execution-guard.ts
@@ -2,11 +2,17 @@ import "server-only";
 
 import { NextResponse } from "next/server";
 import { isBillingEnabled } from "./feature-flag";
-import { checkExecutionLimit, type ExecutionLimitResult } from "./plans-server";
+import {
+  checkExecutionLimit,
+  type ExecutionLimitAllowed,
+} from "./plans-server";
 
 type GuardAllowed = {
   blocked: false;
-  limitResult: ExecutionLimitResult | null;
+  // Null when the check was skipped (billing off, or no org). Otherwise the
+  // verdict this request was admitted on, which the PAYG charge point reads
+  // instead of re-deriving it from a count that by then includes this run.
+  limitResult: ExecutionLimitAllowed | null;
 };
 
 type GuardBlocked = {

--- a/lib/billing/payg/charge.ts
+++ b/lib/billing/payg/charge.ts
@@ -1,15 +1,6 @@
 import "server-only";
 
-import { countMonthlyExecutionsForAdmission } from "@/lib/billing/execution-limit-core";
 import { isBillingEnabled } from "@/lib/billing/feature-flag";
-import {
-  getPlanLimits,
-  PLANS,
-  parsePlanName,
-  parseTierKey,
-} from "@/lib/billing/plans";
-import { getOrgSubscription } from "@/lib/billing/plans-server";
-import { db } from "@/lib/db";
 import { autopayForExecution } from "./autopay";
 import { type PaygBlockReason, paygBlockMessage } from "./errors";
 
@@ -22,40 +13,23 @@ export type PaygChargeMaybe =
   | ({ applicable: true } & PaygChargeResult);
 
 /**
- * Charge an execution only if it is billable under PAYG: billing is on, the org
- * is on the free plan, and it has already used its included monthly executions.
- * For the inline direct-execute routes, which do not know the billing state at
- * the charge point. Executions within the free bucket and non-free plans return
- * `applicable: false` and are not charged.
+ * Charge an execution only if it is billable under PAYG.
+ *
+ * `paygOverflow` is the verdict `checkExecutionLimit` already reached before
+ * this run's row was written: the org is on the free plan and its included
+ * monthly executions were spent before this one. The gate cannot re-derive that here, because the row for the
+ * run being decided is committed by now and a fresh count would include it,
+ * charging the last execution the plan includes. Everything else returns
+ * `applicable: false` and is not charged.
  */
 export async function chargePaygIfBillable(params: {
   organizationId: string;
   executionId: string;
+  paygOverflow: boolean;
 }): Promise<PaygChargeMaybe> {
   // With billing off there is no UI to read or set spend caps, so never move
   // money: the run proceeds unbilled rather than being blocked.
-  if (!isBillingEnabled()) {
-    return { applicable: false };
-  }
-  const sub = await getOrgSubscription(params.organizationId);
-  const plan = parsePlanName(sub?.plan);
-  if (plan !== "free") {
-    return { applicable: false };
-  }
-  const limits = getPlanLimits(
-    plan,
-    parseTierKey(sub?.tier),
-    sub?.planOverrides
-  );
-  const used = await countMonthlyExecutionsForAdmission(
-    db,
-    params.organizationId,
-    {
-      maxExecutionsPerMonth: limits.maxExecutionsPerMonth,
-      overageEnabled: PLANS[plan].overage.enabled,
-    }
-  );
-  if (used < limits.maxExecutionsPerMonth) {
+  if (!(isBillingEnabled() && params.paygOverflow)) {
     return { applicable: false };
   }
   const result = await chargePaygExecution(params);

--- a/lib/billing/plans-server.ts
+++ b/lib/billing/plans-server.ts
@@ -186,6 +186,7 @@ export async function checkFeatureAccess(
 export type ExecutionWithinLimits = {
   allowed: true;
   isOverage: false;
+  paygOverflow: false;
   debtExecutions: number;
   effectiveLimit: number;
 };
@@ -194,9 +195,27 @@ export type ExecutionWithinLimits = {
 export type ExecutionOverageAllowed = {
   allowed: true;
   isOverage: true;
+  paygOverflow: false;
   limit: number;
   used: number;
   overageRate: number;
+  debtExecutions: number;
+  effectiveLimit: number;
+};
+
+/**
+ * Free plan past its included limit -- execution proceeds only because PAYG
+ * charges it per execution downstream. The counterpart of the executor's
+ * PAYG_OVERFLOW_REASON: it is what tells the charge point this run is billable,
+ * so the verdict is computed once here rather than re-derived after the
+ * execution row is written.
+ */
+export type ExecutionPaygOverflow = {
+  allowed: true;
+  isOverage: false;
+  paygOverflow: true;
+  limit: number;
+  used: number;
   debtExecutions: number;
   effectiveLimit: number;
 };
@@ -211,9 +230,14 @@ export type ExecutionLimitExceeded = {
   effectiveLimit: number;
 };
 
-export type ExecutionLimitResult =
+/** Every verdict that lets the execution proceed. */
+export type ExecutionLimitAllowed =
   | ExecutionWithinLimits
   | ExecutionOverageAllowed
+  | ExecutionPaygOverflow;
+
+export type ExecutionLimitResult =
+  | ExecutionLimitAllowed
   | ExecutionLimitExceeded;
 
 /**
@@ -222,7 +246,9 @@ export type ExecutionLimitResult =
  * Returns one of:
  * - allowed + not overage (within limits or unlimited plan)
  * - allowed + overage (paid plan with overage enabled, will be billed later)
- * - not allowed (free plan limit exceeded)
+ * - allowed + paygOverflow (free plan past its included limit, charged per
+ *   execution downstream)
+ * - not allowed (free plan limit exceeded with billing off, or unpaid debt)
  *
  * NOTE: This is a point-in-time check (TOCTOU). The caller does not hold a lock,
  * so concurrent requests may each pass the check before any execution is recorded.
@@ -242,6 +268,7 @@ export async function checkExecutionLimit(
     return {
       allowed: true,
       isOverage: false,
+      paygOverflow: false,
       debtExecutions: 0,
       effectiveLimit: -1,
     };
@@ -287,6 +314,7 @@ export async function checkExecutionLimit(
       return {
         allowed: true,
         isOverage: false,
+        paygOverflow: false,
         debtExecutions,
         effectiveLimit,
       };
@@ -295,6 +323,7 @@ export async function checkExecutionLimit(
       return {
         allowed: true,
         isOverage: true,
+        paygOverflow: false,
         limit: limits.maxExecutionsPerMonth,
         used,
         overageRate: planDef.overage.ratePerThousand,
@@ -310,6 +339,9 @@ export async function checkExecutionLimit(
         return {
           allowed: true,
           isOverage: false,
+          paygOverflow: true,
+          limit: limits.maxExecutionsPerMonth,
+          used,
           debtExecutions,
           effectiveLimit,
         };

--- a/tests/unit/billing-execution-guard.test.ts
+++ b/tests/unit/billing-execution-guard.test.ts
@@ -15,6 +15,7 @@ import { isBillingEnabled } from "@/lib/billing/feature-flag";
 import type {
   ExecutionLimitExceeded,
   ExecutionOverageAllowed,
+  ExecutionPaygOverflow,
   ExecutionWithinLimits,
 } from "@/lib/billing/plans-server";
 import { checkExecutionLimit } from "@/lib/billing/plans-server";
@@ -56,6 +57,7 @@ describe("enforceExecutionLimit", () => {
     const withinLimits: ExecutionWithinLimits = {
       allowed: true,
       isOverage: false,
+      paygOverflow: false,
       debtExecutions: 0,
       effectiveLimit: 25_000,
     };
@@ -74,6 +76,7 @@ describe("enforceExecutionLimit", () => {
     const overageAllowed: ExecutionOverageAllowed = {
       allowed: true,
       isOverage: true,
+      paygOverflow: false,
       limit: 25_000,
       used: 30_000,
       overageRate: 2,
@@ -87,6 +90,29 @@ describe("enforceExecutionLimit", () => {
     expect(result.blocked).toBe(false);
     if (!result.blocked) {
       expect(result.limitResult).toEqual(overageAllowed);
+    }
+  });
+
+  // The charge point bills off this verdict rather than counting again, so the
+  // distinction between an in-bucket run and an overflow run has to survive.
+  it("passes the pay-as-you-go overflow verdict through", async () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    const overflow: ExecutionPaygOverflow = {
+      allowed: true,
+      isOverage: false,
+      paygOverflow: true,
+      limit: 5000,
+      used: 5000,
+      debtExecutions: 0,
+      effectiveLimit: 5000,
+    };
+    vi.mocked(checkExecutionLimit).mockResolvedValue(overflow);
+
+    const result = await enforceExecutionLimit("org_1");
+
+    expect(result.blocked).toBe(false);
+    if (!result.blocked) {
+      expect(result.limitResult?.paygOverflow).toBe(true);
     }
   });
 

--- a/tests/unit/billing-plans-server.test.ts
+++ b/tests/unit/billing-plans-server.test.ts
@@ -123,6 +123,7 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: false,
+      paygOverflow: false,
       debtExecutions: 0,
       effectiveLimit: -1,
     });
@@ -136,6 +137,24 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: false,
+      paygOverflow: false,
+      debtExecutions: 0,
+      effectiveLimit: 5000,
+    });
+  });
+
+  // The last run the plan includes. The count here is usage before this run, so
+  // 4999 prior executions means this one is number 5000 of 5000: included, and
+  // not flagged for the pay-as-you-go charge.
+  it("does not flag the last included execution as billable", async () => {
+    mockSelectReturning([]);
+    mockExecuteReturning([{ count: 4999 }]);
+
+    const result = await checkExecutionLimit("org_1");
+    expect(result).toEqual({
+      allowed: true,
+      isOverage: false,
+      paygOverflow: false,
       debtExecutions: 0,
       effectiveLimit: 5000,
     });
@@ -149,6 +168,7 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: false,
+      paygOverflow: false,
       debtExecutions: 0,
       effectiveLimit: 25_000,
     });
@@ -162,6 +182,7 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: true,
+      paygOverflow: false,
       limit: 25_000,
       used: 30_000,
       overageRate: 2,
@@ -180,6 +201,9 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: false,
+      paygOverflow: true,
+      limit: 5000,
+      used: 5000,
       debtExecutions: 0,
       effectiveLimit: 5000,
     });
@@ -193,6 +217,9 @@ describe("checkExecutionLimit", () => {
     expect(result).toEqual({
       allowed: true,
       isOverage: false,
+      paygOverflow: true,
+      limit: 5000,
+      used: 6000,
       debtExecutions: 0,
       effectiveLimit: 5000,
     });

--- a/tests/unit/payg-charge-gate.test.ts
+++ b/tests/unit/payg-charge-gate.test.ts
@@ -1,18 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
-vi.mock("@/lib/db", () => ({ db: {} }));
-
-const getOrgSubscription = vi.fn();
-vi.mock("@/lib/billing/plans-server", () => ({
-  getOrgSubscription: (...a: unknown[]) => getOrgSubscription(...a),
-}));
-
-const countMonthlyExecutionsForAdmission = vi.fn();
-vi.mock("@/lib/billing/execution-limit-core", () => ({
-  countMonthlyExecutionsForAdmission: (...a: unknown[]) =>
-    countMonthlyExecutionsForAdmission(...a),
-}));
 
 const autopayForExecution = vi.fn();
 vi.mock("@/lib/billing/payg/autopay", () => ({
@@ -22,15 +10,12 @@ vi.mock("@/lib/billing/payg/autopay", () => ({
 import { chargePaygIfBillable } from "@/lib/billing/payg/charge";
 
 const PARAMS = { organizationId: "org_1", executionId: "exec_1" };
-const FREE_LIMIT = 5000;
 
 const originalFlag = process.env.NEXT_PUBLIC_BILLING_ENABLED;
 
 beforeEach(() => {
   vi.clearAllMocks();
   process.env.NEXT_PUBLIC_BILLING_ENABLED = "true";
-  getOrgSubscription.mockResolvedValue({ plan: "free", tier: null });
-  countMonthlyExecutionsForAdmission.mockResolvedValue(FREE_LIMIT + 1);
   autopayForExecution.mockResolvedValue({ ok: true, txHash: "0xtx" });
 });
 
@@ -40,7 +25,10 @@ afterEach(() => {
 
 describe("chargePaygIfBillable gating", () => {
   it("charges a free org that is past its included executions", async () => {
-    const result = await chargePaygIfBillable(PARAMS);
+    const result = await chargePaygIfBillable({
+      ...PARAMS,
+      paygOverflow: true,
+    });
 
     expect(autopayForExecution).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ applicable: true, ok: true, txHash: "0xtx" });
@@ -51,26 +39,22 @@ describe("chargePaygIfBillable gating", () => {
   it("never charges when billing is disabled", async () => {
     process.env.NEXT_PUBLIC_BILLING_ENABLED = "false";
 
-    const result = await chargePaygIfBillable(PARAMS);
-
-    expect(autopayForExecution).not.toHaveBeenCalled();
-    expect(getOrgSubscription).not.toHaveBeenCalled();
-    expect(result).toEqual({ applicable: false });
-  });
-
-  it("does not charge a paid plan", async () => {
-    getOrgSubscription.mockResolvedValue({ plan: "pro", tier: "25k" });
-
-    const result = await chargePaygIfBillable(PARAMS);
+    const result = await chargePaygIfBillable({
+      ...PARAMS,
+      paygOverflow: true,
+    });
 
     expect(autopayForExecution).not.toHaveBeenCalled();
     expect(result).toEqual({ applicable: false });
   });
 
-  it("does not charge inside the included free bucket", async () => {
-    countMonthlyExecutionsForAdmission.mockResolvedValue(FREE_LIMIT - 1);
-
-    const result = await chargePaygIfBillable(PARAMS);
+  // Paid plans and runs inside the free bucket both reach here with the verdict
+  // the admission check already made, so neither is charged.
+  it("does not charge a run the admission check admitted as included", async () => {
+    const result = await chargePaygIfBillable({
+      ...PARAMS,
+      paygOverflow: false,
+    });
 
     expect(autopayForExecution).not.toHaveBeenCalled();
     expect(result).toEqual({ applicable: false });

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -28,6 +28,7 @@ const state = vi.hoisted(() => ({
     | { applicable: false }
     | { applicable: true; ok: true; txHash: string }
     | { applicable: true; ok: false; reason: string; message: string },
+  paygChargeCalls: [] as Record<string, unknown>[],
 }));
 
 // A cap-row insert carries nothing but the org id: lockOrgSpendCapRow creates
@@ -119,7 +120,10 @@ vi.mock("@/lib/db", () => ({
 // PAYG charge runs after a successful reservation. Value-cap tests keep it a
 // no-op (applicable: false); the PAYG-charge tests drive it via state.paygCharge.
 vi.mock("@/lib/billing/payg/charge", () => ({
-  chargePaygIfBillable: () => Promise.resolve(state.paygCharge),
+  chargePaygIfBillable: (params: Record<string, unknown>) => {
+    state.paygChargeCalls.push(params);
+    return Promise.resolve(state.paygCharge);
+  },
 }));
 
 import { checkAndReserveExecution } from "@/app/api/execute/_lib/spending-cap";
@@ -137,6 +141,8 @@ const baseParams = {
   type: "transfer",
   network: "1",
   input: { foo: "bar" },
+  // The admission verdict the route reached before anything was written.
+  paygOverflow: false,
 };
 
 beforeEach(() => {
@@ -149,6 +155,7 @@ beforeEach(() => {
   state.capInsertLosesRace = false;
   state.updated = [];
   state.paygCharge = { applicable: false };
+  state.paygChargeCalls = [];
 });
 
 describe("platform default cap figures", () => {
@@ -509,6 +516,7 @@ describe("checkAndReserveExecution PAYG charge", () => {
     const result = await checkAndReserveExecution({
       ...baseParams,
       reserved: { kind: "evm", valueWei: "0" },
+      paygOverflow: true,
     });
 
     expect(result).toEqual({ allowed: true, executionId: "exec_test" });
@@ -529,6 +537,7 @@ describe("checkAndReserveExecution PAYG charge", () => {
     const result = await checkAndReserveExecution({
       ...baseParams,
       reserved: { kind: "evm", valueWei: "0" },
+      paygOverflow: true,
     });
 
     expect(result).toEqual({ allowed: false, reason: message });
@@ -549,5 +558,26 @@ describe("checkAndReserveExecution PAYG charge", () => {
 
     expect(result).toEqual({ allowed: true, executionId: "exec_test" });
     expect(state.updated).toHaveLength(0);
+  });
+
+  // The reservation is committed before the charge, so the charge point can no
+  // longer tell an over-limit run from the last included one. It gets the
+  // verdict the route already reached instead.
+  it("hands the charge point the admission verdict rather than letting it recount", async () => {
+    await checkAndReserveExecution({
+      ...baseParams,
+      reserved: { kind: "evm", valueWei: "0" },
+      paygOverflow: false,
+    });
+    await checkAndReserveExecution({
+      ...baseParams,
+      reserved: { kind: "evm", valueWei: "0" },
+      paygOverflow: true,
+    });
+
+    expect(state.paygChargeCalls.map((c) => c.paygOverflow)).toEqual([
+      false,
+      true,
+    ]);
   });
 });

--- a/tests/unit/x402-call-route.test.ts
+++ b/tests/unit/x402-call-route.test.ts
@@ -389,6 +389,21 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
   it("Test 3b: charges the owner org before starting an MCP run (PAYG)", async () => {
     setupDbSelectWorkflow(FREE_WORKFLOW);
     setupDbInsertExecution("exec-payg-1");
+    // The admission verdict reached before the execution row was written. The
+    // charge point bills off this rather than counting again, since the count
+    // would by then include this run.
+    mockEnforceExecutionLimit.mockResolvedValue({
+      blocked: false,
+      limitResult: {
+        allowed: true,
+        isOverage: false,
+        paygOverflow: true,
+        limit: 5000,
+        used: 5000,
+        debtExecutions: 0,
+        effectiveLimit: 5000,
+      },
+    });
     mockChargePaygIfBillable.mockResolvedValue({
       applicable: true,
       ok: true,
@@ -403,6 +418,7 @@ describe("POST /api/mcp/workflows/[slug]/call", () => {
     expect(mockChargePaygIfBillable).toHaveBeenCalledWith({
       organizationId: "org-1",
       executionId: "exec-payg-1",
+      paygOverflow: true,
     });
     expect(response.status).toBe(200);
     // The run still starts once the charge settles.


### PR DESCRIPTION
Closes #2193

## What was wrong

The pay-as-you-go charge gate re-derived its own verdict by counting the org's monthly executions:

```ts
const used = await countMonthlyExecutionsForAdmission(...);
if (used < limits.maxExecutionsPerMonth) {
  return { applicable: false };
}
```

Every HTTP call site inserts and commits the execution row before reaching that point, and the count has no status predicate, so the row for the run being decided was already included. An org at 4999 executions of a 5000-execution plan read `used = 5000`, failed the `used < limit` test, and was charged for the last execution its plan includes. The included bucket was effectively 4999.

When the org's wallet could not cover the charge or a spend cap blocked it, that included run was not merely billed, it was refused:

```ts
if (charge.applicable && !charge.ok) {
  await db.update(directExecutions).set({ status: "failed", ... });
  return { allowed: false, reason: charge.message };
}
```

The executor already gets the boundary right: it charges off the pre-insert verdict (`PAYG_OVERFLOW_REASON`) and never re-counts. So the same execution number was free arriving from a schedule, block, or event trigger and charged arriving over HTTP. `lib/billing/overage.ts` and the admission check both treat run 5000 as included, so this was an internal disagreement rather than a pricing decision.

## The fix

Carry the verdict rather than recomputing it at a point where it can no longer be computed correctly.

- `checkExecutionLimit` returns a distinct `ExecutionPaygOverflow` result for the free-plan-over-limit branch, the counterpart of the executor's `PAYG_OVERFLOW_REASON`. Previously that branch returned the same `{ allowed: true, isOverage: false }` shape as a genuinely within-limit run, which is exactly why the gate had to re-count.
- The eight routes that already call `enforceExecutionLimit` before inserting pass `paygOverflow` from that verdict into `chargePaygIfBillable`, through `checkAndReserveExecution` for the direct-execute paths.
- The count, plan lookup and subscription read are gone from `chargePaygIfBillable`; it is now a two-condition gate on the billing flag and the verdict.

`used` now means usage before this run everywhere. The ordering dependency is removed rather than compensated for: changing `<` to `<=` would have encoded "the count includes me" into a helper whose other callers pass pre-insert counts.

## Behaviour change

One execution per org per month that was charged, or refused for lack of funds, is now free. No response shape, status code, unit, or default moves.

## Coverage

The boundary at `used === limit` was never tested, and the existing gate test mocked the count, so no test exercised the real post-insert value. Added:

- `checkExecutionLimit` at 4999 prior executions is an included run, at 5000 is billable
- `chargePaygIfBillable` charges on the verdict and never on a count
- the verdict is threaded through `checkAndReserveExecution` and the MCP call route

Full unit and integration suites pass. `tests/integration/reaper-sh-signing-contract.test.ts` and `tests/integration/workflow-runner.test.ts` fail identically on clean `staging` and are unrelated.