### PR TITLE
ci: require an issue or ticket reference on every pull request

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -23,17 +23,25 @@ name: PR Issue Link
 # is reported as CONTRIBUTOR, which is why the old author-only skip failed
 # team pull requests.
 #
+# When the check fails it leaves one comment on the pull request saying what
+# it found and what to do, and edits that same comment on every later run,
+# down to a one-line resolved note once the check passes. The comment never
+# echoes the title, description or branch name back: they are contributor-
+# controlled text and, rendered as Markdown, could carry mentions or links.
+# The job log keeps them.
+#
 # The job runs on synchronize as well as open and edit so that a result
 # exists for every head commit. A required status check is evaluated per
 # commit; without synchronize it would sit at "Expected" after each push
 # until someone edited the title. The job never checks out code, so
 # rerunning it is free.
 #
-# SAFETY: pull_request_target runs with the base repository's token. This job
-# therefore never checks out, builds, or executes pull request code. It reads
-# the title, body, branch name and labels from the event payload, and the
-# referenced issue through the API, and nothing else. Do not add a checkout
-# step to this file.
+# SAFETY: pull_request_target runs with the base repository's token, which
+# here can write to pull requests so the job can leave its comment. The job
+# therefore never checks out, builds, or executes pull request code. It
+# reads the title, body, branch name and labels from the event payload and
+# the referenced issue through the API, and writes nothing but its own
+# comment. Do not add a checkout step to this file.
 
 on:
   pull_request_target:
@@ -45,7 +53,7 @@ on:
 permissions:
   contents: read
   issues: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   check-issue-link:
@@ -62,6 +70,7 @@ jobs:
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           EXEMPT_LABEL: no-issue-required
@@ -82,55 +91,77 @@ jobs:
             OWNER|MEMBER|COLLABORATOR) is_team=true ;;
           esac
 
+          # The one comment this check owns on the pull request, found by its
+          # marker. Edited in place if present; created only when asked to.
+          # A comment failure must never change the check result, so every
+          # API write degrades to a warning.
+          marker='<!-- check-issue-link -->'
+          comment() {
+            local body id
+            body=$(printf '%s\n%s\n' "$marker" "$1")
+            id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- check-issue-link -->")) | .id' \
+              2>/dev/null | head -n1 || true)
+            if [ -n "$id" ]; then
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api -X PATCH "repos/$REPO/issues/comments/$id" --input - >/dev/null \
+                || echo "::warning::Could not update the check-issue-link comment."
+            elif [ "${2:-}" = "create" ]; then
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input - >/dev/null \
+                || echo "::warning::Could not create the check-issue-link comment."
+            fi
+          }
+
+          pass() {
+            echo "$1"
+            comment "Resolved. $1"
+            exit 0
+          }
+
           fail() {
+            local headline="$1" reasons="${2:-}" md
+            md="### This pull request needs an issue or ticket reference"$'\n\n'
+            md+="$headline"$'\n\n'
+            if [ -n "$reasons" ]; then
+              md+="$(printf '%s' "$reasons" | sed 's/^ */- /')"$'\n\n'
+            fi
+            if [ "$is_team" = true ]; then
+              md+="**Team pull requests** carry the Linear ticket in the branch name, "
+              md+="\`feat/$LINEAR_TEAM_KEY-1234-short-description\`. Rename the branch and "
+              md+="GitHub moves this pull request with it. Referencing an accepted GitHub "
+              md+="issue as below also works."$'\n\n'
+            fi
+            md+="**Outside contributions** start with an issue. Open one, wait for a "
+            md+="maintainer to apply the \`$ACCEPTED_LABEL\` label, then put \`#N\` in the "
+            md+="title, for example \`fix: #1978 return 403 with a body on public /api/chains\`. "
+            md+="No issue is needed for typos, broken links, formatting, or docs corrected to "
+            md+="match existing behaviour; retitle with one of: \`$EXEMPT_TYPES\`. Full policy: "
+            md+="[ISSUES.md](https://github.com/$REPO/blob/staging/ISSUES.md)."$'\n\n'
+            md+="This check reruns on every push and edit, but not when the issue changes; "
+            md+="re-run the job or edit the title to retrigger it."
+
             echo "----------------------------------------------"
-            echo "  ERROR: $1"
+            echo "  ERROR: $headline"
             echo "----------------------------------------------"
             echo ""
-            if [ -n "${2:-}" ]; then
-              printf '%s\n' "$2"
-            fi
             echo "  Got title:  $PR_TITLE"
             echo "  Got branch: $HEAD_REF"
             echo ""
-            if [ "$is_team" = true ]; then
-              echo "  Team pull requests carry their Linear ticket in the branch name:"
-              echo ""
-              echo "    feat/$LINEAR_TEAM_KEY-1234-short-description"
-              echo ""
-              echo "  Rename the branch (GitHub moves the open pull request with it),"
-              echo "  or reference an accepted GitHub issue as below."
-              echo ""
-            fi
-            echo "  KeeperHub takes issues before pull requests. Open an issue,"
-            echo "  wait for a maintainer to apply the '$ACCEPTED_LABEL' label,"
-            echo "  then reference it in this PR's title:"
-            echo ""
-            echo "    fix: #1978 return 403 with a body on public /api/chains"
-            echo "    feat(cli): #2014 add --require-verified to execute status"
-            echo ""
-            echo "  No issue needed for typos, broken links, formatting, or docs"
-            echo "  corrected to match existing behaviour. Retitle as one of:"
-            echo "    $EXEMPT_TYPES"
-            echo ""
-            echo "  Full policy: https://github.com/$REPO/blob/staging/ISSUES.md"
-            echo ""
-            echo "  Already labelled '$ACCEPTED_LABEL'? This check reruns on every"
-            echo "  push and edit, but not when the issue changes - re-run the job,"
-            echo "  or edit the PR title to retrigger it."
+            printf '%s\n' "$md"
+            comment "$md" create
+            echo "::error title=check-issue-link::$headline"
             exit 1
           }
 
           if printf '%s' "$PR_LABELS" | grep -qF "\"$EXEMPT_LABEL\""; then
-            echo "Exempt: pull request carries the '$EXEMPT_LABEL' label."
-            exit 0
+            pass "Exempt: pull request carries the '$EXEMPT_LABEL' label."
           fi
 
           pr_type=$(printf '%s' "$PR_TITLE" | sed -nE 's/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/p' | tr '[:upper:]' '[:lower:]')
           for exempt in $EXEMPT_TYPES; do
             if [ "$pr_type" = "$exempt" ]; then
-              echo "Exempt: '$pr_type' changes do not require a reference."
-              exit 0
+              pass "Exempt: '$pr_type' changes do not require a reference."
             fi
           done
 
@@ -141,8 +172,7 @@ jobs:
             ticket=$(printf '%s\n%s\n%s\n' "$PR_TITLE" "$PR_BODY" "$HEAD_REF" \
               | grep -oiE "\b$LINEAR_TEAM_KEY-[0-9]+\b" | head -n1 | tr '[:lower:]' '[:upper:]' || true)
             if [ -n "$ticket" ]; then
-              echo "References Linear ticket $ticket."
-              exit 0
+              pass "References Linear ticket $ticket."
             fi
           fi
 
@@ -159,7 +189,7 @@ jobs:
           )
 
           if [ -z "$candidates" ]; then
-            fail "No issue or ticket reference in the title, description, or branch name."
+            fail "No issue or ticket reference was found in the title, description, or branch name."
           fi
 
           reasons=""
@@ -179,8 +209,7 @@ jobs:
               reasons+="  #$n is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."$'\n'
               continue
             fi
-            echo "References accepted issue #$n."
-            exit 0
+            pass "References accepted issue #$n."
           done
 
-          fail "No referenced issue passes." "$reasons"
+          fail "None of the referenced issues can be merged against:" "$reasons"

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -1,22 +1,35 @@
 name: PR Issue Link
 
-# Runs on pull_request_target so it also runs on fork pull requests, which are
-# the ones this gate exists for. Fork runs of `pull_request` need per-run
-# maintainer approval, which would leave the gate silent exactly where it is
-# needed.
+# Runs on pull_request_target so it also runs on fork pull requests. Fork runs
+# of `pull_request` need per-run maintainer approval, which would leave the
+# gate silent exactly where it is needed.
 #
-# The gate applies to outside contributors only: the job skips when the PR
-# author is an OWNER, MEMBER, or COLLABORATOR (team PRs are tracked in Linear,
-# not GitHub issues). A skipped job still satisfies branch protection.
+# Every pull request into staging or prod must reference the work it belongs
+# to, in its title, its description, or its branch name:
+#
+#   - a GitHub issue (`#1978`) that exists, is an issue, and carries the
+#     `accepted` label - the issue-first policy in ISSUES.md; or
+#   - a Linear ticket (`KEEP-1234`), which only counts from a team author
+#     (OWNER, MEMBER, COLLABORATOR), since outside contributors cannot have
+#     one. Team branches are named `feat/KEEP-1234-description`, which is
+#     also what Linear's GitHub integration links on. The ticket is matched
+#     by shape only; Linear is not consulted.
+#
+# The job runs on synchronize as well as open and edit so that a result
+# exists for every head commit. A required status check is evaluated per
+# commit; without synchronize it would sit at "Expected" after each push
+# until someone edited the title. The job never checks out code, so
+# rerunning it is free.
 #
 # SAFETY: pull_request_target runs with the base repository's token. This job
 # therefore never checks out, builds, or executes pull request code. It reads
-# the title, the labels, and the referenced issue through the API and nothing
-# else. Do not add a checkout step to this file.
+# the title, body, branch name and labels from the event payload, and the
+# referenced issue through the API, and nothing else. Do not add a checkout
+# step to this file.
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
     branches:
       - staging
       - prod
@@ -28,35 +41,55 @@ permissions:
 
 jobs:
   check-issue-link:
-    if: >-
-      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
-      github.event.pull_request.author_association)
     runs-on: ubuntu-latest
 
     steps:
-      - name: Require an accepted issue in the PR title
+      - name: Require an issue or ticket reference
         env:
           # Untrusted input. Passed through the environment and never
           # interpolated into the script body.
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           EXEMPT_LABEL: no-issue-required
           ACCEPTED_LABEL: accepted
-          # Types that never require an issue. Keep in step with the
-          # "not required" list in ISSUES.md.
-          EXEMPT_TYPES: docs chore style
+          LINEAR_TEAM_KEY: KEEP
+          # Types that never require a reference. Keep in step with the
+          # "not required" list in ISSUES.md. release covers the
+          # staging-to-prod pull requests.
+          EXEMPT_TYPES: docs chore style release
         run: |
           set -euo pipefail
+
+          is_team=false
+          case "$AUTHOR_ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR) is_team=true ;;
+          esac
 
           fail() {
             echo "----------------------------------------------"
             echo "  ERROR: $1"
             echo "----------------------------------------------"
             echo ""
-            echo "  Got title: $PR_TITLE"
+            if [ -n "${2:-}" ]; then
+              printf '%s\n' "$2"
+            fi
+            echo "  Got title:  $PR_TITLE"
+            echo "  Got branch: $HEAD_REF"
             echo ""
+            if [ "$is_team" = true ]; then
+              echo "  Team pull requests carry their Linear ticket in the branch name:"
+              echo ""
+              echo "    feat/$LINEAR_TEAM_KEY-1234-short-description"
+              echo ""
+              echo "  Rename the branch (GitHub moves the open pull request with it),"
+              echo "  or reference an accepted GitHub issue as below."
+              echo ""
+            fi
             echo "  KeeperHub takes issues before pull requests. Open an issue,"
             echo "  wait for a maintainer to apply the '$ACCEPTED_LABEL' label,"
             echo "  then reference it in this PR's title:"
@@ -70,9 +103,9 @@ jobs:
             echo ""
             echo "  Full policy: https://github.com/$REPO/blob/staging/ISSUES.md"
             echo ""
-            echo "  Already labelled '$ACCEPTED_LABEL'? This check does not rerun"
-            echo "  by itself when the issue changes - re-run the job, or edit"
-            echo "  the PR title to retrigger it."
+            echo "  Already labelled '$ACCEPTED_LABEL'? This check reruns on every"
+            echo "  push and edit, but not when the issue changes - re-run the job,"
+            echo "  or edit the PR title to retrigger it."
             exit 1
           }
 
@@ -84,29 +117,58 @@ jobs:
           pr_type=$(printf '%s' "$PR_TITLE" | sed -nE 's/^([a-zA-Z]+)(\([^)]*\))?!?:.*/\1/p' | tr '[:upper:]' '[:lower:]')
           for exempt in $EXEMPT_TYPES; do
             if [ "$pr_type" = "$exempt" ]; then
-              echo "Exempt: '$pr_type' changes do not require an issue."
+              echo "Exempt: '$pr_type' changes do not require a reference."
               exit 0
             fi
           done
 
-          issue_number=$(printf '%s' "$PR_TITLE" | grep -oE '#[0-9]+' | head -n1 | tr -d '#')
-          if [ -z "$issue_number" ]; then
-            fail "PR title carries no issue reference."
+          # Every grep below may legitimately match nothing. `|| true` keeps
+          # pipefail from ending the script before fail() can explain why.
+
+          if [ "$is_team" = true ]; then
+            ticket=$(printf '%s\n%s\n%s\n' "$PR_TITLE" "$PR_BODY" "$HEAD_REF" \
+              | grep -oiE "\b$LINEAR_TEAM_KEY-[0-9]+\b" | head -n1 | tr '[:lower:]' '[:upper:]' || true)
+            if [ -n "$ticket" ]; then
+              echo "References Linear ticket $ticket."
+              exit 0
+            fi
           fi
 
-          if ! issue_json=$(gh api "repos/$REPO/issues/$issue_number" 2>/dev/null); then
-            fail "#$issue_number does not resolve to an issue in $REPO."
+          # `#N` in the title or body, plus a delimited bare number in the
+          # branch name (fix/2057-manual-run-input). Ticket references are
+          # removed from the branch first so KEEP-1080 is not read as #1080.
+          # At most ten distinct candidates are looked up.
+          candidates=$(
+            {
+              printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' || true
+              printf '%s\n' "$HEAD_REF" | sed -E "s/$LINEAR_TEAM_KEY-[0-9]+//Ig" \
+                | grep -oE '(^|[-_/])[0-9]+([-_/]|$)' | tr -d '_/-' || true
+            } | awk '!seen[$0]++ { if (++n <= 10) print }'
+          )
+
+          if [ -z "$candidates" ]; then
+            fail "No issue or ticket reference in the title, description, or branch name."
           fi
 
-          if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
-            fail "#$issue_number is a pull request, not an issue."
-          fi
+          reasons=""
+          for n in $candidates; do
+            if ! issue_json=$(gh api "repos/$REPO/issues/$n" 2>/dev/null); then
+              reasons+="  #$n does not resolve to an issue in $REPO."$'\n'
+              continue
+            fi
+            if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
+              reasons+="  #$n is a pull request, not an issue."$'\n'
+              continue
+            fi
+            if ! printf '%s' "$issue_json" | jq -e --arg l "$ACCEPTED_LABEL" \
+              '.labels | map(.name) | index($l)' >/dev/null 2>&1; then
+              state=$(printf '%s' "$issue_json" | jq -r '.state')
+              labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(", ")')
+              reasons+="  #$n is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."$'\n'
+              continue
+            fi
+            echo "References accepted issue #$n."
+            exit 0
+          done
 
-          if ! printf '%s' "$issue_json" | jq -e --arg l "$ACCEPTED_LABEL" \
-            '.labels | map(.name) | index($l)' >/dev/null 2>&1; then
-            state=$(printf '%s' "$issue_json" | jq -r '.state')
-            labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(", ")')
-            fail "#$issue_number is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."
-          fi
-
-          echo "PR title references accepted issue #$issue_number."
+          fail "No referenced issue passes." "$reasons"

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -23,12 +23,21 @@ name: PR Issue Link
 # is reported as CONTRIBUTOR, which is why the old author-only skip failed
 # team pull requests.
 #
+# HTML comments are removed from the description before it is searched, so
+# the examples in the pull request template can neither satisfy nor confuse
+# the check. A GitHub issue is taken from the branch name only in an explicit
+# form (issue-1978, issue/1978, gh-1978): a bare number in a branch name is
+# not a reference, and can coincide with an unrelated accepted issue.
+#
 # When the check fails it leaves one comment on the pull request saying what
 # it found and what to do, and edits that same comment on every later run,
 # down to a one-line resolved note once the check passes. The comment never
 # echoes the title, description or branch name back: they are contributor-
 # controlled text and, rendered as Markdown, could carry mentions or links.
-# The job log keeps them.
+# The job log keeps them. Issue numbers in the comment sit in code spans so
+# they neither autolink nor leave "mentioned" events on the issues. The
+# concurrency group keeps two overlapping runs (an open followed at once by
+# a label, say) from each creating a comment.
 #
 # The job runs on synchronize as well as open and edit so that a result
 # exists for every head commit. A required status check is evaluated per
@@ -49,6 +58,10 @@ on:
     branches:
       - staging
       - prod
+
+concurrency:
+  group: pr-issue-link-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -90,6 +103,10 @@ jobs:
           case "$AUTHOR_ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR) is_team=true ;;
           esac
+
+          # The description is searched with HTML comments removed, so the
+          # pull request template's own examples never become candidates.
+          body=$(printf '%s' "$PR_BODY" | perl -0pe 's/<!--.*?-->//gs')
 
           # The one comment this check owns on the pull request, found by its
           # marker. Edited in place if present; created only when asked to.
@@ -169,22 +186,21 @@ jobs:
           # pipefail from ending the script before fail() can explain why.
 
           if [ "$is_team" = true ]; then
-            ticket=$(printf '%s\n%s\n%s\n' "$PR_TITLE" "$PR_BODY" "$HEAD_REF" \
+            ticket=$(printf '%s\n%s\n%s\n' "$PR_TITLE" "$body" "$HEAD_REF" \
               | grep -oiE "\b$LINEAR_TEAM_KEY-[0-9]+\b" | head -n1 | tr '[:lower:]' '[:upper:]' || true)
             if [ -n "$ticket" ]; then
               pass "References Linear ticket $ticket."
             fi
           fi
 
-          # `#N` in the title or body, plus a delimited bare number in the
-          # branch name (fix/2057-manual-run-input). Ticket references are
-          # removed from the branch first so KEEP-1080 is not read as #1080.
-          # At most ten distinct candidates are looked up.
+          # `#N` in the title or body, plus an explicit issue form in the
+          # branch name (issue-2057, issue/2057, gh-2057). A bare number in a
+          # branch name is not a reference: it can coincide with an unrelated
+          # accepted issue. At most ten distinct candidates are looked up.
           candidates=$(
             {
-              printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' || true
-              printf '%s\n' "$HEAD_REF" | sed -E "s/$LINEAR_TEAM_KEY-[0-9]+//Ig" \
-                | grep -oE '(^|[-_/])[0-9]+([-_/]|$)' | tr -d '_/-' || true
+              printf '%s\n%s\n' "$PR_TITLE" "$body" | grep -oE '#[0-9]+' | tr -d '#' || true
+              printf '%s\n' "$HEAD_REF" | grep -oiE '(^|/)(issue|gh)[-/]?[0-9]+' | grep -oE '[0-9]+$' || true
             } | awk '!seen[$0]++ { if (++n <= 10) print }'
           )
 
@@ -195,18 +211,18 @@ jobs:
           reasons=""
           for n in $candidates; do
             if ! issue_json=$(gh api "repos/$REPO/issues/$n" 2>/dev/null); then
-              reasons+="  #$n does not resolve to an issue in $REPO."$'\n'
+              reasons+="  \`#$n\` does not resolve to an issue in $REPO."$'\n'
               continue
             fi
             if printf '%s' "$issue_json" | jq -e '.pull_request' >/dev/null 2>&1; then
-              reasons+="  #$n is a pull request, not an issue."$'\n'
+              reasons+="  \`#$n\` is a pull request, not an issue."$'\n'
               continue
             fi
             if ! printf '%s' "$issue_json" | jq -e --arg l "$ACCEPTED_LABEL" \
               '.labels | map(.name) | index($l)' >/dev/null 2>&1; then
               state=$(printf '%s' "$issue_json" | jq -r '.state')
               labels=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(", ")')
-              reasons+="  #$n is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."$'\n'
+              reasons+="  \`#$n\` is not marked '$ACCEPTED_LABEL' (state: $state; labels: ${labels:-none})."$'\n'
               continue
             fi
             pass "References accepted issue #$n."

--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -9,11 +9,19 @@ name: PR Issue Link
 #
 #   - a GitHub issue (`#1978`) that exists, is an issue, and carries the
 #     `accepted` label - the issue-first policy in ISSUES.md; or
-#   - a Linear ticket (`KEEP-1234`), which only counts from a team author
-#     (OWNER, MEMBER, COLLABORATOR), since outside contributors cannot have
-#     one. Team branches are named `feat/KEEP-1234-description`, which is
-#     also what Linear's GitHub integration links on. The ticket is matched
-#     by shape only; Linear is not consulted.
+#   - a Linear ticket (`KEEP-1234`), which only counts on a team pull
+#     request, since outside contributors cannot have one. Team branches
+#     are named `feat/KEEP-1234-description`, which is also what Linear's
+#     GitHub integration links on. The ticket is matched by shape only;
+#     Linear is not consulted.
+#
+# A pull request is a team pull request when its head branch lives in this
+# repository (only push access can create one) or when the payload's
+# author_association is OWNER, MEMBER or COLLABORATOR. The head-repository
+# test comes first because author_association is computed from what the
+# workflow token can see: a member whose organization membership is private
+# is reported as CONTRIBUTOR, which is why the old author-only skip failed
+# team pull requests.
 #
 # The job runs on synchronize as well as open and edit so that a result
 # exists for every head commit. A required status check is evaluated per
@@ -51,6 +59,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
           AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
           REPO: ${{ github.repository }}
@@ -66,6 +75,9 @@ jobs:
           set -euo pipefail
 
           is_team=false
+          if [ -n "$HEAD_REPO" ] && [ "$HEAD_REPO" = "$REPO" ]; then
+            is_team=true
+          fi
           case "$AUTHOR_ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR) is_team=true ;;
           esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,10 @@ before the pull request. **[ISSUES.md](ISSUES.md) is the policy** - what needs a
 issue, what goes straight to a pull request, and what happens after you file one.
 
 The short version: open an issue, wait for the `accepted` label, then reference
-it in your pull request title (`fix: #1978 description`). Typos, broken links,
-formatting, and docs corrected to match existing behaviour skip all of that.
+it from your pull request - in the title (`fix: #1978 description`), as
+`Closes #1978` in the description, or in an `issue-1978` branch name. Typos,
+broken links, formatting, and docs corrected to match existing behaviour skip
+all of that.
 
 ## Table of Contents
 
@@ -82,6 +84,11 @@ make hybrid-down      # Teardown
    git checkout -b feat/KEEP-123-description
    ```
 
+   That is the team's shape, with the Linear ticket in the branch name. Outside
+   contributors have no ticket: name the branch after the issue
+   (`fix/issue-1978-description`) or however you like, and put the issue number
+   in the pull request title.
+
 2. Make your changes and test thoroughly
 
 3. Run quality checks:
@@ -115,7 +122,7 @@ make hybrid-down      # Teardown
 
 ### PR Guidelines
 
-1. **Title**: Conventional commit format carrying the reference, `<type>: #<issue> <description>` or `<type>(scope): #<issue> <description>`. Internal work uses its Linear code in the same position (`feat: KEEP-1234 description`); outside contributions use the GitHub issue number (`fix: #1978 description`). Enforced by the `pr-title-check` and `pr-issue-link` workflows
+1. **Title**: Conventional commit format, `<type>: <description>` or `<type>(scope): <description>`, enforced by the `pr-title-check` workflow. Outside contributions put the accepted issue number after the type (`fix: #1978 description`); the `pr-issue-link` check also accepts `Closes #1978` in the description or an `issue-1978` branch name, and fails a pull request that has none of them with a comment saying what is missing. Internal work carries its Linear ticket in the branch name instead (`feat/KEEP-1234-description`)
 2. **Base branch**: Always target `staging`
 3. **Description**: Explain what and why, not just how
 4. **Scope**: One change per pull request. If a part of it could ship and be correct with the rest reverted, split it

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -143,17 +143,19 @@ request. Two small independent fixes are two.
 
 Once your issue carries `accepted`:
 
-1. **Reference the issue in the pull request title**, after the conventional
-   commit type:
+1. **Reference the issue from the pull request.** The title is the place for
+   it, after the conventional commit type:
 
    ```
    fix: #1978 return 403 with a body on public /api/chains
    feat(cli): #2014 add --require-verified to execute status
    ```
 
-   This mirrors the internal `fix: KEEP-1234 description` convention. The
-   `pr-title-check` workflow already accepts this shape; a separate check
-   resolves the issue number and confirms the issue carries `accepted`.
+   `Closes #1978` in the description or an `issue-1978` branch name also
+   satisfies the check; a bare number in a branch name does not. The
+   `pr-title-check` workflow already accepts this title shape; a separate
+   check, `check-issue-link`, resolves the issue number and confirms the issue
+   carries `accepted`.
 
 2. Fill in the pull request template. The description explains what and why -
    the diff already shows how.
@@ -162,8 +164,11 @@ Once your issue carries `accepted`:
 
 Pull requests that need no issue (the list above) are exempt from the check
 automatically when their type is `docs`, `chore`, or `style`. Anything else
-without a reference is failed by CI with instructions. A maintainer can apply
-`no-issue-required` to exempt a pull request the rules did not anticipate.
+without an accepted reference is failed by CI, which leaves a comment on the
+pull request saying what it found and what to do. The check reruns on every
+push and edit, but not when the issue's labels change: once `accepted` lands,
+edit the title or re-run the job. A maintainer can apply `no-issue-required` to
+exempt a pull request the rules did not anticipate.
 
 ## Continuing an existing issue
 


### PR DESCRIPTION
## Issue

Internal CI change, tracked in Linear via the branch name; no GitHub issue.

## What this changes

`check-issue-link` (`.github/workflows/pr-issue-link.yml`) becomes a reference gate for every pull request into `staging` and `prod`, not only those from outside contributors.

- Reads the title, description and head branch. Passes on a GitHub issue `#N` that exists, is an issue, and carries `accepted`, or on a Linear ticket reference (`KEEP-N`, matched by shape only; Linear is not called). HTML comments are removed from the description first, so the template's own examples never count. From the branch name a GitHub issue is taken only in an explicit form (`issue-N`, `issue/N`, `gh-N`): a bare number is not a reference, and a `2026-` date prefix coincided with an open accepted issue during verification. The ticket form only counts on a team pull request, so outside contributors still need an accepted issue and ISSUES.md is unchanged.
- A team pull request is one whose head branch lives in this repository (only push access can create one), or whose `author_association` is OWNER, MEMBER or COLLABORATOR. The head-repository test comes first because `author_association` is computed from what the workflow token can see: a member whose organization membership is private is reported as CONTRIBUTOR. That is why the old member skip did not fire on this very pull request (run 33461306716) and why team pull requests have been carrying `no-issue-required` to get past the gate.
- On failure, leaves one comment on the pull request with the reasons it found and what to do (a team variant points at the branch name, the contributor variant at the issue-first policy), edits that same comment on every later run, and reduces it to a one-line resolved note once the check passes or the exemption label is applied. Issue numbers in the comment sit in code spans so they neither autolink nor leave "mentioned" events on the issues, and a per-pull-request concurrency group keeps two overlapping runs from each creating a comment. It also emits an `::error` annotation. This is why `pull-requests` moves from `read` to `write`; the job still checks out nothing, and the comment never echoes the title, description or branch name, which are contributor-controlled text that, rendered as Markdown, could carry mentions or links.
- Adds `synchronize` to the trigger. Required status checks are evaluated per head commit; without it the check would sit at "Expected" after every push until the title was edited. The job checks out nothing, so the rerun is free.
- Adds `release` to the exempt types, for the `release: to prod` pull requests. `hotfix` is not exempt.
- Fixes a silent failure in the existing script: under `pipefail`, a title with no `#N` made the `grep` pipeline exit non-zero before `fail()` printed anything, so the check went red with no explanation in the log (the run above shows only the echoed source and the exit code).

Not in this PR: making the check required. `check-issue-link` is not in the `protected-branches` ruleset's required status checks today, so the gate stays advisory until a repo admin adds it after merge.

## Scope

One workflow file, plus the two contributor-facing pages that describe it: `CONTRIBUTING.md` and `ISSUES.md` now name the three places a reference may sit, that a bare branch number does not count, that a failure leaves a comment, and that internal work carries its ticket in the branch name. The job id is unchanged so a ruleset entry can reference it. No checkout is added; every input still reaches the script through `env` and is never interpolated into it. The token's only write is the check's own comment, and a failed comment write degrades to a warning rather than changing the check result.

## How it was verified

- `actionlint` (0 errors) and `shellcheck -s bash` on the run script (clean).
- The run script, extracted verbatim from the YAML, was executed locally against the 15 open pull requests and 35 synthetic cases, with issue lookups going to the real API read-only and every comment write intercepted by a stand-in `gh` that prints instead of sending (zero comments were posted). Cases include a lowercase `keep-` branch, a ticket reference from an outside author (rejected), a member with a private membership (CONTRIBUTOR association, head in this repository, accepted), a member opening from a fork, a same-repository branch with no reference (rejected), `#N` that is a pull request, a non-existent issue, a null body, a deleted fork (null head repository), a version-like branch name (`some-1.2.3-bump`), a date-prefixed branch (`2026-q3-cleanup`) and a `-patch-1` branch (neither yields a candidate), the pull request template left in the body (no candidate) and with `Closes #N` filled in (passes), the explicit branch forms, more references than the lookup cap, shell metacharacters in the title, body and branch (nothing executed), and the comment lifecycle: create on first failure, edit on a later failure, edit to resolved on pass and on `no-issue-required`, no write on a pull request that never failed. Of the 15 open pull requests: 6 contributor PRs fail with a named reason (an issue not yet accepted, or no reference at all), 3 team PRs pass on the `no-issue-required` label they already carry, and the rest pass on an accepted issue, a ticket in the branch name (this one included), or the `chore` exemption.

## Screenshots

Not applicable; CI only.
