### PR TITLE
fix: KEEP-1188 advertise protocol write actions as state-mutating

### DIFF
--- a/lib/mcp/workflow-server.ts
+++ b/lib/mcp/workflow-server.ts
@@ -6,26 +6,69 @@ import {
   detectListingTriggerType,
   normalizeTriggerInput,
 } from "@/lib/mcp/trigger-input-schema";
+import { resolveProtocolMeta } from "@/plugins/protocol/steps/resolve-protocol-meta";
+// Protocol registration is an import side effect: each definition module calls
+// registerProtocol at load. Nothing else in the /mcp/w/[slug] route's graph
+// pulls this barrel, so without it resolveProtocolMeta's registry lookup finds
+// nothing and every protocol node falls back to its cached _protocolMeta
+// alone. lib/execute/stablecoin-cap.ts carries the same import for the same
+// reason, after an empty registry silently voided its allowlist.
+import "@/protocols";
 
-function getNodeActionType(node: unknown): unknown {
+type NodeAction = { actionType: unknown; protocolMeta: unknown };
+
+function getNodeAction(node: unknown): NodeAction {
   if (node === null || typeof node !== "object" || !("data" in node)) {
-    return;
+    return { actionType: undefined, protocolMeta: undefined };
   }
   const { data } = node as { data?: unknown };
   if (data === null || typeof data !== "object") {
-    return;
+    return { actionType: undefined, protocolMeta: undefined };
   }
   const config =
     "config" in data ? (data as Record<string, unknown>).config : undefined;
-  const configActionType =
-    config !== null && typeof config === "object" && "actionType" in config
-      ? (config as Record<string, unknown>).actionType
+  const configRecord =
+    config !== null && typeof config === "object"
+      ? (config as Record<string, unknown>)
       : undefined;
   const legacyActionType =
     "actionType" in data
       ? (data as Record<string, unknown>).actionType
       : undefined;
-  return configActionType ?? legacyActionType;
+  return {
+    actionType: configRecord?.actionType ?? legacyActionType,
+    protocolMeta: configRecord?._protocolMeta,
+  };
+}
+
+/**
+ * True for a protocol action node whose action writes on chain.
+ *
+ * Protocol action types are `<protocol>/<action-slug>` (sky/approve-usds,
+ * lido/wsteth-wrap), so they match none of the literal names in
+ * hasIrreversibleEffect's allowlist and none of isWriteActionType's
+ * write-contract/protocol-write substrings. The sky-staking onboarding
+ * listing is built from two of them and advertised readOnlyHint true while
+ * executing an ERC-20 approval and a vault deposit from the org wallet.
+ *
+ * resolveProtocolMeta is the resolver protocolWriteStep already uses to pick
+ * the contract function, so the annotation and the execution path cannot
+ * disagree about what an action does. It reads the registry first, which
+ * covers every registered protocol including ones added after this code, and
+ * falls back to the node's cached _protocolMeta so a node whose protocol is
+ * absent from this process's registry still classifies.
+ */
+function isProtocolWriteNode({
+  actionType,
+  protocolMeta,
+}: NodeAction): boolean {
+  const meta = resolveProtocolMeta({
+    ...(typeof actionType === "string" ? { _actionType: actionType } : {}),
+    ...(typeof protocolMeta === "string"
+      ? { _protocolMeta: protocolMeta }
+      : {}),
+  });
+  return meta?.actionType === "write";
 }
 
 // Broader than workflowType === "write": also catches actions that
@@ -36,7 +79,12 @@ function getNodeActionType(node: unknown): unknown {
 // transaction or send a message the caller cannot recall, so the annotations
 // need this separate, wider check rather than reusing workflowType.
 function hasMutatingNode(nodes: unknown[]): boolean {
-  return nodes.some((node) => hasIrreversibleEffect(getNodeActionType(node)));
+  return nodes.some((node) => {
+    const action = getNodeAction(node);
+    return (
+      hasIrreversibleEffect(action.actionType) || isProtocolWriteNode(action)
+    );
+  });
 }
 
 type ApiResponse = Record<string, unknown>;

--- a/tests/unit/mcp-tool-annotations.test.ts
+++ b/tests/unit/mcp-tool-annotations.test.ts
@@ -24,6 +24,7 @@ import {
   createWorkflowMcpServer,
   type WorkflowListing,
 } from "@/lib/mcp/workflow-server";
+import { ONBOARDING_WORKFLOW_FIXTURES } from "@/scripts/seed/fixtures/onboarding-workflows";
 
 type ToolAnnotations = {
   title?: string;
@@ -197,6 +198,26 @@ function actionNode(id: string, actionType: string): unknown {
   };
 }
 
+/** A protocol action node as the seeder writes it: action type plus the
+ *  cached _protocolMeta blob computeProtocolMeta serialises. */
+function protocolActionNode(
+  id: string,
+  actionType: string,
+  protocolMeta?: string
+): unknown {
+  return {
+    id,
+    type: "action",
+    data: {
+      type: "action",
+      config: {
+        actionType,
+        ...(protocolMeta === undefined ? {} : { _protocolMeta: protocolMeta }),
+      },
+    },
+  };
+}
+
 function listingAnnotations(
   overrides: Partial<WorkflowListing>
 ): ToolAnnotations {
@@ -306,6 +327,74 @@ describe("per-listing workflow MCP server annotations", () => {
     const annotation = listingAnnotations({
       workflowType: "read" as const,
       nodes: [actionNode("n1", actionType)],
+    });
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // Protocol action types are `<protocol>/<action-slug>`, so they match
+  // neither hasIrreversibleEffect's literal allowlist nor isWriteActionType's
+  // write-contract/protocol-write substrings. sky-staking is the listing this
+  // was found on: a live onboarding fixture that approves USDS and deposits it
+  // into the stUSDS vault from the org wallet, advertised read-only.
+  it("advertises the sky-staking onboarding listing as destructive", () => {
+    const skyStaking = ONBOARDING_WORKFLOW_FIXTURES.find(
+      (fixture) => fixture.listedSlug === "sky-staking"
+    );
+    expect(skyStaking, "sky-staking onboarding fixture").toBeDefined();
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: skyStaking?.nodes ?? [],
+    });
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // Pins the `import "@/protocols"` in workflow-server.ts. These nodes carry
+  // no cached _protocolMeta, so the registry lookup is the only thing that can
+  // classify them; dropping that import empties the registry and turns every
+  // one of these read-only again, silently.
+  it.each([
+    "sky/approve-usds",
+    "sky/st-usds-vault-deposit",
+  ])("treats a read-typed listing containing %s as destructive without cached metadata", (actionType) => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [protocolActionNode("n1", actionType)],
+    });
+    expect(annotation.readOnlyHint).toBe(false);
+    expect(annotation.destructiveHint).toBe(true);
+  });
+
+  // The other half of the acceptance criteria: widening the check must not
+  // swallow the protocol reads, which are the bulk of the listed catalogue.
+  it("still advertises a protocol read action as read-only", () => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [protocolActionNode("n1", "sky/get-usds-balance")],
+    });
+    expect(annotation.readOnlyHint).toBe(true);
+    expect(annotation.destructiveHint).toBe(false);
+  });
+
+  // resolveProtocolMeta falls back to the node's cached blob when the registry
+  // has no such protocol. That fallback is what keeps a listing authored
+  // against a protocol this process does not know from reading as read-only.
+  it("falls back to cached _protocolMeta for an unregistered protocol", () => {
+    const annotation = listingAnnotations({
+      workflowType: "read" as const,
+      nodes: [
+        protocolActionNode(
+          "n1",
+          "somefutureprotocol/vault-deposit",
+          JSON.stringify({
+            protocolSlug: "somefutureprotocol",
+            contractKey: "vault",
+            functionName: "deposit",
+            actionType: "write",
+          })
+        ),
+      ],
     });
     expect(annotation.readOnlyHint).toBe(false);
     expect(annotation.destructiveHint).toBe(true);


### PR DESCRIPTION
## Issue

No GitHub issue - tracked in Linear as [KEEP-1188](https://linear.app/keeperhubapp/issue/KEEP-1188/readonlyhint-advertises-state-mutating-workflows-as-read-only-to-mcp). Distinct from #2014, which is about `workflowType` on newly created write-only workflows; nothing here touches that path.

## What this changes

A listed workflow built from protocol write actions advertises `readOnlyHint: true` to MCP agents. Agents invoke read-only tools speculatively without confirmation, and the call route sends a `read` listing to `handleReadWorkflow`, which executes the body server-side on the org wallet. For the `sky-staking` onboarding fixture that is an ERC-20 approval followed by a stUSDS vault deposit, auto-approved.

`hasIrreversibleEffect` is an allowlist of literal action-type names - `web3/*`, `tempo/*`, the message senders. Protocol action types are `<protocol>/<action-slug>`, so `sky/approve-usds` and `sky/st-usds-vault-deposit` match nothing in it, and they match neither of `isWriteActionType`'s `write-contract`/`protocol-write` substrings either. Every protocol write fell through both.

`hasMutatingNode` now also asks `resolveProtocolMeta` - the resolver `protocolWriteStep` already uses to pick the contract function - so the annotation and the execution path cannot disagree about what an action does. It reads the protocol registry first, covering every registered protocol including ones added after this code, and falls back to the node's cached `_protocolMeta` so a node whose protocol is absent from this process's registry still classifies. `getNodeActionType` becomes `getNodeAction` so one traversal yields both fields.

Worth knowing, since neither is predictable from the title:

- **`workflow-server.ts` now imports `@/protocols`.** The registry is populated by import side effect and nothing else in the `/mcp/w/[slug]` route's graph pulls the barrel, so without it the registry lookup finds nothing. `lib/execute/stablecoin-cap.ts` carries the same import for the same reason, after an empty registry silently voided its allowlist. The two cases asserting nodes with no cached metadata pin it: dropping the import turns exactly those read-only again.
- **Delivery mode is untouched.** `isWriteActionType`, `deriveWorkflowType`, the call route's read/write fork, the x402 output example and OpenAPI keep the narrow predicate they need to stay in lockstep with the calldata generator. I audited the other `workflowType` consumers - `call/route.ts:725`, `openapi/route.ts:187`, `validate-workflow.ts:329` are all delivery-mode and correct as they stand. `workflow-server.ts` was the only one treating `workflowType` as a safety property.

The allowlist residual is narrower but not gone: a non-protocol plugin that broadcasts or emits still has to be named in `lib/mcp/action-type.ts`. The existing test pinning that residual is unchanged. Closing it properly wants a declared side-effect field on `PluginAction`, which is out of scope here.

## Scope

One change. The predicate widening and the `@/protocols` import cannot ship apart - without the import the widened predicate classifies nothing, and without the widening the import is dead weight.

## How it was verified

Four cases added to `tests/unit/mcp-tool-annotations.test.ts`, all four confirmed failing against unmodified `lib/` by stashing the fix and re-running:

- the real `sky-staking` onboarding fixture advertises `readOnlyHint: false` / `destructiveHint: true` - the ticket's acceptance criterion, keyed on the fixture so drift in it is caught
- `sky/approve-usds` and `sky/st-usds-vault-deposit` as nodes carrying no `_protocolMeta`, which only the registry lookup can classify
- the `_protocolMeta` fallback for an unregistered protocol slug

Plus one that is green before and after, guarding the other half of the criteria: a protocol *read* action still advertises `readOnlyHint: true`.

```
vitest run tests/unit/mcp-tool-annotations.test.ts tests/unit/mcp-calldata.test.ts \
  tests/unit/onboarding-workflows.test.ts tests/unit/validate-workflow-structural.test.ts \
  tests/unit/validate-workflow-deep.test.ts
  -> 178 passed

tsc --noEmit                                        -> clean
biome check lib/mcp/workflow-server.ts tests/unit/mcp-tool-annotations.test.ts -> clean
```

---

- [x] Targets `staging`
- [x] Title carries the ticket code
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed