### PR TITLE
docs(workflows): document how template references resolve at runtime

### DIFF
--- a/docs/workflows/creating.md
+++ b/docs/workflows/creating.md
@@ -132,6 +132,8 @@ Combine multiple rules with **AND** / **OR** logic toggles, and nest groups for 
 
 **When to use `doesNotExist` vs `isNull` / `isUndefined`:** `exists` and `doesNotExist` treat null and undefined the same, which is the right choice for most checks (for example, a node output field that may or may not be present). Reach for `isNull`, `isNotNull`, `isUndefined`, or `isNotUndefined` only when you need to tell null and undefined apart, since these match one but not the other.
 
+**Referencing a field that may be absent:** the existence operators are also the only ones that accept a field path that is not present on the upstream output at all. Every other operator fails the run when the path is missing, so that a mistyped reference is caught rather than quietly satisfying a comparison. Put an existence operator in the first clause of an AND group to guard the clauses after it. See [Runtime resolution](/workflows/templating#runtime-resolution) in the templating reference for the full rules.
+
 **When to use soft vs strict equality:** Use `==` (soft equals) when comparing values that may differ in type, such as a string `"0"` against a number `0`. Use `===` (equals) when you need exact type matching. Most blockchain data arrives as strings, so soft equality is the default for new conditions.
 
 #### Expression Mode

--- a/docs/workflows/templating.md
+++ b/docs/workflows/templating.md
@@ -7,7 +7,7 @@ description: "Canonical grammar for the `{{...}}` template tokens you can use to
 
 KeeperHub workflows wire data between nodes using `{{...}}` template tokens. A template token is any string of the form `{{ ... }}` that appears inside a node's config field. When the workflow runs, the executor replaces each token with the corresponding upstream value.
 
-This page is the canonical reference. If a token does not match one of the grammars listed below, the executor will refuse to run the action and surface an error pointing at the offending reference. If a token does match the grammar but the upstream value cannot be resolved at runtime (the node has not run yet, the field does not exist, the upstream returned `null`), the executor will likewise abort the action with a structured error.
+This page is the canonical reference. If a token does not match one of the grammars listed below, the executor will refuse to run the action and surface an error pointing at the offending reference. If a token does match the grammar but the field it names is not present on the upstream output, the executor aborts the action with a structured error. See [Runtime resolution](#runtime-resolution) for how a field that is present but empty is treated, and for the one case in a Condition where a missing field is allowed.
 
 ## Supported grammars
 
@@ -93,7 +93,7 @@ The following parses but will fail at **runtime** if the reference cannot be res
 |-------|-----|
 | `{{$trigger.input.ts}}` | n8n-style `$variable` is not recognized as a node id |
 | `{{Some Label.x}}` where `Some Label` does not match any node | Display format requires a real label |
-| `{{@n1:Label.does.not.exist}}` | Field path does not exist on the upstream output |
+| `{{@n1:Label.does.not.exist}}` | Field path is not present on the upstream output. In a Condition, the existence operators accept this; see [Runtime resolution](#runtime-resolution) |
 
 When a runtime resolution fails, the action aborts with a structured error listing every unresolved reference. Earlier behaviour silently substituted an empty string or left the literal `{{...}}` token in the rendered value, which caused real on-chain corruption when the corrupted value flowed into a write action. The strict mode is the default.
 
@@ -108,12 +108,74 @@ Templates work in any string-valued config field. Common places:
 
 Templates do **not** work inside binary fields (images, file uploads) or inside the workflow's structural metadata (node ids, edge ids, position).
 
+## Referencing a field the editor has not seen yet
+
+The `@` autocomplete lists the fields it can see on a node's recorded output, taking the current run first and the node's last run otherwise. A node that has not run yet has no recorded output, so it offers no fields.
+
+When you already know a field will be there, you can write the path yourself. Double-click a reference chip in any config field and it becomes editable text with the cursor inside the closing braces. Type the rest of the path, then click away and it renders as a chip again.
+
+Extend the path inside the braces rather than after them. `{{@n1:My Step.data}}.timestamp` resolves `data` to the whole object and leaves `.timestamp` as literal text after it; `{{@n1:My Step.data.timestamp}}` is the reference you want.
+
+Saving does not check that the path exists, only that the token parses. The path is resolved when the workflow runs, so a field that is genuinely there when the node executes works even though the editor could not suggest it. A path that is still not there at run time is handled as described below.
+
 ## Runtime resolution
 
-The executor always fails closed: any unresolved reference aborts the action with a clear error. Empty-string substitution and literal `{{...}}` pass-through are not allowed because the same behaviour previously produced on-chain corruption.
+A reference that matches the grammar is resolved against the upstream node's recorded output when the workflow runs. Empty-string substitution and literal `{{...}}` pass-through are not allowed, because a corrupted value that reaches a write action is expensive to undo.
+
+### A present but empty field resolves
+
+A field that exists and holds `null` or `undefined` is a real value, not a missing one. It resolves:
+
+| Where the reference appears | A present field holding `null` resolves to |
+|-----------------------------|--------------------------------------------|
+| Action config field | the empty string |
+| Run Code source | the `null` literal, so the inlined code stays valid JavaScript |
+| Condition | `null`, which `is null` and `does not exist` match |
+
+This matters for optional output: a node that returns a key whose value is empty is treated as having answered, and the run continues.
+
+### A field that is absent aborts the action
+
+A field that is not present on the output is a different case. The action aborts with a structured error naming every unresolved reference and listing the field names that are available, so a mistyped path is caught before it can write an empty value on-chain.
+
+### Conditions and the existence operators
+
+Conditions follow the same rule, with one addition.
+
+Every reference in a Condition is resolved before the expression is evaluated, so an expression cannot short-circuit its own way past a field that is not there. The existence operators are what make that possible. `is undefined`, `is not undefined`, `exists`, `does not exist`, `is empty` and `is not empty` accept a field that is absent and read it as undefined. Every other operator rejects it and the run fails.
+
+Given an upstream output of `{ "someObject": { "nested": { "d": 0 } } }`:
+
+| Condition | Result |
+|-----------|--------|
+| `someObject.nonExisting` **is not undefined** | `false` |
+| `someObject.nonExisting` **is undefined** | `true` |
+| `someObject.nonExisting` **is not undefined** AND `someObject.nonExisting` **equals** `5` | `false` |
+| `someObject.nonExisting` **equals** `5` | the run fails |
+
+To reference a field that may not be present, put an existence operator in the first clause of an AND group. The group evaluates to `false` while the field is absent, and the clauses after it are evaluated once it is there.
+
+A comparison against an absent field with no such guard fails the run and names the operators that handle it:
+
+```
+Condition references field "someObject.nonExisting": "nonExisting" does not exist
+on the data. Available fields: nested. Use the "is undefined" or "is not
+undefined" operator to test whether the field is present.
+```
+
+That is deliberate. A mistyped path in a bare comparison would otherwise satisfy the comparison quietly and send the run down a branch you did not intend.
+
+Whenever a Condition reads an absent path, the path and the field names that were available are recorded as `unresolvedFields` on the step's input in the run detail. That holds even when the branch evaluated normally, so a guarded reference that is quietly empty is still visible.
+
+### Nodes that produced no output
+
+A reference to a node that produced no output at all fails the run, because the reference itself is broken rather than the value being empty.
+
+A node that ran and returned `null` behaves like an absent field: an action aborts, and in a Condition the existence operators can test it.
 
 ## Tips
 
-- Click a field in the editor's autocomplete dropdown rather than typing `@` references by hand. Hand-authored references are the main source of typos this validator catches.
+- Click a field in the editor's autocomplete dropdown rather than typing `@` references by hand. Hand-authored references are the main source of typos this validator catches. When the field you need is not offered yet, double-click the chip and extend its path inside the braces.
+- Guard a field that may not be present with an existence operator in the first clause of an AND group, rather than comparing it directly.
 - If you see `INVALID_TEMPLATE_SYNTAX` on save, check the `invalidTemplates` field in the response: each entry tells you the exact token and the reason it failed to parse.
 - If you see `Unresolved template reference` at runtime, the upstream node either has not run yet (check the workflow topology), produced no data (check the upstream node's run output), or you typed the field path wrong (check the autocomplete suggestions).

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -263,7 +263,7 @@ function describeMissingFieldPath(data: unknown, fieldPath: string): string {
       const [, key, indexStr] = arrayMatch;
       const index = Number.parseInt(indexStr, 10);
       if (!(key in container)) {
-        return `"${fieldPath}": "${key}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}`;
+        return `"${fieldPath}": "${key}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}.`;
       }
       const arr = container[key];
       if (!Array.isArray(arr)) {
@@ -277,7 +277,7 @@ function describeMissingFieldPath(data: unknown, fieldPath: string): string {
     }
 
     if (!(segment in container)) {
-      return `"${fieldPath}": "${segment}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}`;
+      return `"${fieldPath}": "${segment}" does not exist on the data. Available fields: ${Object.keys(container).join(", ") || "(none)"}.`;
     }
     current = container[segment];
   }


### PR DESCRIPTION
## Why

The templating reference described the old resolution rule. It stated that any
reference which cannot be resolved aborts the action, listing an upstream
`null` as one of those cases, and its runtime table said an absent field path
always fails. Neither is the whole picture any more, and nothing documented how
to reference a field the editor has not seen yet.

## What changed

`docs/workflows/templating.md`

- New section **Referencing a field the editor has not seen yet**. The `@`
  autocomplete can only offer field paths it has seen on a recorded run, so a
  node that has not run yet offers none. Covers double-clicking a reference
  chip to edit its path in place, and the difference between
  `{{@n1:Step.data}}.timestamp` and `{{@n1:Step.data.timestamp}}`.
- **Runtime resolution** rewritten into four subsections:
  - a field that is present but holds `null` or `undefined` resolves, with a
    table for action config, Run Code and Condition
  - a field that is absent aborts the action
  - Conditions and the existence operators, with a worked example and the
    literal error text
  - nodes that produced no output
- Two tips added.

`docs/workflows/creating.md`

- A paragraph under the condition operator table noting that the existence
  operators are the only ones that accept a field path which is not present,
  linking to the runtime section.

## One code change

Capturing the error text the docs quote showed it renders as
`Available fields: nested Use the "is undefined" ...` with no separator,
because the diagnostic string had no trailing period and the caller appends a
sentence to it. Added the period to the two diagnostics so the quoted sentence
matches what users see. Two characters, no behaviour change; the existing tests
match on substrings and are unaffected.

Happy to split that into its own PR if it should not ride along with docs.

## Verification

Every documented claim was checked by running the tests that encode the
contract rather than written from memory, including capturing the literal
runtime error message. Lint and type-check clean; the 101 tests across
`condition-absent-field-paths`, `workflow-codegen-condition` and
`template-fail-closed` pass.
