### PR TITLE
fix(execute): reject missing required protocol action params

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -38,37 +38,11 @@ import {
   redactInput,
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
+import { buildProtocolFunctionArgs } from "../_lib/protocol-function-args";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseNativeValueWei } from "../_lib/reserved-value";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { requireWallet } from "../_lib/wallet-check";
-
-function buildFunctionArgs(
-  input: Record<string, unknown>,
-  protocolSlug: string,
-  contractKey: string,
-  functionName: string
-): string | undefined {
-  const protocol = getProtocol(protocolSlug);
-  if (!protocol) {
-    return undefined;
-  }
-
-  const protocolAction = protocol.actions.find(
-    (a) => a.function === functionName && a.contract === contractKey
-  );
-
-  if (!protocolAction || protocolAction.inputs.length === 0) {
-    return undefined;
-  }
-
-  const args = protocolAction.inputs.map((inp) => {
-    const value = input[inp.name];
-    return value === undefined ? "" : String(value);
-  });
-
-  return JSON.stringify(args);
-}
 
 async function executeProtocolAction(
   actionType: string,
@@ -195,12 +169,29 @@ async function executeProtocolAction(
     );
   }
 
-  const functionArgs = buildFunctionArgs(
+  const argsResult = buildProtocolFunctionArgs(
     body,
     meta.protocolSlug,
     meta.contractKey,
     meta.functionName
   );
+  if (!argsResult.ok) {
+    // Pre-broadcast validation: release so the same key can retry with a
+    // complete body instead of caching a client mistake for 24h.
+    return recordIdempotentResponse(
+      idem,
+      NextResponse.json(
+        {
+          success: false,
+          error: argsResult.error,
+          field: argsResult.field,
+        },
+        { status: HttpStatus.BAD_REQUEST }
+      ),
+      "release"
+    );
+  }
+  const { functionArgs } = argsResult;
 
   if (meta.actionType === "read") {
     const coreInput: ReadContractCoreInput = {

--- a/app/api/execute/_lib/protocol-function-args.ts
+++ b/app/api/execute/_lib/protocol-function-args.ts
@@ -7,26 +7,28 @@ export type BuildProtocolFunctionArgsResult =
   | { ok: false; error: string; field: string };
 
 function isBlank(value: unknown): boolean {
-  return value === undefined || value === "";
+  return value === undefined || value === null || value === "";
 }
 
 function resolveInputValue(
   inp: ProtocolActionInput,
   raw: unknown
 ): { ok: true; value: string } | { ok: false; error: string; field: string } {
+  // Match buildInputField in lib/protocol-registry.ts:
+  // isRequired = required ?? (default === undefined). Reject blank required
+  // fields first; apply registry defaults only for optional blanks.
+  const isRequired = inp.required ?? inp.default === undefined;
+
   if (isBlank(raw)) {
-    if (inp.default !== undefined) {
-      return { ok: true, value: String(inp.default) };
-    }
-    // Match buildInputField in lib/protocol-registry.ts:
-    // required ?? (default === undefined)
-    const isRequired = inp.required ?? true;
     if (isRequired) {
       return {
         ok: false,
         field: inp.name,
         error: `Missing required field: ${inp.name}`,
       };
+    }
+    if (inp.default !== undefined) {
+      return { ok: true, value: String(inp.default) };
     }
     return { ok: true, value: "" };
   }

--- a/app/api/execute/_lib/protocol-function-args.ts
+++ b/app/api/execute/_lib/protocol-function-args.ts
@@ -1,0 +1,74 @@
+import "server-only";
+
+import { getProtocol, type ProtocolActionInput } from "@/lib/protocol-registry";
+
+export type BuildProtocolFunctionArgsResult =
+  | { ok: true; functionArgs: string | undefined }
+  | { ok: false; error: string; field: string };
+
+function isBlank(value: unknown): boolean {
+  return value === undefined || value === "";
+}
+
+function resolveInputValue(
+  inp: ProtocolActionInput,
+  raw: unknown
+): { ok: true; value: string } | { ok: false; error: string; field: string } {
+  if (isBlank(raw)) {
+    if (inp.default !== undefined) {
+      return { ok: true, value: String(inp.default) };
+    }
+    // Match buildInputField in lib/protocol-registry.ts:
+    // required ?? (default === undefined)
+    const isRequired = inp.required ?? true;
+    if (isRequired) {
+      return {
+        ok: false,
+        field: inp.name,
+        error: `Missing required field: ${inp.name}`,
+      };
+    }
+    return { ok: true, value: "" };
+  }
+
+  if (typeof raw === "object") {
+    return { ok: true, value: JSON.stringify(raw) };
+  }
+  return { ok: true, value: String(raw) };
+}
+
+/**
+ * Resolve protocol action ABI args for the direct-execute catch-all route.
+ * Applies registry defaults for blank fields and rejects required fields that
+ * are missing or empty instead of coercing them to "".
+ */
+export function buildProtocolFunctionArgs(
+  input: Record<string, unknown>,
+  protocolSlug: string,
+  contractKey: string,
+  functionName: string
+): BuildProtocolFunctionArgsResult {
+  const protocol = getProtocol(protocolSlug);
+  if (!protocol) {
+    return { ok: true, functionArgs: undefined };
+  }
+
+  const protocolAction = protocol.actions.find(
+    (a) => a.function === functionName && a.contract === contractKey
+  );
+
+  if (!protocolAction || protocolAction.inputs.length === 0) {
+    return { ok: true, functionArgs: undefined };
+  }
+
+  const args: string[] = [];
+  for (const inp of protocolAction.inputs) {
+    const resolved = resolveInputValue(inp, input[inp.name]);
+    if (!resolved.ok) {
+      return resolved;
+    }
+    args.push(resolved.value);
+  }
+
+  return { ok: true, functionArgs: JSON.stringify(args) };
+}

--- a/tests/unit/execute-protocol-required-params.test.ts
+++ b/tests/unit/execute-protocol-required-params.test.ts
@@ -217,6 +217,57 @@ describe("buildProtocolFunctionArgs", () => {
     });
   });
 
+  it("rejects null as a blank required field", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount" },
+        { name: "referralCode", default: "0" },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { asset: "0xToken", amount: null },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      field: "amount",
+      error: "Missing required field: amount",
+    });
+  });
+
+  it("rejects blank when required is true even if a default exists", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount", required: true, default: "0" },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { asset: "0xToken" },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      field: "amount",
+      error: "Missing required field: amount",
+    });
+  });
+
   it("allows blank when required is false and no default", async () => {
     getProtocolMock.mockReturnValue(
       protocolWithSupplyInputs([
@@ -351,6 +402,27 @@ describe("POST /api/execute/{protocol}/{action} required params", () => {
       expect.any(NextResponse),
       "release"
     );
+  });
+
+  it("returns 400 and does not broadcast when a required field is null", async () => {
+    const response = await postSupply({
+      chainId: 8453,
+      asset: "0xToken",
+      amount: null,
+    });
+    const body = (await response.json()) as {
+      success: boolean;
+      error: string;
+      field: string;
+    };
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error: "Missing required field: amount",
+      field: "amount",
+    });
+    expect(writeContractCoreMock).not.toHaveBeenCalled();
   });
 
   it("applies defaults and broadcasts when only optional fields are omitted", async () => {

--- a/tests/unit/execute-protocol-required-params.test.ts
+++ b/tests/unit/execute-protocol-required-params.test.ts
@@ -1,0 +1,370 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+const getProtocolMock = vi.fn();
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: (slug: string) => getProtocolMock(slug),
+  resolveContractAddress: (
+    contract: {
+      userSpecifiedAddress?: boolean;
+      addresses: Record<string, string>;
+    },
+    network: string,
+    providedAddress: string | undefined
+  ) =>
+    contract.userSpecifiedAddress
+      ? providedAddress
+      : contract.addresses[network],
+}));
+
+vi.mock("../../app/api/execute/_lib/auth", () => ({
+  validateApiKey: vi
+    .fn()
+    .mockResolvedValue({ organizationId: "org_1", apiKeyId: "key_1" }),
+}));
+
+vi.mock("../../app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn(),
+}));
+
+vi.mock("@/lib/abi/cache", () => ({
+  resolveAbi: vi.fn().mockResolvedValue({ abi: "[]", source: "definition" }),
+}));
+
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: vi.fn().mockReturnValue({
+    protocolSlug: "test-protocol",
+    contractKey: "pool",
+    functionName: "supply",
+    actionType: "write",
+  }),
+}));
+
+const writeContractCoreMock = vi.fn();
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: (input: unknown) => writeContractCoreMock(input),
+}));
+
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: vi.fn(),
+}));
+
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: {
+    "test-protocol/supply": () => Promise.resolve({}),
+  },
+}));
+
+const enforceExecutionLimitMock = vi.fn();
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: (orgId: string) => enforceExecutionLimitMock(orgId),
+}));
+
+const requireWalletMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: (orgId: string) => requireWalletMock(orgId),
+}));
+
+const checkAndReserveExecutionMock = vi.fn();
+vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: (params: unknown) =>
+    checkAndReserveExecutionMock(params),
+}));
+
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../app/api/execute/_lib/execution-service", () => ({
+  markRunning: vi.fn(),
+  completeExecution: vi.fn().mockResolvedValue({ status: "completed" }),
+  failExecution: vi.fn(),
+  redactInput: (x: unknown) => x,
+  withRejectedSignerOverride: (a: unknown) => a,
+}));
+
+const recordIdempotentResponseMock = vi.fn(
+  (_outcome: unknown, response: Response, _disposition?: string) =>
+    Promise.resolve(response)
+);
+vi.mock("@/lib/idempotency", () => ({
+  beginIdempotentFromRequest: vi.fn().mockResolvedValue({ kind: "proceed" }),
+  idempotencyEarlyResponse: vi.fn().mockReturnValue(null),
+  recordIdempotentResponse: (
+    outcome: unknown,
+    response: Response,
+    disposition?: string
+  ) => recordIdempotentResponseMock(outcome, response, disposition),
+  withIdempotencyHeartbeat: (_outcome: unknown, fn: () => unknown) => fn(),
+}));
+
+function protocolWithSupplyInputs(
+  inputs: Array<{
+    name: string;
+    type?: string;
+    label?: string;
+    default?: string;
+    required?: boolean;
+  }>
+) {
+  return {
+    contracts: { pool: { addresses: { "8453": "0xPool" } } },
+    actions: [
+      {
+        function: "supply",
+        contract: "pool",
+        inputs: inputs.map((inp) => ({
+          type: "uint256",
+          label: inp.name,
+          ...inp,
+        })),
+      },
+    ],
+  };
+}
+
+describe("buildProtocolFunctionArgs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a missing required field", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount" },
+        { name: "referralCode", default: "0" },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { asset: "0xToken" },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      field: "amount",
+      error: "Missing required field: amount",
+    });
+  });
+
+  it("applies registry defaults for blank optional fields", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount" },
+        { name: "referralCode", default: "0" },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { asset: "0xToken", amount: "1000" },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      functionArgs: JSON.stringify(["0xToken", "1000", "0"]),
+    });
+  });
+
+  it("returns ok when all required fields are present", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount" },
+        { name: "onBehalfOf" },
+        { name: "referralCode", default: "0" },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      {
+        asset: "0xToken",
+        amount: "1000",
+        onBehalfOf: "0xUser",
+        referralCode: "7",
+      },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      functionArgs: JSON.stringify(["0xToken", "1000", "0xUser", "7"]),
+    });
+  });
+
+  it("allows blank when required is false and no default", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "note", required: false },
+      ])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { asset: "0xToken" },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      functionArgs: JSON.stringify(["0xToken", ""]),
+    });
+  });
+
+  it("returns undefined functionArgs when the action has no inputs", async () => {
+    getProtocolMock.mockReturnValue({
+      contracts: { pool: { addresses: { "8453": "0xPool" } } },
+      actions: [{ function: "supply", contract: "pool", inputs: [] }],
+    });
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      {},
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({ ok: true, functionArgs: undefined });
+  });
+
+  it("JSON-stringifies object values", async () => {
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([{ name: "path" }])
+    );
+
+    const { buildProtocolFunctionArgs } = await import(
+      "@/app/api/execute/_lib/protocol-function-args"
+    );
+    const result = buildProtocolFunctionArgs(
+      { path: ["0xA", "0xB"] },
+      "test-protocol",
+      "pool",
+      "supply"
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      functionArgs: JSON.stringify([JSON.stringify(["0xA", "0xB"])]),
+    });
+  });
+});
+
+describe("POST /api/execute/{protocol}/{action} required params", () => {
+  async function postSupply(body: Record<string, unknown>): Promise<Response> {
+    const { POST } = await import("@/app/api/execute/[...slug]/route");
+    const req = new Request("http://test/api/execute/test-protocol/supply", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer x",
+        "idempotency-key": "idem_required_params",
+      },
+    });
+    return POST(req, {
+      params: Promise.resolve({ slug: ["test-protocol", "supply"] }),
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProtocolMock.mockReturnValue(
+      protocolWithSupplyInputs([
+        { name: "asset" },
+        { name: "amount" },
+        { name: "referralCode", default: "0" },
+      ])
+    );
+    enforceExecutionLimitMock.mockResolvedValue({ blocked: false });
+    requireWalletMock.mockResolvedValue(null);
+    checkAndReserveExecutionMock.mockResolvedValue({
+      allowed: true,
+      executionId: "exec_1",
+    });
+    writeContractCoreMock.mockResolvedValue({
+      success: true,
+      transactionHash: "0xtx",
+      chainId: 8453,
+      transactionLink: "https://scan/0xtx",
+      gasUsed: "21000",
+      effectiveGasPrice: "1000000000",
+    });
+    recordIdempotentResponseMock.mockImplementation(
+      (_outcome: unknown, response: Response, _disposition?: string) =>
+        Promise.resolve(response)
+    );
+  });
+
+  it("returns 400 and does not broadcast when a required field is missing", async () => {
+    const response = await postSupply({
+      chainId: 8453,
+      asset: "0xToken",
+    });
+    const body = (await response.json()) as {
+      success: boolean;
+      error: string;
+      field: string;
+    };
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error: "Missing required field: amount",
+      field: "amount",
+    });
+    expect(writeContractCoreMock).not.toHaveBeenCalled();
+    expect(recordIdempotentResponseMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(NextResponse),
+      "release"
+    );
+  });
+
+  it("applies defaults and broadcasts when only optional fields are omitted", async () => {
+    const response = await postSupply({
+      chainId: 8453,
+      asset: "0xToken",
+      amount: "1000",
+    });
+
+    expect(response.status).toBe(200);
+    expect(writeContractCoreMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionArgs: JSON.stringify(["0xToken", "1000", "0"]),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Validate required protocol action inputs before encode/broadcast (HTTP 400 + field name when missing)
- Apply registry defaults instead of coercing missing values to empty strings
- Fixes #2205

## Test plan
- [ ] `pnpm exec vitest run tests/unit/execute-protocol-required-params.test.ts`
- [ ] Missing required param → 400 with `field`
- [ ] Registry default applied when defined
- [ ] All required present → proceeds past validation