### PR TITLE
ci: build fork pull requests without registry credentials and say so

### DIFF
--- a/.github/workflows/fork-build-notice.yml
+++ b/.github/workflows/fork-build-notice.yml
@@ -1,0 +1,101 @@
+name: Fork Build Notice
+
+# A pull request from a fork cannot get the credentials `build` uses for the
+# image registry cache and the staging build configuration: GitHub passes no
+# secrets, no OIDC token and no environment variables to fork runs. So
+# pr-checks.yml builds fork pull requests without them. The result is a real
+# compile check, but slower and with empty public build args, and every
+# workflow run on a fork pull request waits for a maintainer's approval
+# first. This job says so once, on the pull request, so a slow or waiting
+# `build` is not read by the contributor as their mistake.
+#
+# Only fires for fork pull requests that touch build inputs, judged with the
+# same relevance filter as the build job in pr-checks.yml. Keep the two in
+# step. One comment per pull request, found by its marker and edited in
+# place, reduced to a one-line note if the pull request stops touching build
+# inputs.
+#
+# SAFETY: pull_request_target runs with the base repository's token, which
+# here can write to pull requests so the job can leave its comment. The job
+# never checks out, builds, or executes pull request code. It reads the
+# changed-file list and its own comment through the API and writes nothing
+# but that comment. Do not add a checkout step to this file.
+
+on:
+  pull_request_target:
+    # labeled/unlabeled let a maintainer re-run this on an existing pull
+    # request without a push; the comment is edited in place, so a rerun
+    # costs nothing and notifies nobody.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+    branches:
+      - staging
+      - prod
+
+concurrency:
+  group: fork-build-notice-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  fork-build-notice:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Explain the fork build once
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Same filter as "Check for build-relevant changes" in pr-checks.yml.
+          relevant=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate -q '.[].filename' \
+            | grep -vE '^(docs/|specs/|\.github/|.*\.md$)' | head -n1 || true)
+
+          marker='<!-- fork-build-notice -->'
+          id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- fork-build-notice -->")) | .id' \
+            2>/dev/null | head -n1 || true)
+
+          # A comment failure must never fail this job: the notice is a
+          # courtesy, not a check.
+          write() {
+            local body
+            body=$(printf '%s\n%s\n' "$marker" "$1")
+            if [ -n "$id" ]; then
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api -X PATCH "repos/$REPO/issues/comments/$id" --input - >/dev/null \
+                || echo "::warning::Could not update the fork-build-notice comment."
+            else
+              jq -n --arg body "$body" '{body: $body}' \
+                | gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input - >/dev/null \
+                || echo "::warning::Could not create the fork-build-notice comment."
+            fi
+          }
+
+          if [ -z "$relevant" ]; then
+            echo "No build inputs changed; nothing to explain."
+            if [ -n "$id" ]; then
+              write "This pull request no longer touches build inputs, so the note about the fork build does not apply."
+            fi
+            exit 0
+          fi
+
+          md="### About the \`build\` check on this pull request"$'\n\n'
+          md+="This pull request comes from a fork, so GitHub does not pass it the "
+          md+="credentials \`build\` normally uses for our image registry cache and "
+          md+="staging build configuration. The build still runs and still compiles "
+          md+="the image, so a red \`build\` here is real; it just takes longer than "
+          md+="on team branches."$'\n\n'
+          md+="Every workflow run on a pull request from a fork also waits for a "
+          md+="maintainer to approve it, so checks can sit at \"awaiting approval\" "
+          md+="for a while after each push. Nothing is needed from you for either "
+          md+="of these."
+
+          printf '%s\n' "$md"
+          write "$md"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -252,15 +252,27 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         uses: docker/setup-buildx-action@v4
 
+      # A pull request from a fork gets no secrets, no OIDC token and no
+      # environment variables, so these two steps cannot succeed on one and
+      # are skipped instead. Bake then runs with ECR_REGISTRY empty, which
+      # docker-bake.hcl turns into no registry tags and no registry cache:
+      # the build is a plain compile check, slower and with empty public
+      # build args. fork-build-notice.yml tells the contributor why.
       - name: Configure AWS credentials
-        if: steps.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
+        if: >-
+          steps.changes.outputs.relevant == 'true'
+          && github.actor != 'dependabot[bot]'
+          && github.event.pull_request.head.repo.full_name == github.repository
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.TO_REGION }}
 
       - name: Login to AWS ECR
-        if: steps.changes.outputs.relevant == 'true' && github.actor != 'dependabot[bot]'
+        if: >-
+          steps.changes.outputs.relevant == 'true'
+          && github.actor != 'dependabot[bot]'
+          && github.event.pull_request.head.repo.full_name == github.repository
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 


### PR DESCRIPTION
## Issue

Internal CI change; no GitHub issue. Supersedes #2222, which GitHub closed when its head branch was renamed.

## What this changes

A pull request from a fork gets no secrets, no OIDC token and no environment variables from GitHub, so the `build` job died at `Configure AWS credentials` (`Input required and not supplied: aws-region`) on every code change from a fork, and a required check stayed red for reasons unrelated to the change. Four fork pull requests have been merged with it red.

- `pr-checks.yml`: `Configure AWS credentials` and `Login to AWS ECR` are skipped when the head repository is not this one, next to the existing dependabot guard. Bake then runs with `ECR_REGISTRY` empty, which `docker-bake.hcl` already resolves to no registry tags and no registry cache (`docker buildx bake --print app` confirms `tags`, `cache-from` and `cache-to` come out null). The build becomes a plain compile check on fork pull requests: slower, no cache, empty public build args. The real cached build is still verified where it is today, on the release pull request. This reverses the earlier decision to leave the fork build red, on the grounds that `build` is a required check.
- `fork-build-notice.yml` (new): a `pull_request_target` job, no checkout, that leaves one comment on a fork pull request touching build inputs (same relevance filter as the build job) explaining that the build runs without our credentials, is slower, is still real, and that fork runs wait for approval. Edited in place on later events; reduced to a one-liner if the pull request stops touching build inputs. `labeled`/`unlabeled` are in its triggers so a maintainer can run it on an existing pull request without waiting for a push.

## Scope

Two workflow files. No permission change to `pr-checks.yml`; the notice job has `pull-requests: write` for its own comment only and never checks out pull request code.

## How it was verified

- `actionlint` clean on the new file; the one warning it reports for `pr-checks.yml` (`SC2034`, an unused loop variable in the sandbox readiness step) is pre-existing on `staging` and untouched here. `shellcheck -s bash` clean on the notice script.
- Notice script executed locally against real pull requests with the file list read from the API and every comment write intercepted: code-touching fork pull requests get the comment, an existing comment is edited rather than duplicated, a docs-only fork pull request gets nothing, and a stale note on a docs-only pull request is reduced. Zero comments were posted.
- Fork path of the build job: exercised by #2223, a one-file pull request opened from a fork (`suisuss/keeperhub`) against this branch, so its `pull_request` run used the modified `pr-checks.yml`. On that run's `build` job (https://github.com/KeeperHub/keeperhub/actions/runs/33466094546/job/99726156779): `Check for build-relevant changes` success, `Configure AWS credentials` skipped, `Login to AWS ECR` skipped, `Build images` success with `ECR_REGISTRY` empty, 363 s. Every other job on that run passed except `test-unit`, which fails on every branch today for an unrelated reason (a merge interaction between two earlier pull requests; fix in its own pull request).

## Screenshots

Not applicable; CI only.
