### PR TITLE
fix: align the redispatch test with the paygOverflow charge argument

### DIFF
--- a/tests/unit/workflow-execute-redispatch.test.ts
+++ b/tests/unit/workflow-execute-redispatch.test.ts
@@ -315,6 +315,7 @@ describe("workflow execute redispatch guard", () => {
     expect(mockChargePaygIfBillable).toHaveBeenCalledWith({
       organizationId: "org_1",
       executionId: "exec_pend",
+      paygOverflow: false,
     });
     expect(mockExecuteWorkflowInBackground).toHaveBeenCalledWith(
       "exec_pend",


### PR DESCRIPTION
## Issue

Internal fix for a red `test-unit` on every pull request since 02:06 UTC today; no GitHub issue.

## What this changes

One expectation in `tests/unit/workflow-execute-redispatch.test.ts` (`starts pending reuse once (scheduler handoff)`) gains `paygOverflow: false`.

Two pull requests were each green on their own branch and red together: #2216 added this test, pinning the exact argument object passed to `chargePaygIfBillable` on a pending reuse, and #2209 then added `paygOverflow: executionGuard.limitResult?.paygOverflow === true` to that call in `app/api/workflow/[workflowId]/execute/route.ts`. #2209's last CI run (2026-08-31 17:38) predates #2216's merge (18:49), and the ruleset does not require branches to be up to date with `staging`, so the combination was first seen after #2209 merged (2026-09-01 01:35). `ci-pipeline.yml` on the `staging` push runs no unit tests, so `staging` itself gave no signal; only pull requests did. A pending reuse on the free path is not an overflow, so the expected value is `false`, matching what the route passes.

## Scope

One test file, one assertion. No production code.

## How it was verified

The failing assertion's "Received" block in the CI log (run 33466057685, job `test-unit`) shows the exact object now expected; `app/api/workflow/[workflowId]/execute/route.ts:359` is the source of the added field. `test-unit` on this pull request is the proof.

## Screenshots

Not applicable.
