### PR TITLE
fix(executor): stop For Each continuation after iteration failure

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2033,6 +2033,15 @@ export function planIterationContinuation(
 
 export type ForEachIterationFailure = { success: false; error: string };
 
+export type ForEachIterationSummary = {
+  arrayLength: number;
+  maxIterations: number;
+  iterationsRan: number;
+  failedIterations: number;
+  firstFailureError?: string;
+  firstFailureNodeId?: string;
+};
+
 /**
  * First failed iteration result, if any. Used to flip the For Each log and
  * to gate post-loop Collect / done-targets continuation.
@@ -2577,7 +2586,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         forEachNode: nestedForEachNode,
         processedConfig,
       }) => {
-        await handleForEachExecution({
+        return await handleForEachExecution({
           forEachNodeId: nestedForEachNodeId,
           forEachNode: nestedForEachNode,
           processedConfig,
@@ -2642,14 +2651,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       fromNodeId: string,
       targets: string[]
     ) => Promise<void>;
-  }): Promise<{
-    arrayLength: number;
-    maxIterations: number;
-    iterationsRan: number;
-    failedIterations: number;
-    firstFailureError?: string;
-    firstFailureNodeId?: string;
-  }> {
+  }): Promise<ForEachIterationSummary> {
     const {
       forEachNodeId,
       forEachNode,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -105,8 +105,7 @@ import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
 
-export type { ForEachIterationFailure };
-export { isForEachBodyFailureResult };
+export { isForEachBodyFailureResult, type ForEachIterationFailure };
 
 // System actions that don't have plugins - maps to module import functions.
 // `satisfies Record<SystemActionType, ...>` makes the dispatch table and the

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -94,11 +94,19 @@ import {
   preValidateConditionExpression,
   validateConditionExpression,
 } from "@/lib/workflow/nodes/condition/validator";
+import {
+  FOR_EACH_BODY_FAILURE_MARKER,
+  type ForEachIterationFailure,
+  isForEachBodyFailureResult,
+} from "@/lib/workflow/nodes/for-each/iteration-failure";
 import { ARRAY_SOURCE_RE } from "@/lib/workflow/nodes/for-each/utils";
 import { triggerStep } from "@/lib/workflow/nodes/trigger/step";
 import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
+
+export type { ForEachIterationFailure };
+export { isForEachBodyFailureResult };
 
 // System actions that don't have plugins - maps to module import functions.
 // `satisfies Record<SystemActionType, ...>` makes the dispatch table and the
@@ -2031,13 +2039,6 @@ export function planIterationContinuation(
   return { kind: "none" };
 }
 
-export type ForEachIterationFailure = {
-  __forEachBodyFailure: true;
-  success: false;
-  error: string;
-  nodeId?: string;
-};
-
 export type ForEachIterationSummary = {
   arrayLength: number;
   maxIterations: number;
@@ -2046,17 +2047,6 @@ export type ForEachIterationSummary = {
   firstFailureError?: string;
   firstFailureNodeId?: string;
 };
-
-function isForEachBodyFailureResult(
-  result: unknown
-): result is ForEachIterationFailure {
-  return (
-    result !== null &&
-    typeof result === "object" &&
-    "__forEachBodyFailure" in (result as object) &&
-    (result as { __forEachBodyFailure?: unknown }).__forEachBodyFailure === true
-  );
-}
 
 /**
  * First failed iteration result, if any. Used to flip the For Each log and
@@ -2083,16 +2073,25 @@ export function markCollectSkippedOnForEachFailure(params: {
   collectNodeId: string | undefined;
   doneCollectNodeId: string | undefined;
   error: string;
+  iterationResults: unknown[];
   currentVisited: Set<string>;
   currentResults: Record<
     string,
     { success: boolean; error?: string; data?: unknown }
   >;
+  attemptedNodes: Set<string>;
 }): void {
+  const skipData = {
+    results: params.iterationResults,
+    count: params.iterationResults.length,
+    skipped: true as const,
+  };
   params.currentVisited.add(params.aggregateCollectNodeId);
+  params.attemptedNodes.add(params.aggregateCollectNodeId);
   params.currentResults[params.aggregateCollectNodeId] = {
     success: false,
     error: params.error,
+    data: skipData,
   };
 
   if (
@@ -2101,6 +2100,7 @@ export function markCollectSkippedOnForEachFailure(params: {
     params.collectNodeId !== params.doneCollectNodeId
   ) {
     params.currentVisited.add(params.collectNodeId);
+    params.attemptedNodes.add(params.collectNodeId);
   }
 }
 
@@ -2127,6 +2127,57 @@ export async function dispatchForEachPostLoopIfNeeded(params: {
     return "done-targets";
   }
   return "none";
+}
+
+export type ForEachPostLoopResult =
+  | "skipped"
+  | "aggregate-collect"
+  | "done-targets"
+  | "none";
+
+/**
+ * Dispatch post-loop continuation, or mark Collect skipped with an explicit
+ * result so the parent DAG cannot re-fire it and execution output still has
+ * a `data` payload.
+ */
+export async function settleForEachPostLoop(params: {
+  firstIterationFailure: ForEachIterationFailure | undefined;
+  continuation: IterationContinuation;
+  onAggregateCollect: (collectNodeId: string) => Promise<void>;
+  onDoneTargets: (targets: string[]) => Promise<void>;
+  collectNodeId: string | undefined;
+  doneCollectNodeId: string | undefined;
+  iterationResults: unknown[];
+  currentVisited: Set<string>;
+  currentResults: Record<
+    string,
+    { success: boolean; error?: string; data?: unknown }
+  >;
+  attemptedNodes: Set<string>;
+}): Promise<ForEachPostLoopResult> {
+  const postLoopResult = await dispatchForEachPostLoopIfNeeded({
+    firstIterationFailure: params.firstIterationFailure,
+    continuation: params.continuation,
+    onAggregateCollect: params.onAggregateCollect,
+    onDoneTargets: params.onDoneTargets,
+  });
+  if (
+    postLoopResult === "skipped" &&
+    params.continuation.kind === "aggregate-collect" &&
+    params.firstIterationFailure
+  ) {
+    markCollectSkippedOnForEachFailure({
+      aggregateCollectNodeId: params.continuation.collectNodeId,
+      collectNodeId: params.collectNodeId,
+      doneCollectNodeId: params.doneCollectNodeId,
+      error: params.firstIterationFailure.error,
+      iterationResults: params.iterationResults,
+      currentVisited: params.currentVisited,
+      currentResults: params.currentResults,
+      attemptedNodes: params.attemptedNodes,
+    });
+  }
+  return postLoopResult;
 }
 
 /**
@@ -2821,11 +2872,11 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           `[Workflow Executor] For Each "${getNodeName(forEachNode)}" iteration ${index} failed at node "${getNodeName(nodeMap.get(bodyFailure[0]) ?? forEachNode)}" (${bodyFailure[0]}): ${bodyFailure[1].error}`
         );
         return {
-          __forEachBodyFailure: true as const,
-          success: false as const,
+          [FOR_EACH_BODY_FAILURE_MARKER]: true,
+          success: false,
           error: bodyFailure[1].error ?? "Body node failed",
           nodeId: bodyFailure[0],
-        };
+        } satisfies ForEachIterationFailure;
       }
 
       // Capture output from the last body node(s) that produced data.
@@ -2914,7 +2965,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     //                      (no aggregation injection).
     //   none:              fire-and-forget loop, nothing to do here.
     // Any failed iteration skips this block entirely (no Collect / downstream).
-    const postLoopResult = await dispatchForEachPostLoopIfNeeded({
+    await settleForEachPostLoop({
       firstIterationFailure,
       continuation,
       onAggregateCollect: async (aggregateCollectNodeId) => {
@@ -2977,22 +3028,13 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           await continueWithDoneTargets(forEachNodeId, targets);
         }
       },
+      collectNodeId,
+      doneCollectNodeId,
+      iterationResults,
+      currentVisited,
+      currentResults,
+      attemptedNodes,
     });
-
-    if (
-      postLoopResult === "skipped" &&
-      continuation.kind === "aggregate-collect" &&
-      firstIterationFailure
-    ) {
-      markCollectSkippedOnForEachFailure({
-        aggregateCollectNodeId: continuation.collectNodeId,
-        collectNodeId,
-        doneCollectNodeId,
-        error: firstIterationFailure.error,
-        currentVisited,
-        currentResults,
-      });
-    }
 
     return {
       arrayLength: resolvedArray.length,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -106,8 +106,8 @@ import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
 
 export {
-  isForEachBodyFailureResult,
   type ForEachIterationFailure,
+  isForEachBodyFailureResult,
 } from "@/lib/workflow/nodes/for-each/iteration-failure";
 
 // System actions that don't have plugins - maps to module import functions.
@@ -2051,6 +2051,18 @@ export type ForEachIterationSummary = {
 };
 
 /**
+ * Prefer a nested For Each summary's firstFailureNodeId over the bodyResults
+ * key. Insertion order records the nested loop id before routeAfterSuccess
+ * overwrites the entry with data: summary.
+ */
+export function resolveBodyFailureNodeId(
+  bodyFailure: [string, { success: boolean; error?: string; data?: unknown }]
+): string {
+  const summary = bodyFailure[1].data as ForEachIterationSummary | undefined;
+  return summary?.firstFailureNodeId ?? bodyFailure[0];
+}
+
+/**
  * First failed iteration result, if any. Used to flip the For Each log and
  * to gate post-loop Collect / done-targets continuation.
  */
@@ -2085,7 +2097,9 @@ export function markCollectSkippedOnForEachFailure(params: {
 }): void {
   const skipData = {
     results: params.iterationResults.map((result) =>
-      isForEachBodyFailureResult(result) ? result.error : result
+      isForEachBodyFailureResult(result)
+        ? { error: result.error, nodeId: result.nodeId }
+        : result
     ),
     count: params.iterationResults.length,
     skipped: true as const,
@@ -2108,6 +2122,12 @@ export function markCollectSkippedOnForEachFailure(params: {
   }
 }
 
+export type ForEachPostLoopResult =
+  | "skipped"
+  | "aggregate-collect"
+  | "done-targets"
+  | "none";
+
 /**
  * Dispatch Collect aggregation or done-targets after runIterations.
  * Skips entirely when any iteration failed so downstream side effects
@@ -2118,7 +2138,7 @@ async function dispatchForEachPostLoopIfNeeded(params: {
   continuation: IterationContinuation;
   onAggregateCollect: (collectNodeId: string) => Promise<void>;
   onDoneTargets: (targets: string[]) => Promise<void>;
-}): Promise<"skipped" | "aggregate-collect" | "done-targets" | "none"> {
+}): Promise<ForEachPostLoopResult> {
   if (params.firstIterationFailure) {
     return "skipped";
   }
@@ -2132,12 +2152,6 @@ async function dispatchForEachPostLoopIfNeeded(params: {
   }
   return "none";
 }
-
-export type ForEachPostLoopResult =
-  | "skipped"
-  | "aggregate-collect"
-  | "done-targets"
-  | "none";
 
 /**
  * Dispatch post-loop continuation, or mark Collect skipped with an explicit
@@ -2872,14 +2886,15 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         ([, r]) => !r.success
       );
       if (bodyFailure) {
+        const failureNodeId = resolveBodyFailureNodeId(bodyFailure);
         console.log(
-          `[Workflow Executor] For Each "${getNodeName(forEachNode)}" iteration ${index} failed at node "${getNodeName(nodeMap.get(bodyFailure[0]) ?? forEachNode)}" (${bodyFailure[0]}): ${bodyFailure[1].error}`
+          `[Workflow Executor] For Each "${getNodeName(forEachNode)}" iteration ${index} failed at node "${getNodeName(nodeMap.get(failureNodeId) ?? forEachNode)}" (${failureNodeId}): ${bodyFailure[1].error}`
         );
         return {
           [FOR_EACH_BODY_FAILURE_MARKER]: true,
           success: false,
           error: bodyFailure[1].error ?? "Body node failed",
-          nodeId: bodyFailure[0],
+          nodeId: failureNodeId,
         } satisfies ForEachIterationFailure;
       }
 

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2031,6 +2031,49 @@ export function planIterationContinuation(
   return { kind: "none" };
 }
 
+export type ForEachIterationFailure = { success: false; error: string };
+
+/**
+ * First failed iteration result, if any. Used to flip the For Each log and
+ * to gate post-loop Collect / done-targets continuation.
+ */
+export function findFirstIterationFailure(
+  iterationResults: unknown[]
+): ForEachIterationFailure | undefined {
+  return iterationResults.find(
+    (r): r is ForEachIterationFailure =>
+      r !== null &&
+      typeof r === "object" &&
+      "success" in (r as object) &&
+      (r as { success: unknown }).success === false
+  );
+}
+
+/**
+ * Dispatch Collect aggregation or done-targets after runIterations.
+ * Skips entirely when any iteration failed so downstream side effects
+ * (transfers, webhooks) do not fire after a failed loop body.
+ */
+export async function dispatchForEachPostLoopIfNeeded(params: {
+  firstIterationFailure: ForEachIterationFailure | undefined;
+  continuation: IterationContinuation;
+  onAggregateCollect: (collectNodeId: string) => Promise<void>;
+  onDoneTargets: (targets: string[]) => Promise<void>;
+}): Promise<"skipped" | "aggregate-collect" | "done-targets" | "none"> {
+  if (params.firstIterationFailure) {
+    return "skipped";
+  }
+  if (params.continuation.kind === "aggregate-collect") {
+    await params.onAggregateCollect(params.continuation.collectNodeId);
+    return "aggregate-collect";
+  }
+  if (params.continuation.kind === "done-targets") {
+    await params.onDoneTargets(params.continuation.targets);
+    return "done-targets";
+  }
+  return "none";
+}
+
 /**
  * Resolve a template string to its raw array value.
  * Accepts {{@nodeId:Label.field}} syntax or a JSON array literal.
@@ -2796,13 +2839,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
 
     // 5a. If any iteration failed, flip the For Each node's own log row to error
     // so the UI can surface which step errored rather than showing all green.
-    const firstIterationFailure = iterationResults.find(
-      (r): r is { success: false; error: string } =>
-        r !== null &&
-        typeof r === "object" &&
-        "success" in (r as object) &&
-        (r as { success: unknown }).success === false
-    );
+    const firstIterationFailure = findFirstIterationFailure(iterationResults);
     if (firstIterationFailure && executionId) {
       await triggerStep({
         triggerData: {},
@@ -2828,67 +2865,71 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     //                      ordinary post-loop steps via continueWithDoneTargets
     //                      (no aggregation injection).
     //   none:              fire-and-forget loop, nothing to do here.
-    if (continuation.kind === "aggregate-collect") {
-      const aggregateCollectNodeId = continuation.collectNodeId;
-      const collectData = {
-        results: iterationResults,
-        count: iterationResults.length,
-      };
-      const sanitizedCollectId = aggregateCollectNodeId.replace(
-        /[^a-zA-Z0-9]/g,
-        "_"
-      );
-      const collectNode = nodeMap.get(aggregateCollectNodeId);
-      const collectLabel = collectNode ? getNodeName(collectNode) : "Collect";
+    // Any failed iteration skips this block entirely (no Collect / downstream).
+    await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure,
+      continuation,
+      onAggregateCollect: async (aggregateCollectNodeId) => {
+        const collectData = {
+          results: iterationResults,
+          count: iterationResults.length,
+        };
+        const sanitizedCollectId = aggregateCollectNodeId.replace(
+          /[^a-zA-Z0-9]/g,
+          "_"
+        );
+        const collectNode = nodeMap.get(aggregateCollectNodeId);
+        const collectLabel = collectNode ? getNodeName(collectNode) : "Collect";
 
-      const collectAction = SYSTEM_ACTIONS.Collect;
-      if (collectAction) {
-        const mod = await collectAction.importer();
-        await mod[collectAction.stepFunction]({
-          ...collectData,
-          _context: {
-            executionId,
-            nodeId: aggregateCollectNodeId,
-            nodeName: collectLabel,
-            nodeType: "Collect",
-            forEachNodeId,
-            organizationId,
-            orgSlug: organizationSlug,
-            createdBy,
-            workflowId,
-          } satisfies StepContext,
-        });
-      }
+        const collectAction = SYSTEM_ACTIONS.Collect;
+        if (collectAction) {
+          const mod = await collectAction.importer();
+          await mod[collectAction.stepFunction]({
+            ...collectData,
+            _context: {
+              executionId,
+              nodeId: aggregateCollectNodeId,
+              nodeName: collectLabel,
+              nodeType: "Collect",
+              forEachNodeId,
+              organizationId,
+              orgSlug: organizationSlug,
+              createdBy,
+              workflowId,
+            } satisfies StepContext,
+          });
+        }
 
-      currentOutputs[sanitizedCollectId] = {
-        label: collectLabel,
-        data: collectData,
-      };
-      currentResults[aggregateCollectNodeId] = {
-        success: true,
-        data: collectData,
-      };
-      currentVisited.add(aggregateCollectNodeId);
+        currentOutputs[sanitizedCollectId] = {
+          label: collectLabel,
+          data: collectData,
+        };
+        currentResults[aggregateCollectNodeId] = {
+          success: true,
+          data: collectData,
+        };
+        currentVisited.add(aggregateCollectNodeId);
 
-      // Skip the legacy in-body Collect in mixed wiring: don't re-fire it,
-      // but mark it visited so the parent DAG dispatcher leaves it alone.
-      if (
-        doneCollectNodeId &&
-        collectNodeId &&
-        collectNodeId !== doneCollectNodeId
-      ) {
-        currentVisited.add(collectNodeId);
-      }
+        // Skip the legacy in-body Collect in mixed wiring: don't re-fire it,
+        // but mark it visited so the parent DAG dispatcher leaves it alone.
+        if (
+          doneCollectNodeId &&
+          collectNodeId &&
+          collectNodeId !== doneCollectNodeId
+        ) {
+          currentVisited.add(collectNodeId);
+        }
 
-      if (continueAfterCollect) {
-        await continueAfterCollect(aggregateCollectNodeId);
-      }
-    } else if (
-      continuation.kind === "done-targets" &&
-      continueWithDoneTargets
-    ) {
-      await continueWithDoneTargets(forEachNodeId, continuation.targets);
-    }
+        if (continueAfterCollect) {
+          await continueAfterCollect(aggregateCollectNodeId);
+        }
+      },
+      onDoneTargets: async (targets) => {
+        if (continueWithDoneTargets) {
+          await continueWithDoneTargets(forEachNodeId, targets);
+        }
+      },
+    });
 
     return {
       arrayLength: resolvedArray.length,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2031,7 +2031,12 @@ export function planIterationContinuation(
   return { kind: "none" };
 }
 
-export type ForEachIterationFailure = { success: false; error: string };
+export type ForEachIterationFailure = {
+  __forEachBodyFailure: true;
+  success: false;
+  error: string;
+  nodeId?: string;
+};
 
 export type ForEachIterationSummary = {
   arrayLength: number;
@@ -2042,6 +2047,17 @@ export type ForEachIterationSummary = {
   firstFailureNodeId?: string;
 };
 
+function isForEachBodyFailureResult(
+  result: unknown
+): result is ForEachIterationFailure {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    "__forEachBodyFailure" in (result as object) &&
+    (result as { __forEachBodyFailure?: unknown }).__forEachBodyFailure === true
+  );
+}
+
 /**
  * First failed iteration result, if any. Used to flip the For Each log and
  * to gate post-loop Collect / done-targets continuation.
@@ -2049,13 +2065,43 @@ export type ForEachIterationSummary = {
 export function findFirstIterationFailure(
   iterationResults: unknown[]
 ): ForEachIterationFailure | undefined {
-  return iterationResults.find(
-    (r): r is ForEachIterationFailure =>
-      r !== null &&
-      typeof r === "object" &&
-      "success" in (r as object) &&
-      (r as { success: unknown }).success === false
-  );
+  return iterationResults.find(isForEachBodyFailureResult);
+}
+
+/** Count iteration results tagged as genuine body failures. */
+export function countIterationFailures(iterationResults: unknown[]): number {
+  return iterationResults.filter(isForEachBodyFailureResult).length;
+}
+
+/**
+ * When post-loop Collect is skipped due to iteration failure, mark the Collect
+ * node visited and record an explicit failure so the parent DAG dispatcher does
+ * not re-dispatch it via a second incoming edge.
+ */
+export function markCollectSkippedOnForEachFailure(params: {
+  aggregateCollectNodeId: string;
+  collectNodeId: string | undefined;
+  doneCollectNodeId: string | undefined;
+  error: string;
+  currentVisited: Set<string>;
+  currentResults: Record<
+    string,
+    { success: boolean; error?: string; data?: unknown }
+  >;
+}): void {
+  params.currentVisited.add(params.aggregateCollectNodeId);
+  params.currentResults[params.aggregateCollectNodeId] = {
+    success: false,
+    error: params.error,
+  };
+
+  if (
+    params.doneCollectNodeId &&
+    params.collectNodeId &&
+    params.collectNodeId !== params.doneCollectNodeId
+  ) {
+    params.currentVisited.add(params.collectNodeId);
+  }
 }
 
 /**
@@ -2868,7 +2914,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     //                      (no aggregation injection).
     //   none:              fire-and-forget loop, nothing to do here.
     // Any failed iteration skips this block entirely (no Collect / downstream).
-    await dispatchForEachPostLoopIfNeeded({
+    const postLoopResult = await dispatchForEachPostLoopIfNeeded({
       firstIterationFailure,
       continuation,
       onAggregateCollect: async (aggregateCollectNodeId) => {
@@ -2933,13 +2979,28 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       },
     });
 
+    if (
+      postLoopResult === "skipped" &&
+      continuation.kind === "aggregate-collect" &&
+      firstIterationFailure
+    ) {
+      markCollectSkippedOnForEachFailure({
+        aggregateCollectNodeId: continuation.collectNodeId,
+        collectNodeId,
+        doneCollectNodeId,
+        error: firstIterationFailure.error,
+        currentVisited,
+        currentResults,
+      });
+    }
+
     return {
       arrayLength: resolvedArray.length,
       maxIterations,
       iterationsRan: itemsToProcess.length,
-      failedIterations: firstIterationFailure === undefined ? 0 : 1,
+      failedIterations: countIterationFailures(iterationResults),
       firstFailureError: firstIterationFailure?.error,
-      firstFailureNodeId: undefined,
+      firstFailureNodeId: firstIterationFailure?.nodeId,
     };
   }
 

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -105,7 +105,10 @@ import type { WorkflowEdge, WorkflowNode } from "@/lib/workflow/store";
 import { splitTemplateRef } from "@/lib/workflow/template-ref";
 import { LEGACY_ACTION_MAPPINGS } from "@/plugins/legacy-mappings";
 
-export { isForEachBodyFailureResult, type ForEachIterationFailure };
+export {
+  isForEachBodyFailureResult,
+  type ForEachIterationFailure,
+} from "@/lib/workflow/nodes/for-each/iteration-failure";
 
 // System actions that don't have plugins - maps to module import functions.
 // `satisfies Record<SystemActionType, ...>` makes the dispatch table and the
@@ -2081,7 +2084,9 @@ export function markCollectSkippedOnForEachFailure(params: {
   attemptedNodes: Set<string>;
 }): void {
   const skipData = {
-    results: params.iterationResults,
+    results: params.iterationResults.map((result) =>
+      isForEachBodyFailureResult(result) ? result.error : result
+    ),
     count: params.iterationResults.length,
     skipped: true as const,
   };
@@ -2108,7 +2113,7 @@ export function markCollectSkippedOnForEachFailure(params: {
  * Skips entirely when any iteration failed so downstream side effects
  * (transfers, webhooks) do not fire after a failed loop body.
  */
-export async function dispatchForEachPostLoopIfNeeded(params: {
+async function dispatchForEachPostLoopIfNeeded(params: {
   firstIterationFailure: ForEachIterationFailure | undefined;
   continuation: IterationContinuation;
   onAggregateCollect: (collectNodeId: string) => Promise<void>;

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2053,13 +2053,24 @@ export type ForEachIterationSummary = {
 /**
  * Prefer a nested For Each summary's firstFailureNodeId over the bodyResults
  * key. Insertion order records the nested loop id before routeAfterSuccess
- * overwrites the entry with data: summary.
+ * overwrites the entry with data: summary. Guard on `failedIterations` so a
+ * failed result with unrelated `data` is not treated as a summary.
  */
 export function resolveBodyFailureNodeId(
   bodyFailure: [string, { success: boolean; error?: string; data?: unknown }]
 ): string {
-  const summary = bodyFailure[1].data as ForEachIterationSummary | undefined;
-  return summary?.firstFailureNodeId ?? bodyFailure[0];
+  const data = bodyFailure[1].data;
+  if (
+    data !== null &&
+    typeof data === "object" &&
+    "failedIterations" in data &&
+    typeof (data as ForEachIterationSummary).failedIterations === "number"
+  ) {
+    return (
+      (data as ForEachIterationSummary).firstFailureNodeId ?? bodyFailure[0]
+    );
+  }
+  return bodyFailure[0];
 }
 
 /**
@@ -2086,6 +2097,7 @@ export function markCollectSkippedOnForEachFailure(params: {
   aggregateCollectNodeId: string;
   collectNodeId: string | undefined;
   doneCollectNodeId: string | undefined;
+  collectLabel: string;
   error: string;
   iterationResults: unknown[];
   currentVisited: Set<string>;
@@ -2093,6 +2105,7 @@ export function markCollectSkippedOnForEachFailure(params: {
     string,
     { success: boolean; error?: string; data?: unknown }
   >;
+  currentOutputs: NodeOutputs;
   attemptedNodes: Set<string>;
 }): void {
   const skipData = {
@@ -2104,11 +2117,19 @@ export function markCollectSkippedOnForEachFailure(params: {
     count: params.iterationResults.length,
     skipped: true as const,
   };
+  const sanitizedCollectId = params.aggregateCollectNodeId.replace(
+    /[^a-zA-Z0-9]/g,
+    "_"
+  );
   params.currentVisited.add(params.aggregateCollectNodeId);
   params.attemptedNodes.add(params.aggregateCollectNodeId);
   params.currentResults[params.aggregateCollectNodeId] = {
     success: false,
     error: params.error,
+    data: skipData,
+  };
+  params.currentOutputs[sanitizedCollectId] = {
+    label: params.collectLabel,
     data: skipData,
   };
 
@@ -2165,12 +2186,14 @@ export async function settleForEachPostLoop(params: {
   onDoneTargets: (targets: string[]) => Promise<void>;
   collectNodeId: string | undefined;
   doneCollectNodeId: string | undefined;
+  collectLabel: string;
   iterationResults: unknown[];
   currentVisited: Set<string>;
   currentResults: Record<
     string,
     { success: boolean; error?: string; data?: unknown }
   >;
+  currentOutputs: NodeOutputs;
   attemptedNodes: Set<string>;
 }): Promise<ForEachPostLoopResult> {
   const postLoopResult = await dispatchForEachPostLoopIfNeeded({
@@ -2188,10 +2211,12 @@ export async function settleForEachPostLoop(params: {
       aggregateCollectNodeId: params.continuation.collectNodeId,
       collectNodeId: params.collectNodeId,
       doneCollectNodeId: params.doneCollectNodeId,
+      collectLabel: params.collectLabel,
       error: params.firstIterationFailure.error,
       iterationResults: params.iterationResults,
       currentVisited: params.currentVisited,
       currentResults: params.currentResults,
+      currentOutputs: params.currentOutputs,
       attemptedNodes: params.attemptedNodes,
     });
   }
@@ -2984,6 +3009,17 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
     //                      (no aggregation injection).
     //   none:              fire-and-forget loop, nothing to do here.
     // Any failed iteration skips this block entirely (no Collect / downstream).
+    const skipCollectNodeId =
+      continuation.kind === "aggregate-collect"
+        ? continuation.collectNodeId
+        : undefined;
+    const skipCollectNode = skipCollectNodeId
+      ? nodeMap.get(skipCollectNodeId)
+      : undefined;
+    const skipCollectLabel = skipCollectNode
+      ? getNodeName(skipCollectNode)
+      : "Collect";
+
     await settleForEachPostLoop({
       firstIterationFailure,
       continuation,
@@ -3049,9 +3085,11 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
       },
       collectNodeId,
       doneCollectNodeId,
+      collectLabel: skipCollectLabel,
       iterationResults,
       currentVisited,
       currentResults,
+      currentOutputs,
       attemptedNodes,
     });
 

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -2138,8 +2138,19 @@ export function markCollectSkippedOnForEachFailure(params: {
     params.collectNodeId &&
     params.collectNodeId !== params.doneCollectNodeId
   ) {
-    params.currentVisited.add(params.collectNodeId);
-    params.attemptedNodes.add(params.collectNodeId);
+    const legacyCollectNodeId = params.collectNodeId;
+    const sanitizedLegacyId = legacyCollectNodeId.replace(/[^a-zA-Z0-9]/g, "_");
+    params.currentVisited.add(legacyCollectNodeId);
+    params.attemptedNodes.add(legacyCollectNodeId);
+    params.currentResults[legacyCollectNodeId] = {
+      success: false,
+      error: params.error,
+      data: skipData,
+    };
+    params.currentOutputs[sanitizedLegacyId] = {
+      label: params.collectLabel,
+      data: skipData,
+    };
   }
 }
 
@@ -3032,8 +3043,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           /[^a-zA-Z0-9]/g,
           "_"
         );
-        const collectNode = nodeMap.get(aggregateCollectNodeId);
-        const collectLabel = collectNode ? getNodeName(collectNode) : "Collect";
+        const collectLabel = skipCollectLabel;
 
         const collectAction = SYSTEM_ACTIONS.Collect;
         if (collectAction) {

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -200,9 +200,14 @@ async function routeAfterSuccess(params: {
         bodyVisited: ctx.bodyVisited,
       });
       if (summary.failedIterations > 0) {
+        const nodeHint = summary.firstFailureNodeId
+          ? ` at node ${summary.firstFailureNodeId}`
+          : "";
+        const baseError =
+          summary.firstFailureError ?? "For Each iteration body failed";
         ctx.bodyResults[nodeId] = {
           success: false,
-          error: summary.firstFailureError ?? "For Each iteration body failed",
+          error: `${baseError}${nodeHint}`,
         };
         return;
       }

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -203,6 +203,7 @@ async function routeAfterSuccess(params: {
         ctx.bodyResults[nodeId] = {
           success: false,
           error: summary.firstFailureError ?? "For Each iteration body failed",
+          data: summary,
         };
         return;
       }

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -200,14 +200,9 @@ async function routeAfterSuccess(params: {
         bodyVisited: ctx.bodyVisited,
       });
       if (summary.failedIterations > 0) {
-        const nodeHint = summary.firstFailureNodeId
-          ? ` at node ${summary.firstFailureNodeId}`
-          : "";
-        const baseError =
-          summary.firstFailureError ?? "For Each iteration body failed";
         ctx.bodyResults[nodeId] = {
           success: false,
-          error: `${baseError}${nodeHint}`,
+          error: summary.firstFailureError ?? "For Each iteration body failed",
         };
         return;
       }

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -26,7 +26,10 @@
  *    actions or conditions came before it in the iteration body.
  */
 import type { EdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-utils";
-import { resolveBodyConditionTargets } from "@/lib/workflow/executor/executor.workflow";
+import {
+  type ForEachIterationSummary,
+  resolveBodyConditionTargets,
+} from "@/lib/workflow/executor/executor.workflow";
 import {
   EXCEEDED_MAX_RETRIES_REGEX,
   FAILED_AFTER_RETRIES_REGEX,

--- a/lib/workflow/executor/for-each-body-runner.ts
+++ b/lib/workflow/executor/for-each-body-runner.ts
@@ -70,7 +70,7 @@ export type NestedForEachHandler = (params: {
   scopedOutputs: BodyNodeOutputs;
   bodyResults: Record<string, BodyExecutionResult>;
   bodyVisited: Set<string>;
-}) => Promise<void>;
+}) => Promise<ForEachIterationSummary>;
 
 /** KEEP-543: Resolver for spurious-max-retries inside iteration bodies. When
  *  the Workflow DevKit throws "exceeded max retries" because it lost the
@@ -188,7 +188,7 @@ async function routeAfterSuccess(params: {
 
   if (actionType === "For Each") {
     if (ctx.handleNestedForEach) {
-      await ctx.handleNestedForEach({
+      const summary = await ctx.handleNestedForEach({
         forEachNodeId: nodeId,
         forEachNode: node,
         processedConfig,
@@ -196,6 +196,13 @@ async function routeAfterSuccess(params: {
         bodyResults: ctx.bodyResults,
         bodyVisited: ctx.bodyVisited,
       });
+      if (summary.failedIterations > 0) {
+        ctx.bodyResults[nodeId] = {
+          success: false,
+          error: summary.firstFailureError ?? "For Each iteration body failed",
+        };
+        return;
+      }
     }
     const downstream = ctx.bodyEdgesBySource.get(nodeId) ?? [];
     await recurseInto(downstream, ctx);

--- a/lib/workflow/nodes/for-each/concurrency.ts
+++ b/lib/workflow/nodes/for-each/concurrency.ts
@@ -4,17 +4,16 @@
  * Extracted from the workflow executor to enable isolated unit testing.
  */
 
+import {
+  FOR_EACH_BODY_FAILURE_MARKER,
+  type ForEachIterationFailure,
+} from "@/lib/workflow/nodes/for-each/iteration-failure";
+
 export type ConcurrencyMode = "sequential" | "parallel" | "custom";
 
 export type IterationExecutor<T> = (item: T, index: number) => Promise<unknown>;
 
 export type ErrorHandler = (error: unknown) => Promise<string>;
-
-interface IterationFailure {
-  __forEachBodyFailure: true;
-  success: false;
-  error: string;
-}
 
 /**
  * Run iterations over `items` with the specified concurrency strategy.
@@ -62,10 +61,10 @@ async function runSequential<T>(
     } catch (error) {
       const errorMessage = await handleError(error);
       results.push({
-        __forEachBodyFailure: true,
+        [FOR_EACH_BODY_FAILURE_MARKER]: true,
         success: false,
         error: errorMessage,
-      } satisfies IterationFailure);
+      } satisfies ForEachIterationFailure);
     }
   }
   return results;
@@ -86,10 +85,10 @@ async function runParallel<T>(
     } else {
       const errorMessage = await handleError(entry.reason);
       results.push({
-        __forEachBodyFailure: true,
+        [FOR_EACH_BODY_FAILURE_MARKER]: true,
         success: false,
         error: errorMessage,
-      } satisfies IterationFailure);
+      } satisfies ForEachIterationFailure);
     }
   }
   return results;
@@ -112,10 +111,10 @@ async function runWorkerPool<T>(
       } catch (error) {
         const errorMessage = await handleError(error);
         results[i] = {
-          __forEachBodyFailure: true,
+          [FOR_EACH_BODY_FAILURE_MARKER]: true,
           success: false,
           error: errorMessage,
-        } satisfies IterationFailure;
+        } satisfies ForEachIterationFailure;
       }
     }
   };

--- a/lib/workflow/nodes/for-each/concurrency.ts
+++ b/lib/workflow/nodes/for-each/concurrency.ts
@@ -11,6 +11,7 @@ export type IterationExecutor<T> = (item: T, index: number) => Promise<unknown>;
 export type ErrorHandler = (error: unknown) => Promise<string>;
 
 interface IterationFailure {
+  __forEachBodyFailure: true;
   success: false;
   error: string;
 }
@@ -23,8 +24,8 @@ interface IterationFailure {
  * - **custom**: worker-pool with at most `concurrencyLimit` concurrent.
  *
  * Results are always returned in iteration order regardless of mode.
- * Individual iteration failures are captured as `{ success: false, error }`,
- * they never abort sibling iterations.
+ * Individual iteration failures are captured as tagged `{ success: false, error }`
+ * objects (`__forEachBodyFailure`), they never abort sibling iterations.
  */
 export async function runIterations<T>(
   items: T[],
@@ -61,6 +62,7 @@ async function runSequential<T>(
     } catch (error) {
       const errorMessage = await handleError(error);
       results.push({
+        __forEachBodyFailure: true,
         success: false,
         error: errorMessage,
       } satisfies IterationFailure);
@@ -84,6 +86,7 @@ async function runParallel<T>(
     } else {
       const errorMessage = await handleError(entry.reason);
       results.push({
+        __forEachBodyFailure: true,
         success: false,
         error: errorMessage,
       } satisfies IterationFailure);
@@ -109,6 +112,7 @@ async function runWorkerPool<T>(
       } catch (error) {
         const errorMessage = await handleError(error);
         results[i] = {
+          __forEachBodyFailure: true,
           success: false,
           error: errorMessage,
         } satisfies IterationFailure;

--- a/lib/workflow/nodes/for-each/concurrency.ts
+++ b/lib/workflow/nodes/for-each/concurrency.ts
@@ -7,6 +7,7 @@
 import {
   FOR_EACH_BODY_FAILURE_MARKER,
   type ForEachIterationFailure,
+  nodeIdFromThrown,
 } from "@/lib/workflow/nodes/for-each/iteration-failure";
 
 export type ConcurrencyMode = "sequential" | "parallel" | "custom";
@@ -64,6 +65,7 @@ async function runSequential<T>(
         [FOR_EACH_BODY_FAILURE_MARKER]: true,
         success: false,
         error: errorMessage,
+        nodeId: nodeIdFromThrown(error),
       } satisfies ForEachIterationFailure);
     }
   }
@@ -88,6 +90,7 @@ async function runParallel<T>(
         [FOR_EACH_BODY_FAILURE_MARKER]: true,
         success: false,
         error: errorMessage,
+        nodeId: nodeIdFromThrown(entry.reason),
       } satisfies ForEachIterationFailure);
     }
   }
@@ -114,6 +117,7 @@ async function runWorkerPool<T>(
           [FOR_EACH_BODY_FAILURE_MARKER]: true,
           success: false,
           error: errorMessage,
+          nodeId: nodeIdFromThrown(error),
         } satisfies ForEachIterationFailure;
       }
     }

--- a/lib/workflow/nodes/for-each/iteration-failure.ts
+++ b/lib/workflow/nodes/for-each/iteration-failure.ts
@@ -1,0 +1,28 @@
+/**
+ * Tagged For Each iteration-body failure.
+ *
+ * Concurrency catch sites and the executor body-failure path must stamp the
+ * same marker so findFirstIterationFailure cannot miss a thrown iteration
+ * (and so a successful step whose data is shaped `{ success: false }` cannot
+ * false-positive the post-loop gate).
+ */
+
+export const FOR_EACH_BODY_FAILURE_MARKER = "__forEachBodyFailure" as const;
+
+export type ForEachIterationFailure = {
+  [FOR_EACH_BODY_FAILURE_MARKER]: true;
+  success: false;
+  error: string;
+  nodeId?: string;
+};
+
+export function isForEachBodyFailureResult(
+  result: unknown
+): result is ForEachIterationFailure {
+  if (result === null || typeof result !== "object") {
+    return false;
+  }
+  return (
+    (result as Record<string, unknown>)[FOR_EACH_BODY_FAILURE_MARKER] === true
+  );
+}

--- a/lib/workflow/nodes/for-each/iteration-failure.ts
+++ b/lib/workflow/nodes/for-each/iteration-failure.ts
@@ -26,3 +26,16 @@ export function isForEachBodyFailureResult(
     (result as Record<string, unknown>)[FOR_EACH_BODY_FAILURE_MARKER] === true
   );
 }
+
+/** Pull `nodeId` off a thrown error when the thrower stamped one. */
+export function nodeIdFromThrown(error: unknown): string | undefined {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "nodeId" in error &&
+    typeof (error as { nodeId: unknown }).nodeId === "string"
+  ) {
+    return (error as { nodeId: string }).nodeId;
+  }
+  return undefined;
+}

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -987,18 +987,16 @@ describe("runBodyNode: KEEP-543 / KEEP-586 authority-backed recovery", () => {
 // Nested For Each failure propagation (PR #2217 Joel review)
 // ===========================================================================
 
-describe("runBodyNode: nested For Each failure stops inner and outer continuation", () => {
-  it("marks the nested For Each failed and skips downstream when inner body fails", async () => {
+describe("runBodyNode: nested For Each failure stops inner continuation", () => {
+  it("marks the nested For Each failed and skips inner downstream when inner body fails", async () => {
     const nodes = [
       makeForEach("outer-fe", "Outer loop"),
       makeForEach("inner-fe", "Inner loop"),
       makeAction("fail-step", "web3/read-contract", "Failing step"),
       makeAction("inner-post", "web3/read-contract", "Inner post-loop"),
-      makeAction("outer-post", "web3/read-contract", "Outer post-loop"),
     ];
     const edges = [
       edge("outer-fe", "inner-fe", "loop"),
-      edge("outer-fe", "outer-post", "done"),
       edge("inner-fe", "fail-step", "loop"),
       edge("inner-fe", "inner-post", "done"),
     ];
@@ -1013,25 +1011,40 @@ describe("runBodyNode: nested For Each failure stops inner and outer continuatio
         }
         return { success: true, data: { ok: true } };
       },
-      nestedForEachHandler: (ctx) => async () => {
-        await runBodyNode("fail-step", ctx);
-        const failResult = ctx.bodyResults["fail-step"];
-        return {
-          arrayLength: 1,
-          maxIterations: 1,
-          iterationsRan: 1,
-          failedIterations: failResult?.success === false ? 1 : 0,
-          firstFailureError: failResult?.error,
-        };
-      },
+      nestedForEachHandler:
+        (ctx) =>
+        async ({ forEachNodeId }) => {
+          const edgesBySource = buildEdgesBySource(edges);
+          const fullHandleMap = buildEdgesBySourceHandle(edges);
+          const innerBody = identifyLoopBody(
+            forEachNodeId,
+            edgesBySource,
+            ctx.nodeMap,
+            fullHandleMap
+          );
+          const innerBodyNodes =
+            innerBody.bodyEdgesBySource.get(forEachNodeId) ?? [];
+          for (const bodyNodeId of innerBodyNodes) {
+            await runBodyNode(bodyNodeId, ctx);
+          }
+          const failResult = ctx.bodyResults["fail-step"];
+          return {
+            arrayLength: 1,
+            maxIterations: 1,
+            iterationsRan: 1,
+            failedIterations: failResult?.success === false ? 1 : 0,
+            firstFailureError: failResult?.error,
+            firstFailureNodeId:
+              failResult?.success === false ? "fail-step" : undefined,
+          };
+        },
     });
 
     expect(bodyResults["inner-fe"]?.success).toBe(false);
-    expect(bodyResults["inner-fe"]?.error).toBe("inner body failed");
+    expect(bodyResults["inner-fe"]?.error).toContain("inner body failed");
+    expect(bodyResults["inner-fe"]?.error).toContain("fail-step");
     expect(bodyResults["inner-post"]).toBeUndefined();
-    expect(bodyResults["outer-post"]).toBeUndefined();
     expect(visitOrder).toContain("fail-step");
     expect(visitOrder).not.toContain("inner-post");
-    expect(visitOrder).not.toContain("outer-post");
   });
 });

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -1043,6 +1043,10 @@ describe("runBodyNode: nested For Each failure stops inner continuation", () => 
     expect(bodyResults["inner-fe"]?.success).toBe(false);
     expect(bodyResults["inner-fe"]?.error).toBe("inner body failed");
     expect(bodyResults["inner-fe"]?.error).not.toContain(" at node ");
+    expect(bodyResults["inner-fe"]?.data).toMatchObject({
+      firstFailureNodeId: "fail-step",
+      failedIterations: 1,
+    });
     expect(bodyResults["inner-post"]).toBeUndefined();
     expect(visitOrder).toContain("fail-step");
     expect(visitOrder).not.toContain("inner-post");

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -1041,8 +1041,8 @@ describe("runBodyNode: nested For Each failure stops inner continuation", () => 
     });
 
     expect(bodyResults["inner-fe"]?.success).toBe(false);
-    expect(bodyResults["inner-fe"]?.error).toContain("inner body failed");
-    expect(bodyResults["inner-fe"]?.error).toContain("fail-step");
+    expect(bodyResults["inner-fe"]?.error).toBe("inner body failed");
+    expect(bodyResults["inner-fe"]?.error).not.toContain(" at node ");
     expect(bodyResults["inner-post"]).toBeUndefined();
     expect(visitOrder).toContain("fail-step");
     expect(visitOrder).not.toContain("inner-post");

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -1019,7 +1019,7 @@ describe("runBodyNode: nested For Each failure stops inner continuation", () => 
           const innerBody = identifyLoopBody(
             forEachNodeId,
             edgesBySource,
-            ctx.nodeMap,
+            new Map(ctx.nodeMap),
             fullHandleMap
           );
           const innerBodyNodes =

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -26,6 +26,11 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+vi.mock("@/lib/step-registry", () => ({
+  getActionLabel: (actionType: string) => actionType,
+  getStepImporter: () => undefined,
+}));
+
 import { buildEdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-utils";
 import { buildEdgesBySource } from "@/lib/workflow/executor/convergence-barrier";
 import { identifyLoopBody } from "@/lib/workflow/executor/executor.workflow";

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -33,6 +33,7 @@ import {
   type BodyExecutionResult,
   type BodyNodeOutputs,
   type BodyStepRunner,
+  type NestedForEachHandler,
   type RunBodyContext,
   runBodyNode,
   type SpuriousRecoveryResolver,

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -98,6 +98,8 @@ type RunIterationOptions = {
   resolveSpuriousRecovery?: SpuriousRecoveryResolver;
   /** KEEP-543: Optional callback fired on successful recovery. */
   onSpuriousRecovery?: RunBodyContext["onSpuriousRecovery"];
+  /** Optional nested For Each handler factory (receives the live ctx). */
+  nestedForEachHandler?: (ctx: RunBodyContext) => NestedForEachHandler;
 };
 
 type RunIterationOutcome = {
@@ -174,6 +176,10 @@ async function runIteration(
       workflowId: "wf-test",
     } satisfies Omit<StepContext, "nodeId" | "nodeName" | "nodeType">,
   };
+
+  if (options.nestedForEachHandler) {
+    ctx.handleNestedForEach = options.nestedForEachHandler(ctx);
+  }
 
   const firstBodyNodes = bodyEdgesBySource.get(forEachNodeId) ?? [];
   for (const bodyNodeId of firstBodyNodes) {
@@ -973,5 +979,58 @@ describe("runBodyNode: KEEP-543 / KEEP-586 authority-backed recovery", () => {
 
     expect(bodyResults.read?.success).toBe(false);
     expect(bodyResults.decode).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+// Nested For Each failure propagation (PR #2217 Joel review)
+// ===========================================================================
+
+describe("runBodyNode: nested For Each failure stops inner and outer continuation", () => {
+  it("marks the nested For Each failed and skips downstream when inner body fails", async () => {
+    const nodes = [
+      makeForEach("outer-fe", "Outer loop"),
+      makeForEach("inner-fe", "Inner loop"),
+      makeAction("fail-step", "web3/read-contract", "Failing step"),
+      makeAction("inner-post", "web3/read-contract", "Inner post-loop"),
+      makeAction("outer-post", "web3/read-contract", "Outer post-loop"),
+    ];
+    const edges = [
+      edge("outer-fe", "inner-fe", "loop"),
+      edge("outer-fe", "outer-post", "done"),
+      edge("inner-fe", "fail-step", "loop"),
+      edge("inner-fe", "inner-post", "done"),
+    ];
+
+    const { bodyResults, visitOrder } = await runIteration({
+      nodes,
+      edges,
+      forEachNodeId: "outer-fe",
+      stepResultFor: (nodeId) => {
+        if (nodeId === "fail-step") {
+          return { success: false, error: "inner body failed" };
+        }
+        return { success: true, data: { ok: true } };
+      },
+      nestedForEachHandler: (ctx) => async () => {
+        await runBodyNode("fail-step", ctx);
+        const failResult = ctx.bodyResults["fail-step"];
+        return {
+          arrayLength: 1,
+          maxIterations: 1,
+          iterationsRan: 1,
+          failedIterations: failResult?.success === false ? 1 : 0,
+          firstFailureError: failResult?.error,
+        };
+      },
+    });
+
+    expect(bodyResults["inner-fe"]?.success).toBe(false);
+    expect(bodyResults["inner-fe"]?.error).toBe("inner body failed");
+    expect(bodyResults["inner-post"]).toBeUndefined();
+    expect(bodyResults["outer-post"]).toBeUndefined();
+    expect(visitOrder).toContain("fail-step");
+    expect(visitOrder).not.toContain("inner-post");
+    expect(visitOrder).not.toContain("outer-post");
   });
 });

--- a/tests/unit/for-each-body-runner.test.ts
+++ b/tests/unit/for-each-body-runner.test.ts
@@ -26,11 +26,6 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/step-registry", () => ({
-  getActionLabel: (actionType: string) => actionType,
-  getStepImporter: () => undefined,
-}));
-
 import { buildEdgesBySourceHandle } from "@/lib/workflow/editor/edge-handle-utils";
 import { buildEdgesBySource } from "@/lib/workflow/executor/convergence-barrier";
 import { identifyLoopBody } from "@/lib/workflow/executor/executor.workflow";

--- a/tests/unit/for-each-concurrency.test.ts
+++ b/tests/unit/for-each-concurrency.test.ts
@@ -121,9 +121,17 @@ describe("runIterations - sequential", () => {
     );
     expect(results).toEqual([
       10,
-      { success: false, error: "Iteration 1 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 1 failed",
+      },
       30,
-      { success: false, error: "Iteration 3 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 3 failed",
+      },
     ]);
   });
 
@@ -134,7 +142,13 @@ describe("runIterations - sequential", () => {
       simpleErrorHandler,
       "sequential"
     );
-    expect(results).toEqual([{ success: false, error: "Iteration 0 failed" }]);
+    expect(results).toEqual([
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 0 failed",
+      },
+    ]);
   });
 
   it("handles all iterations failing", async () => {
@@ -145,6 +159,7 @@ describe("runIterations - sequential", () => {
       "sequential"
     );
     for (const result of results) {
+      expect(result).toHaveProperty("__forEachBodyFailure", true);
       expect(result).toHaveProperty("success", false);
       expect(result).toHaveProperty("error");
     }
@@ -262,9 +277,17 @@ describe("runIterations - parallel", () => {
       "parallel"
     );
     expect(results).toEqual([
-      { success: false, error: "Iteration 0 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 0 failed",
+      },
       20,
-      { success: false, error: "Iteration 2 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 2 failed",
+      },
       40,
     ]);
   });
@@ -398,10 +421,18 @@ describe("runIterations - custom", () => {
     );
     expect(results).toEqual([
       10,
-      { success: false, error: "Iteration 1 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 1 failed",
+      },
       30,
       40,
-      { success: false, error: "Iteration 4 failed" },
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 4 failed",
+      },
       60,
     ]);
   });
@@ -536,6 +567,7 @@ describe("runIterations - edge cases", () => {
       const results = await runIterations([1], executor, handler, mode, 3);
       expect(handler).toHaveBeenCalledOnce();
       expect(results[0]).toEqual({
+        __forEachBodyFailure: true,
         success: false,
         error: "caught: string-error",
       });
@@ -572,6 +604,7 @@ describe("runIterations - error handler", () => {
       "sequential"
     );
     expect(results[0]).toEqual({
+      __forEachBodyFailure: true,
       success: false,
       error: "custom-error-message",
     });
@@ -604,6 +637,10 @@ describe("runIterations - error handler", () => {
       slowHandler,
       "parallel"
     );
-    expect(results[0]).toEqual({ success: false, error: "slow-error" });
+    expect(results[0]).toEqual({
+      __forEachBodyFailure: true,
+      success: false,
+      error: "slow-error",
+    });
   });
 });

--- a/tests/unit/for-each-concurrency.test.ts
+++ b/tests/unit/for-each-concurrency.test.ts
@@ -41,6 +41,21 @@ function failingExecutor(failIndices: Set<number>): IterationExecutor<number> {
   };
 }
 
+/** Executor that rejects with a stamped body nodeId on the thrown error. */
+function failingExecutorWithNodeId(
+  failIndices: Set<number>,
+  nodeId: string
+): IterationExecutor<number> {
+  return (item: number, index: number): Promise<number> => {
+    if (failIndices.has(index)) {
+      return Promise.reject(
+        Object.assign(new Error(`Iteration ${index} failed`), { nodeId })
+      );
+    }
+    return Promise.resolve(item * 10);
+  };
+}
+
 /** Executor that tracks concurrency via an active counter. */
 function concurrencyTrackingExecutor(
   peakTracker: { peak: number; active: number },
@@ -149,6 +164,22 @@ describe("runIterations - sequential", () => {
         error: "Iteration 0 failed",
       },
     ]);
+  });
+
+  it("carries nodeId from a stamped thrown error", async () => {
+    const results = await runIterations(
+      [1, 2],
+      failingExecutorWithNodeId(new Set([0]), "step-a"),
+      simpleErrorHandler,
+      "sequential"
+    );
+    expect(results[0]).toEqual({
+      __forEachBodyFailure: true,
+      success: false,
+      error: "Iteration 0 failed",
+      nodeId: "step-a",
+    });
+    expect(results[1]).toBe(20);
   });
 
   it("handles all iterations failing", async () => {
@@ -335,6 +366,23 @@ describe("runIterations - parallel", () => {
     );
     expect(errorHandler).toHaveBeenCalledOnce();
   });
+
+  it("carries nodeId from a stamped thrown error", async () => {
+    const results = await runIterations(
+      [1],
+      failingExecutorWithNodeId(new Set([0]), "step-a"),
+      simpleErrorHandler,
+      "parallel"
+    );
+    expect(results).toEqual([
+      {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "Iteration 0 failed",
+        nodeId: "step-a",
+      },
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -435,6 +483,23 @@ describe("runIterations - custom", () => {
       },
       60,
     ]);
+  });
+
+  it("carries nodeId from a stamped thrown error", async () => {
+    const results = await runIterations(
+      [1, 2],
+      failingExecutorWithNodeId(new Set([1]), "step-a"),
+      simpleErrorHandler,
+      "custom",
+      2
+    );
+    expect(results[0]).toBe(10);
+    expect(results[1]).toEqual({
+      __forEachBodyFailure: true,
+      success: false,
+      error: "Iteration 1 failed",
+      nodeId: "step-a",
+    });
   });
 
   it("handles all iterations failing", async () => {

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -70,11 +70,11 @@ describe("countIterationFailures", () => {
   it("counts only marked body failures", () => {
     const results = Array.from({ length: 500 }, (_, index) => {
       if (index === 1 || index === 50 || index === 400) {
-          return {
-            [FOR_EACH_BODY_FAILURE_MARKER]: true as const,
-            success: false as const,
-            error: `fail-${index}`,
-          };
+        return {
+          [FOR_EACH_BODY_FAILURE_MARKER]: true as const,
+          success: false as const,
+          error: `fail-${index}`,
+        };
       }
       if (index === 10) {
         return { success: false, error: "api-shaped output" };

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -10,11 +10,14 @@ import {
   countIterationFailures,
   dispatchForEachPostLoopIfNeeded,
   findFirstIterationFailure,
+  isForEachBodyFailureResult,
   markCollectSkippedOnForEachFailure,
+  settleForEachPostLoop,
 } from "@/lib/workflow/executor/executor.workflow";
+import { FOR_EACH_BODY_FAILURE_MARKER } from "@/lib/workflow/nodes/for-each/iteration-failure";
 
 const markedFailure = {
-  __forEachBodyFailure: true as const,
+  [FOR_EACH_BODY_FAILURE_MARKER]: true as const,
   success: false as const,
   error: "boom",
   nodeId: "step-a",
@@ -36,7 +39,7 @@ describe("findFirstIterationFailure", () => {
         { success: true },
         markedFailure,
         {
-          __forEachBodyFailure: true as const,
+          [FOR_EACH_BODY_FAILURE_MARKER]: true as const,
           success: false as const,
           error: "later",
         },
@@ -67,11 +70,11 @@ describe("countIterationFailures", () => {
   it("counts only marked body failures", () => {
     const results = Array.from({ length: 500 }, (_, index) => {
       if (index === 1 || index === 50 || index === 400) {
-        return {
-          __forEachBodyFailure: true as const,
-          success: false as const,
-          error: `fail-${index}`,
-        };
+          return {
+            [FOR_EACH_BODY_FAILURE_MARKER]: true as const,
+            success: false as const,
+            error: `fail-${index}`,
+          };
       }
       if (index === 10) {
         return { success: false, error: "api-shaped output" };
@@ -83,33 +86,55 @@ describe("countIterationFailures", () => {
   });
 });
 
+describe("isForEachBodyFailureResult", () => {
+  it("accepts only the shared marker", () => {
+    expect(isForEachBodyFailureResult(markedFailure)).toBe(true);
+    expect(
+      isForEachBodyFailureResult({ success: false, error: "api-shaped" })
+    ).toBe(false);
+    expect(isForEachBodyFailureResult(null)).toBe(false);
+  });
+});
+
 describe("markCollectSkippedOnForEachFailure", () => {
-  it("marks aggregate Collect visited and records explicit failure", () => {
+  it("marks aggregate Collect visited and records explicit failure with data", () => {
     const visited = new Set<string>();
+    const attempted = new Set<string>();
     const results: Record<
       string,
       { success: boolean; error?: string; data?: unknown }
     > = {};
+    const iterationResults = [markedFailure, { ok: 2 }];
 
     markCollectSkippedOnForEachFailure({
       aggregateCollectNodeId: "done-collect",
       collectNodeId: "legacy-collect",
       doneCollectNodeId: "done-collect",
       error: "body failed",
+      iterationResults,
       currentVisited: visited,
       currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(visited.has("done-collect")).toBe(true);
     expect(visited.has("legacy-collect")).toBe(true);
+    expect(attempted.has("done-collect")).toBe(true);
+    expect(attempted.has("legacy-collect")).toBe(true);
     expect(results["done-collect"]).toEqual({
       success: false,
       error: "body failed",
+      data: {
+        results: iterationResults,
+        count: 2,
+        skipped: true,
+      },
     });
   });
 
   it("does not mark legacy in-body Collect when it is the done Collect", () => {
     const visited = new Set<string>();
+    const attempted = new Set<string>();
     const results: Record<
       string,
       { success: boolean; error?: string; data?: unknown }
@@ -120,12 +145,20 @@ describe("markCollectSkippedOnForEachFailure", () => {
       collectNodeId: "collect-1",
       doneCollectNodeId: "collect-1",
       error: "body failed",
+      iterationResults: [markedFailure],
       currentVisited: visited,
       currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect([...visited]).toEqual(["collect-1"]);
+    expect([...attempted]).toEqual(["collect-1"]);
     expect(results["collect-1"]?.success).toBe(false);
+    expect(results["collect-1"]?.data).toEqual({
+      results: [markedFailure],
+      count: 1,
+      skipped: true,
+    });
   });
 });
 
@@ -215,5 +248,49 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
     expect(result).toBe("none");
     expect(onAggregateCollect).not.toHaveBeenCalled();
     expect(onDoneTargets).not.toHaveBeenCalled();
+  });
+});
+
+describe("settleForEachPostLoop", () => {
+  it("skips Collect dispatch and marks Collect skipped with data", async () => {
+    const onAggregateCollect = vi.fn();
+    const onDoneTargets = vi.fn();
+    const visited = new Set<string>();
+    const attempted = new Set<string>();
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {
+      "for-each": { success: false, error: "body failed" },
+    };
+    const iterationResults = [markedFailure];
+
+    const outcome = await settleForEachPostLoop({
+      firstIterationFailure: markedFailure,
+      continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
+      onAggregateCollect,
+      onDoneTargets,
+      collectNodeId: "collect-1",
+      doneCollectNodeId: "collect-1",
+      iterationResults,
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
+    });
+
+    expect(outcome).toBe("skipped");
+    expect(onAggregateCollect).not.toHaveBeenCalled();
+    expect(visited.has("collect-1")).toBe(true);
+    expect(attempted.has("collect-1")).toBe(true);
+    expect(results["collect-1"]?.data).toEqual({
+      results: iterationResults,
+      count: 1,
+      skipped: true,
+    });
+    expect(Object.values(results).at(-1)?.data).toEqual({
+      results: iterationResults,
+      count: 1,
+      skipped: true,
+    });
   });
 });

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -1,0 +1,120 @@
+/**
+ * For Each stop-on-failure: post-loop Collect / done-targets must not run
+ * after any failed iteration.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  dispatchForEachPostLoopIfNeeded,
+  findFirstIterationFailure,
+} from "@/lib/workflow/executor/executor.workflow";
+
+describe("findFirstIterationFailure", () => {
+  it("returns undefined when all iterations succeeded", () => {
+    expect(
+      findFirstIterationFailure([
+        { success: true, data: 1 },
+        { success: true, data: 2 },
+      ])
+    ).toBeUndefined();
+  });
+
+  it("returns the first failed iteration", () => {
+    expect(
+      findFirstIterationFailure([
+        { success: true },
+        { success: false, error: "boom" },
+        { success: false, error: "later" },
+      ])
+    ).toEqual({ success: false, error: "boom" });
+  });
+
+  it("ignores null and non-object results", () => {
+    expect(
+      findFirstIterationFailure([null, "x", { success: false, error: "e" }])
+    ).toEqual({ success: false, error: "e" });
+  });
+});
+
+describe("dispatchForEachPostLoopIfNeeded", () => {
+  it("skips Collect and done-targets when an iteration failed", async () => {
+    const onAggregateCollect = vi.fn();
+    const onDoneTargets = vi.fn();
+
+    const result = await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure: { success: false, error: "body failed" },
+      continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
+      onAggregateCollect,
+      onDoneTargets,
+    });
+
+    expect(result).toBe("skipped");
+    expect(onAggregateCollect).not.toHaveBeenCalled();
+    expect(onDoneTargets).not.toHaveBeenCalled();
+  });
+
+  it("skips done-targets continuation when an iteration failed", async () => {
+    const onAggregateCollect = vi.fn();
+    const onDoneTargets = vi.fn();
+
+    const result = await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure: { success: false, error: "body failed" },
+      continuation: { kind: "done-targets", targets: ["after-1"] },
+      onAggregateCollect,
+      onDoneTargets,
+    });
+
+    expect(result).toBe("skipped");
+    expect(onDoneTargets).not.toHaveBeenCalled();
+  });
+
+  it("runs aggregate-collect when all iterations succeeded", async () => {
+    const onAggregateCollect = vi.fn().mockResolvedValue(undefined);
+    const onDoneTargets = vi.fn();
+
+    const result = await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure: undefined,
+      continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
+      onAggregateCollect,
+      onDoneTargets,
+    });
+
+    expect(result).toBe("aggregate-collect");
+    expect(onAggregateCollect).toHaveBeenCalledWith("collect-1");
+    expect(onDoneTargets).not.toHaveBeenCalled();
+  });
+
+  it("runs done-targets when all iterations succeeded", async () => {
+    const onAggregateCollect = vi.fn();
+    const onDoneTargets = vi.fn().mockResolvedValue(undefined);
+
+    const result = await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure: undefined,
+      continuation: { kind: "done-targets", targets: ["a", "b"] },
+      onAggregateCollect,
+      onDoneTargets,
+    });
+
+    expect(result).toBe("done-targets");
+    expect(onDoneTargets).toHaveBeenCalledWith(["a", "b"]);
+    expect(onAggregateCollect).not.toHaveBeenCalled();
+  });
+
+  it("returns none when there is no post-loop continuation", async () => {
+    const onAggregateCollect = vi.fn();
+    const onDoneTargets = vi.fn();
+
+    const result = await dispatchForEachPostLoopIfNeeded({
+      firstIterationFailure: undefined,
+      continuation: { kind: "none" },
+      onAggregateCollect,
+      onDoneTargets,
+    });
+
+    expect(result).toBe("none");
+    expect(onAggregateCollect).not.toHaveBeenCalled();
+    expect(onDoneTargets).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -8,7 +8,6 @@ vi.mock("server-only", () => ({}));
 
 import {
   countIterationFailures,
-  dispatchForEachPostLoopIfNeeded,
   findFirstIterationFailure,
   isForEachBodyFailureResult,
   markCollectSkippedOnForEachFailure,
@@ -125,7 +124,7 @@ describe("markCollectSkippedOnForEachFailure", () => {
       success: false,
       error: "body failed",
       data: {
-        results: iterationResults,
+        results: ["boom", { ok: 2 }],
         count: 2,
         skipped: true,
       },
@@ -155,47 +154,67 @@ describe("markCollectSkippedOnForEachFailure", () => {
     expect([...attempted]).toEqual(["collect-1"]);
     expect(results["collect-1"]?.success).toBe(false);
     expect(results["collect-1"]?.data).toEqual({
-      results: [markedFailure],
+      results: ["boom"],
       count: 1,
       skipped: true,
     });
   });
 });
 
-describe("dispatchForEachPostLoopIfNeeded", () => {
+describe("settleForEachPostLoop", () => {
+  const emptyVisited = () => ({
+    visited: new Set<string>(),
+    attempted: new Set<string>(),
+    results: {} as Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    >,
+  });
+
   it("skips Collect and done-targets when an iteration failed", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
+    const { visited, attempted, results } = emptyVisited();
 
-    const result = await dispatchForEachPostLoopIfNeeded({
-      firstIterationFailure: {
-        __forEachBodyFailure: true,
-        success: false,
-        error: "body failed",
-      },
+    const result = await settleForEachPostLoop({
+      firstIterationFailure: markedFailure,
       continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
       onAggregateCollect,
       onDoneTargets,
+      collectNodeId: "collect-1",
+      doneCollectNodeId: "collect-1",
+      iterationResults: [markedFailure],
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(result).toBe("skipped");
     expect(onAggregateCollect).not.toHaveBeenCalled();
     expect(onDoneTargets).not.toHaveBeenCalled();
+    expect(results["collect-1"]?.data).toEqual({
+      results: ["boom"],
+      count: 1,
+      skipped: true,
+    });
   });
 
   it("skips done-targets continuation when an iteration failed", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
+    const { visited, attempted, results } = emptyVisited();
 
-    const result = await dispatchForEachPostLoopIfNeeded({
-      firstIterationFailure: {
-        __forEachBodyFailure: true,
-        success: false,
-        error: "body failed",
-      },
+    const result = await settleForEachPostLoop({
+      firstIterationFailure: markedFailure,
       continuation: { kind: "done-targets", targets: ["after-1"] },
       onAggregateCollect,
       onDoneTargets,
+      collectNodeId: undefined,
+      doneCollectNodeId: undefined,
+      iterationResults: [markedFailure],
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(result).toBe("skipped");
@@ -205,12 +224,19 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
   it("runs aggregate-collect when all iterations succeeded", async () => {
     const onAggregateCollect = vi.fn().mockResolvedValue(undefined);
     const onDoneTargets = vi.fn();
+    const { visited, attempted, results } = emptyVisited();
 
-    const result = await dispatchForEachPostLoopIfNeeded({
+    const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
       continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
       onAggregateCollect,
       onDoneTargets,
+      collectNodeId: "collect-1",
+      doneCollectNodeId: "collect-1",
+      iterationResults: [{ ok: true }],
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(result).toBe("aggregate-collect");
@@ -221,12 +247,19 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
   it("runs done-targets when all iterations succeeded", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn().mockResolvedValue(undefined);
+    const { visited, attempted, results } = emptyVisited();
 
-    const result = await dispatchForEachPostLoopIfNeeded({
+    const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
       continuation: { kind: "done-targets", targets: ["a", "b"] },
       onAggregateCollect,
       onDoneTargets,
+      collectNodeId: undefined,
+      doneCollectNodeId: undefined,
+      iterationResults: [{ ok: true }],
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(result).toBe("done-targets");
@@ -237,21 +270,26 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
   it("returns none when there is no post-loop continuation", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
+    const { visited, attempted, results } = emptyVisited();
 
-    const result = await dispatchForEachPostLoopIfNeeded({
+    const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
       continuation: { kind: "none" },
       onAggregateCollect,
       onDoneTargets,
+      collectNodeId: undefined,
+      doneCollectNodeId: undefined,
+      iterationResults: [{ ok: true }],
+      currentVisited: visited,
+      currentResults: results,
+      attemptedNodes: attempted,
     });
 
     expect(result).toBe("none");
     expect(onAggregateCollect).not.toHaveBeenCalled();
     expect(onDoneTargets).not.toHaveBeenCalled();
   });
-});
 
-describe("settleForEachPostLoop", () => {
   it("skips Collect dispatch and marks Collect skipped with data", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
@@ -283,12 +321,12 @@ describe("settleForEachPostLoop", () => {
     expect(visited.has("collect-1")).toBe(true);
     expect(attempted.has("collect-1")).toBe(true);
     expect(results["collect-1"]?.data).toEqual({
-      results: iterationResults,
+      results: ["boom"],
       count: 1,
       skipped: true,
     });
     expect(Object.values(results).at(-1)?.data).toEqual({
-      results: iterationResults,
+      results: ["boom"],
       count: 1,
       skipped: true,
     });

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -7,9 +7,18 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
+  countIterationFailures,
   dispatchForEachPostLoopIfNeeded,
   findFirstIterationFailure,
+  markCollectSkippedOnForEachFailure,
 } from "@/lib/workflow/executor/executor.workflow";
+
+const markedFailure = {
+  __forEachBodyFailure: true as const,
+  success: false as const,
+  error: "boom",
+  nodeId: "step-a",
+};
 
 describe("findFirstIterationFailure", () => {
   it("returns undefined when all iterations succeeded", () => {
@@ -21,20 +30,102 @@ describe("findFirstIterationFailure", () => {
     ).toBeUndefined();
   });
 
-  it("returns the first failed iteration", () => {
+  it("returns the first marked body failure", () => {
     expect(
       findFirstIterationFailure([
         { success: true },
-        { success: false, error: "boom" },
-        { success: false, error: "later" },
+        markedFailure,
+        {
+          __forEachBodyFailure: true as const,
+          success: false as const,
+          error: "later",
+        },
       ])
-    ).toEqual({ success: false, error: "boom" });
+    ).toEqual(markedFailure);
+  });
+
+  it("ignores bare success:false shapes without the marker", () => {
+    expect(
+      findFirstIterationFailure([
+        { success: false, error: "api error object" },
+        markedFailure,
+      ])
+    ).toEqual(markedFailure);
+    expect(
+      findFirstIterationFailure([{ success: false, error: "api error object" }])
+    ).toBeUndefined();
   });
 
   it("ignores null and non-object results", () => {
-    expect(
-      findFirstIterationFailure([null, "x", { success: false, error: "e" }])
-    ).toEqual({ success: false, error: "e" });
+    expect(findFirstIterationFailure([null, "x", markedFailure])).toEqual(
+      markedFailure
+    );
+  });
+});
+
+describe("countIterationFailures", () => {
+  it("counts only marked body failures", () => {
+    const results = Array.from({ length: 500 }, (_, index) => {
+      if (index === 1 || index === 50 || index === 400) {
+        return {
+          __forEachBodyFailure: true as const,
+          success: false as const,
+          error: `fail-${index}`,
+        };
+      }
+      if (index === 10) {
+        return { success: false, error: "api-shaped output" };
+      }
+      return { ok: index };
+    });
+
+    expect(countIterationFailures(results)).toBe(3);
+  });
+});
+
+describe("markCollectSkippedOnForEachFailure", () => {
+  it("marks aggregate Collect visited and records explicit failure", () => {
+    const visited = new Set<string>();
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {};
+
+    markCollectSkippedOnForEachFailure({
+      aggregateCollectNodeId: "done-collect",
+      collectNodeId: "legacy-collect",
+      doneCollectNodeId: "done-collect",
+      error: "body failed",
+      currentVisited: visited,
+      currentResults: results,
+    });
+
+    expect(visited.has("done-collect")).toBe(true);
+    expect(visited.has("legacy-collect")).toBe(true);
+    expect(results["done-collect"]).toEqual({
+      success: false,
+      error: "body failed",
+    });
+  });
+
+  it("does not mark legacy in-body Collect when it is the done Collect", () => {
+    const visited = new Set<string>();
+    const results: Record<
+      string,
+      { success: boolean; error?: string; data?: unknown }
+    > = {};
+
+    markCollectSkippedOnForEachFailure({
+      aggregateCollectNodeId: "collect-1",
+      collectNodeId: "collect-1",
+      doneCollectNodeId: "collect-1",
+      error: "body failed",
+      currentVisited: visited,
+      currentResults: results,
+    });
+
+    expect([...visited]).toEqual(["collect-1"]);
+    expect(results["collect-1"]?.success).toBe(false);
   });
 });
 
@@ -44,7 +135,11 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
     const onDoneTargets = vi.fn();
 
     const result = await dispatchForEachPostLoopIfNeeded({
-      firstIterationFailure: { success: false, error: "body failed" },
+      firstIterationFailure: {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "body failed",
+      },
       continuation: { kind: "aggregate-collect", collectNodeId: "collect-1" },
       onAggregateCollect,
       onDoneTargets,
@@ -60,7 +155,11 @@ describe("dispatchForEachPostLoopIfNeeded", () => {
     const onDoneTargets = vi.fn();
 
     const result = await dispatchForEachPostLoopIfNeeded({
-      firstIterationFailure: { success: false, error: "body failed" },
+      firstIterationFailure: {
+        __forEachBodyFailure: true,
+        success: false,
+        error: "body failed",
+      },
       continuation: { kind: "done-targets", targets: ["after-1"] },
       onAggregateCollect,
       onDoneTargets,

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -6,11 +6,17 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
+vi.mock("@/lib/step-registry", () => ({
+  getActionLabel: (actionType: string) => actionType,
+  getStepImporter: () => undefined,
+}));
+
 import {
   countIterationFailures,
   findFirstIterationFailure,
   isForEachBodyFailureResult,
   markCollectSkippedOnForEachFailure,
+  resolveBodyFailureNodeId,
   settleForEachPostLoop,
 } from "@/lib/workflow/executor/executor.workflow";
 import { FOR_EACH_BODY_FAILURE_MARKER } from "@/lib/workflow/nodes/for-each/iteration-failure";
@@ -21,6 +27,8 @@ const markedFailure = {
   error: "boom",
   nodeId: "step-a",
 };
+
+const mappedFailure = { error: "boom", nodeId: "step-a" };
 
 describe("findFirstIterationFailure", () => {
   it("returns undefined when all iterations succeeded", () => {
@@ -124,7 +132,7 @@ describe("markCollectSkippedOnForEachFailure", () => {
       success: false,
       error: "body failed",
       data: {
-        results: ["boom", { ok: 2 }],
+        results: [mappedFailure, { ok: 2 }],
         count: 2,
         skipped: true,
       },
@@ -154,10 +162,34 @@ describe("markCollectSkippedOnForEachFailure", () => {
     expect([...attempted]).toEqual(["collect-1"]);
     expect(results["collect-1"]?.success).toBe(false);
     expect(results["collect-1"]?.data).toEqual({
-      results: ["boom"],
+      results: [mappedFailure],
       count: 1,
       skipped: true,
     });
+  });
+});
+
+describe("resolveBodyFailureNodeId", () => {
+  it("prefers nested summary firstFailureNodeId over the bodyResults key", () => {
+    expect(
+      resolveBodyFailureNodeId([
+        "inner-fe",
+        {
+          success: false,
+          error: "inner body failed",
+          data: {
+            firstFailureNodeId: "fail-step",
+            failedIterations: 1,
+          },
+        },
+      ])
+    ).toBe("fail-step");
+  });
+
+  it("falls back to the bodyResults key when summary has no firstFailureNodeId", () => {
+    expect(
+      resolveBodyFailureNodeId(["step-a", { success: false, error: "boom" }])
+    ).toBe("step-a");
   });
 });
 
@@ -193,7 +225,7 @@ describe("settleForEachPostLoop", () => {
     expect(onAggregateCollect).not.toHaveBeenCalled();
     expect(onDoneTargets).not.toHaveBeenCalled();
     expect(results["collect-1"]?.data).toEqual({
-      results: ["boom"],
+      results: [mappedFailure],
       count: 1,
       skipped: true,
     });
@@ -321,12 +353,12 @@ describe("settleForEachPostLoop", () => {
     expect(visited.has("collect-1")).toBe(true);
     expect(attempted.has("collect-1")).toBe(true);
     expect(results["collect-1"]?.data).toEqual({
-      results: ["boom"],
+      results: [mappedFailure],
       count: 1,
       skipped: true,
     });
     expect(Object.values(results).at(-1)?.data).toEqual({
-      results: ["boom"],
+      results: [mappedFailure],
       count: 1,
       skipped: true,
     });

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -144,7 +144,16 @@ describe("markCollectSkippedOnForEachFailure", () => {
       error: "body failed",
       data: skipData,
     });
+    expect(results["legacy-collect"]).toEqual({
+      success: false,
+      error: "body failed",
+      data: skipData,
+    });
     expect(outputs.done_collect).toEqual({
+      label: "Done Collect",
+      data: skipData,
+    });
+    expect(outputs.legacy_collect).toEqual({
       label: "Done Collect",
       data: skipData,
     });

--- a/tests/unit/foreach-stop-on-failure.test.ts
+++ b/tests/unit/foreach-stop-on-failure.test.ts
@@ -6,11 +6,6 @@ import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/step-registry", () => ({
-  getActionLabel: (actionType: string) => actionType,
-  getStepImporter: () => undefined,
-}));
-
 import {
   countIterationFailures,
   findFirstIterationFailure,
@@ -29,6 +24,20 @@ const markedFailure = {
 };
 
 const mappedFailure = { error: "boom", nodeId: "step-a" };
+
+type TestOutputs = Record<string, { label: string; data: unknown }>;
+
+const emptyVisited = (): {
+  visited: Set<string>;
+  attempted: Set<string>;
+  results: Record<string, { success: boolean; error?: string; data?: unknown }>;
+  outputs: TestOutputs;
+} => ({
+  visited: new Set<string>(),
+  attempted: new Set<string>(),
+  results: {},
+  outputs: {},
+});
 
 describe("findFirstIterationFailure", () => {
   it("returns undefined when all iterations succeeded", () => {
@@ -105,22 +114,24 @@ describe("isForEachBodyFailureResult", () => {
 
 describe("markCollectSkippedOnForEachFailure", () => {
   it("marks aggregate Collect visited and records explicit failure with data", () => {
-    const visited = new Set<string>();
-    const attempted = new Set<string>();
-    const results: Record<
-      string,
-      { success: boolean; error?: string; data?: unknown }
-    > = {};
+    const { visited, attempted, results, outputs } = emptyVisited();
     const iterationResults = [markedFailure, { ok: 2 }];
+    const skipData = {
+      results: [mappedFailure, { ok: 2 }],
+      count: 2,
+      skipped: true as const,
+    };
 
     markCollectSkippedOnForEachFailure({
       aggregateCollectNodeId: "done-collect",
       collectNodeId: "legacy-collect",
       doneCollectNodeId: "done-collect",
+      collectLabel: "Done Collect",
       error: "body failed",
       iterationResults,
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -131,40 +142,42 @@ describe("markCollectSkippedOnForEachFailure", () => {
     expect(results["done-collect"]).toEqual({
       success: false,
       error: "body failed",
-      data: {
-        results: [mappedFailure, { ok: 2 }],
-        count: 2,
-        skipped: true,
-      },
+      data: skipData,
+    });
+    expect(outputs.done_collect).toEqual({
+      label: "Done Collect",
+      data: skipData,
     });
   });
 
   it("does not mark legacy in-body Collect when it is the done Collect", () => {
-    const visited = new Set<string>();
-    const attempted = new Set<string>();
-    const results: Record<
-      string,
-      { success: boolean; error?: string; data?: unknown }
-    > = {};
+    const { visited, attempted, results, outputs } = emptyVisited();
+    const skipData = {
+      results: [mappedFailure],
+      count: 1,
+      skipped: true as const,
+    };
 
     markCollectSkippedOnForEachFailure({
       aggregateCollectNodeId: "collect-1",
       collectNodeId: "collect-1",
       doneCollectNodeId: "collect-1",
+      collectLabel: "Collect",
       error: "body failed",
       iterationResults: [markedFailure],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
     expect([...visited]).toEqual(["collect-1"]);
     expect([...attempted]).toEqual(["collect-1"]);
     expect(results["collect-1"]?.success).toBe(false);
-    expect(results["collect-1"]?.data).toEqual({
-      results: [mappedFailure],
-      count: 1,
-      skipped: true,
+    expect(results["collect-1"]?.data).toEqual(skipData);
+    expect(outputs.collect_1).toEqual({
+      label: "Collect",
+      data: skipData,
     });
   });
 });
@@ -191,22 +204,26 @@ describe("resolveBodyFailureNodeId", () => {
       resolveBodyFailureNodeId(["step-a", { success: false, error: "boom" }])
     ).toBe("step-a");
   });
+
+  it("falls back when data has firstFailureNodeId but no failedIterations", () => {
+    expect(
+      resolveBodyFailureNodeId([
+        "inner-fe",
+        {
+          success: false,
+          error: "boom",
+          data: { firstFailureNodeId: "should-not-win" },
+        },
+      ])
+    ).toBe("inner-fe");
+  });
 });
 
 describe("settleForEachPostLoop", () => {
-  const emptyVisited = () => ({
-    visited: new Set<string>(),
-    attempted: new Set<string>(),
-    results: {} as Record<
-      string,
-      { success: boolean; error?: string; data?: unknown }
-    >,
-  });
-
   it("skips Collect and done-targets when an iteration failed", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
-    const { visited, attempted, results } = emptyVisited();
+    const { visited, attempted, results, outputs } = emptyVisited();
 
     const result = await settleForEachPostLoop({
       firstIterationFailure: markedFailure,
@@ -215,9 +232,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: "collect-1",
       doneCollectNodeId: "collect-1",
+      collectLabel: "Collect",
       iterationResults: [markedFailure],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -229,12 +248,20 @@ describe("settleForEachPostLoop", () => {
       count: 1,
       skipped: true,
     });
+    expect(outputs.collect_1).toEqual({
+      label: "Collect",
+      data: {
+        results: [mappedFailure],
+        count: 1,
+        skipped: true,
+      },
+    });
   });
 
   it("skips done-targets continuation when an iteration failed", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
-    const { visited, attempted, results } = emptyVisited();
+    const { visited, attempted, results, outputs } = emptyVisited();
 
     const result = await settleForEachPostLoop({
       firstIterationFailure: markedFailure,
@@ -243,9 +270,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: undefined,
       doneCollectNodeId: undefined,
+      collectLabel: "Collect",
       iterationResults: [markedFailure],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -256,7 +285,7 @@ describe("settleForEachPostLoop", () => {
   it("runs aggregate-collect when all iterations succeeded", async () => {
     const onAggregateCollect = vi.fn().mockResolvedValue(undefined);
     const onDoneTargets = vi.fn();
-    const { visited, attempted, results } = emptyVisited();
+    const { visited, attempted, results, outputs } = emptyVisited();
 
     const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
@@ -265,9 +294,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: "collect-1",
       doneCollectNodeId: "collect-1",
+      collectLabel: "Collect",
       iterationResults: [{ ok: true }],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -279,7 +310,7 @@ describe("settleForEachPostLoop", () => {
   it("runs done-targets when all iterations succeeded", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn().mockResolvedValue(undefined);
-    const { visited, attempted, results } = emptyVisited();
+    const { visited, attempted, results, outputs } = emptyVisited();
 
     const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
@@ -288,9 +319,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: undefined,
       doneCollectNodeId: undefined,
+      collectLabel: "Collect",
       iterationResults: [{ ok: true }],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -302,7 +335,7 @@ describe("settleForEachPostLoop", () => {
   it("returns none when there is no post-loop continuation", async () => {
     const onAggregateCollect = vi.fn();
     const onDoneTargets = vi.fn();
-    const { visited, attempted, results } = emptyVisited();
+    const { visited, attempted, results, outputs } = emptyVisited();
 
     const result = await settleForEachPostLoop({
       firstIterationFailure: undefined,
@@ -311,9 +344,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: undefined,
       doneCollectNodeId: undefined,
+      collectLabel: "Collect",
       iterationResults: [{ ok: true }],
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -333,7 +368,13 @@ describe("settleForEachPostLoop", () => {
     > = {
       "for-each": { success: false, error: "body failed" },
     };
+    const outputs: TestOutputs = {};
     const iterationResults = [markedFailure];
+    const skipData = {
+      results: [mappedFailure],
+      count: 1,
+      skipped: true as const,
+    };
 
     const outcome = await settleForEachPostLoop({
       firstIterationFailure: markedFailure,
@@ -342,9 +383,11 @@ describe("settleForEachPostLoop", () => {
       onDoneTargets,
       collectNodeId: "collect-1",
       doneCollectNodeId: "collect-1",
+      collectLabel: "Collect",
       iterationResults,
       currentVisited: visited,
       currentResults: results,
+      currentOutputs: outputs,
       attemptedNodes: attempted,
     });
 
@@ -352,15 +395,11 @@ describe("settleForEachPostLoop", () => {
     expect(onAggregateCollect).not.toHaveBeenCalled();
     expect(visited.has("collect-1")).toBe(true);
     expect(attempted.has("collect-1")).toBe(true);
-    expect(results["collect-1"]?.data).toEqual({
-      results: [mappedFailure],
-      count: 1,
-      skipped: true,
+    expect(results["collect-1"]?.data).toEqual(skipData);
+    expect(outputs.collect_1).toEqual({
+      label: "Collect",
+      data: skipData,
     });
-    expect(Object.values(results).at(-1)?.data).toEqual({
-      results: [mappedFailure],
-      count: 1,
-      skipped: true,
-    });
+    expect(Object.values(results).at(-1)?.data).toEqual(skipData);
   });
 });


### PR DESCRIPTION
## Summary
- After a failed For Each iteration, skip Collect / `continueAfterCollect` / done-targets
- Keep error flip on For Each node, visited body nodes, and failure summary
- **Nested For Each:** propagate inner `handleForEachExecution` summary through `handleNestedForEach`; `routeAfterSuccess` marks the nested node failed and skips its downstream when `failedIterations > 0`, so outer iterations fail and outer post-loop continuation is gated for free
- Thrown iteration catches stamp `__forEachBodyFailure` and carry `nodeId` when the thrown error was stamped with one (`nodeIdFromThrown`)
- On the skip path, aggregate and legacy in-body Collect both get visited/attempted plus `results`/`outputs` with a tagged `{ skipped: true, ... }` payload (a Collect with a second consumer on a still-running parallel branch previously tripped `assertResolved`; it now resolves to this tagged skip payload)
- Separate from nested-boundary scoping bugs in #2194 / #2158 — no dependency on those fixes
- All-success path unchanged
- Fixes #2211

## Test plan
- [x] `pnpm exec vitest run tests/unit/for-each-concurrency.test.ts tests/unit/foreach-stop-on-failure.test.ts`
- [x] Failed iteration → Collect / done-targets callbacks not invoked
- [x] Success path still dispatches aggregate-collect and done-targets
- [x] Two-level loop: inner body failure marks nested For Each failed; inner-post and outer-post nodes do not run
- [x] Concurrency catch preserves stamped `nodeId` (sequential / parallel / custom)
- [x] Legacy Collect skip writes `currentResults` / `currentOutputs`