### PR TITLE
fix(mcp): forward idempotency_key for execute_protocol_action

### DIFF
--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -2418,7 +2418,7 @@ export function registerMetaTools(
   // Meta-tool 2: Execute any protocol action by actionType
   server.tool(
     "execute_protocol_action",
-    "Execute a DeFi protocol action directly. Use search_protocol_actions first to discover available actions and their required parameters. The actionType follows the format 'protocol/action-slug' (e.g., 'chronicle/eth-usd-read', 'aave-v3/supply', 'morpho/get-position'). Pass all required parameters in the params object.",
+    "Execute a DeFi protocol action directly. Use search_protocol_actions first to discover available actions and their required parameters. The actionType follows the format 'protocol/action-slug' (e.g., 'chronicle/eth-usd-read', 'aave-v3/supply', 'morpho/get-position'). Pass all required parameters in the params object. For writes, pass idempotency_key and retry with the same key when the previous attempt's outcome is unknown (e.g. after a timeout).",
     {
       actionType: z
         .string()
@@ -2430,6 +2430,7 @@ export function registerMetaTools(
         .describe(
           "Action parameters as key-value pairs (e.g., {network: '1', address: '0x...'}). Use search_protocol_actions to discover required params."
         ),
+      idempotency_key: IDEMPOTENCY_KEY_ARG,
     },
     // actionType selects both reads (chronicle/eth-usd-read) and writes
     // (aave-v3/supply) through one entry point, and a static annotation
@@ -2467,7 +2468,7 @@ export function registerMetaTools(
           `/api/execute/${integration}/${slug}`,
           "POST",
           args.params as Record<string, unknown>,
-          undefined,
+          args.idempotency_key,
           NO_MCP_FETCH_TIMEOUT
         );
 

--- a/tests/unit/mcp-execute-protocol-idempotency.test.ts
+++ b/tests/unit/mcp-execute-protocol-idempotency.test.ts
@@ -1,0 +1,117 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
+import { registerMetaTools } from "@/lib/mcp/tools";
+
+type RegisteredTool = {
+  name: string;
+  description: string;
+  schema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+};
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+let fetchMock: FetchMock;
+
+function registerExecuteProtocolTool(): RegisteredTool {
+  const registeredTools: RegisteredTool[] = [];
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        description: string,
+        schema: Record<string, unknown>,
+        _annotations: Record<string, unknown>,
+        handler: RegisteredTool["handler"]
+      ) => {
+        registeredTools.push({ name, description, schema, handler });
+      }
+    ),
+  } as unknown as McpServer;
+
+  registerMetaTools(server, "http://internal", "Bearer test", SCOPE_MCP_WRITE);
+
+  const tool = registeredTools.find(
+    (registered) => registered.name === "execute_protocol_action"
+  );
+  if (!tool) {
+    throw new Error("execute_protocol_action not registered");
+  }
+  return tool;
+}
+
+function lastFetchInit(): RequestInit {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error("fetch was not called");
+  }
+  return call[1] as RequestInit;
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: { get: () => "application/json" },
+      json: () => Promise.resolve({ success: true }),
+      text: () => Promise.resolve("{}"),
+    })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("execute_protocol_action idempotency", () => {
+  it("registers an optional idempotency_key and mentions retry-with-same-key", () => {
+    const tool = registerExecuteProtocolTool();
+
+    expect(tool.schema).toHaveProperty("idempotency_key");
+    expect(tool.description.toLowerCase()).toContain("idempotency_key");
+  });
+
+  it("forwards idempotency_key as Idempotency-Key and does not put it in the body", async () => {
+    const tool = registerExecuteProtocolTool();
+    const params = { chainId: 8453, amount: "1000" };
+
+    await tool.handler({
+      actionType: "aave-v3/supply",
+      params,
+      idempotency_key: "protocol-key-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toBe("http://internal/api/execute/aave-v3/supply");
+
+    const init = lastFetchInit();
+    expect(init.headers).toMatchObject({
+      "Idempotency-Key": "protocol-key-1",
+    });
+    expect(init.signal).toBeUndefined();
+    expect(JSON.parse(String(init.body))).toEqual(params);
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("idempotency_key");
+  });
+
+  it("omits Idempotency-Key when idempotency_key is not provided", async () => {
+    const tool = registerExecuteProtocolTool();
+
+    await tool.handler({
+      actionType: "chronicle/eth-usd-read",
+      params: { chainId: 1 },
+    });
+
+    const init = lastFetchInit();
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Idempotency-Key"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `idempotency_key` to `execute_protocol_action` MCP tool schema
- Forward `Idempotency-Key` via `callApi` (no longer passes `undefined`)
- Fixes #2207

## Test plan
- [ ] `pnpm exec vitest run tests/unit/mcp-execute-protocol-idempotency.test.ts`
- [ ] Tool schema includes `idempotency_key`
- [ ] Same key retry does not start a second protocol write
