### PR TITLE
fix: KEEP-1187 freeze workflowType on listed workflows

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -680,7 +680,27 @@ export async function PATCH(
     );
     const workflowTypeChanged =
       resolvedWorkflowType !== existingWorkflow.workflowType;
-    if (workflowTypeChanged) {
+    // Derive freely until the workflow is published, freeze it afterwards.
+    // Once a row is listed its workflowType is part of a call contract that
+    // external, possibly paying, callers already depend on, so an ordinary
+    // editor save must not change it as a side effect — the
+    // WORKFLOW_TYPE_FROZEN gate below rejects the edits that would.
+    //
+    // The freeze deliberately does not cover the PATCH that does the listing
+    // (`isTransitioningToListed`): that request is the publish event itself,
+    // there is no prior contract to protect, and the curator publish path
+    // (lib/mcp/listing.ts::listWorkflow) derives at exactly the same moment.
+    //
+    // A row that is already listed and whose stored type already disagreed
+    // with its nodes before this PATCH still reaches here with
+    // workflowTypeChanged true when the PATCH does not touch nodes. It is
+    // left as-is rather than silently repaired: repairing would republish a
+    // different contract on the back of an unrelated edit, and rejecting
+    // would lock the owner out of renaming their own workflow.
+    const isWorkflowTypeFrozen =
+      !isTransitioningToUnlisted && existingWorkflow.isListed === true;
+    const workflowTypePersisted = workflowTypeChanged && !isWorkflowTypeFrozen;
+    if (workflowTypePersisted) {
       updateData.workflowType = resolvedWorkflowType;
     }
 
@@ -724,6 +744,31 @@ export async function PATCH(
         updateData.inputSchema !== undefined
           ? updateData.inputSchema
           : existingWorkflow.inputSchema;
+
+      // Freezing workflowType on a listed row is the mirror of
+      // MISSING_WRITE_ACTION below: that gate stops a listed "write" from
+      // losing the write node its type promises, this one stops a listed
+      // "read" from gaining one. Without it, adding a write node to a listed,
+      // priced "read" workflow silently reclassified the row — the call route
+      // switched from executing the workflow with the owner's wallet to
+      // returning unsigned calldata the caller must sign and send, and the
+      // advertised x402 output example, the OpenAPI response shape and
+      // readOnlyHint changed with it — leaving a listingVersion bump as the
+      // only signal to callers.
+      //
+      // `checkNodes` is what keeps this to edits that introduce the change.
+      // On a frozen (already-listed) row it means `updateData.nodes !== undefined`,
+      // since isTransitioningToListed is false there by construction; a
+      // divergence that pre-dates the PATCH is handled at the derive above.
+      if (isWorkflowTypeFrozen && checkNodes && workflowTypeChanged) {
+        return NextResponse.json(
+          {
+            error: "WORKFLOW_TYPE_FROZEN",
+            message: `Listed workflows cannot change workflowType. This edit would change it from '${existingWorkflow.workflowType}' to '${resolvedWorkflowType}', which changes what POST /api/mcp/workflows/<slug>/call returns for callers of the published listing. Revert the change, or unlist the workflow before saving these changes.`,
+          },
+          { status: 422 }
+        );
+      }
 
       // Gate ordering matches the publish path (lib/mcp/listing.ts::listWorkflow):
       // write-action -> bare-@ -> input-schema. Same DB state therefore yields
@@ -775,15 +820,18 @@ export async function PATCH(
 
     // Bump listingVersion when a listed (or about-to-be-listed) workflow has
     // its schema-defining fields changed via this route — including an
-    // auto-flip of workflowType. Keeps per-workflow MCP consumers in sync
-    // without a dedicated version endpoint.
+    // auto-flip of workflowType on the PATCH that lists it. Keeps per-workflow
+    // MCP consumers in sync without a dedicated version endpoint. The flip is
+    // keyed to what was persisted, not to what was derived: on a frozen row
+    // the derived type is discarded, so a bump there would advertise a change
+    // that did not happen.
     if (
       willBeListed &&
       (body.nodes !== undefined ||
         body.edges !== undefined ||
         body.inputSchema !== undefined ||
         body.outputMapping !== undefined ||
-        workflowTypeChanged)
+        workflowTypePersisted)
     ) {
       updateData.listingVersion = sql`${workflows.listingVersion} + 1`;
     }

--- a/tests/integration/workflow-listing-route.test.ts
+++ b/tests/integration/workflow-listing-route.test.ts
@@ -1682,4 +1682,174 @@ describe("PATCH /api/workflows/[workflowId] — workflowType auto-flip", () => {
     expect(response.status).toBe(200);
     expect(capturedSet.data?.workflowType).toBeUndefined();
   });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // KEEP-1187: the auto-flip above is correct while a workflow is a draft
+  // and wrong once it is published. On a listed row workflowType is part of
+  // the call contract external callers have already paid against, so the
+  // flip is frozen and the edit that would cause it is rejected instead.
+  // ───────────────────────────────────────────────────────────────────────
+
+  const READ_ONLY_NODE = {
+    id: "webhook-1",
+    type: "action",
+    data: {
+      type: "action",
+      config: {
+        actionType: "webhook/send-webhook",
+        webhookUrl: "https://example.com",
+        webhookMethod: "POST",
+      },
+    },
+  };
+
+  function makeListedRead(overrides: Record<string, unknown> = {}) {
+    return makeWorkflow({
+      isListed: true,
+      listedSlug: "live-read",
+      listedAt: new Date(),
+      inputSchema: { type: "object" },
+      priceUsdcPerCall: "1.00",
+      workflowType: "read",
+      nodes: [],
+      ...overrides,
+    });
+  }
+
+  it("KEEP-1187: rejects WORKFLOW_TYPE_FROZEN when a listed 'read' workflow gains a write node", async () => {
+    mockWorkflowsFindFirst.mockResolvedValue(makeListedRead());
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [WRITE_CONTRACT_NODE], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("WORKFLOW_TYPE_FROZEN");
+    expect(data.message).toContain("'read'");
+    expect(data.message).toContain("'write'");
+    // The row must be left alone entirely — no type flip, and no
+    // listingVersion bump advertising a change that was refused.
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+    expect(capturedSet.data).toBeNull();
+  });
+
+  it("KEEP-1187: the same edit succeeds and re-derives once the workflow is unlisted", async () => {
+    // Acceptance path the 422 message points the owner at: unlist, then save.
+    // listedSlug/listedAt survive unlisting, so the row is unmistakably a
+    // previously-published one rather than a fresh draft.
+    mockWorkflowsFindFirst.mockResolvedValue(
+      makeListedRead({ isListed: false })
+    );
+    mockUpdateReturning.mockResolvedValue([
+      makeListedRead({
+        isListed: false,
+        workflowType: "write",
+        nodes: [WRITE_CONTRACT_NODE],
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [WRITE_CONTRACT_NODE], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBe("write");
+  });
+
+  it("KEEP-1187: unlisting in the same PATCH that adds the write node re-derives", async () => {
+    // The unlist-and-clean-up bypass the other listed-workflow gates already
+    // grant: the post-patch state never reaches the bazaar, so there is no
+    // published contract left to protect.
+    mockWorkflowsFindFirst.mockResolvedValue(makeListedRead());
+    mockUpdateReturning.mockResolvedValue([
+      makeListedRead({
+        isListed: false,
+        workflowType: "write",
+        nodes: [WRITE_CONTRACT_NODE],
+      }),
+    ]);
+
+    const response = await PATCH(
+      createRequest("PATCH", {
+        isListed: false,
+        nodes: [WRITE_CONTRACT_NODE],
+        edges: [],
+      }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBe("write");
+  });
+
+  it("KEEP-1187: listing a 'read' row whose nodes already imply write still derives on the publish PATCH", async () => {
+    // The freeze must not swallow the publish event itself. Listing is the
+    // moment the contract is minted, so deriving here is what the curator
+    // publish path (lib/mcp/listing.ts::listWorkflow) does too — blocking it
+    // would strand the row with a type its own nodes contradict.
+    mockWorkflowsFindFirst.mockResolvedValue(
+      makeListedRead({ isListed: false, nodes: [WRITE_CONTRACT_NODE] })
+    );
+    mockUpdateReturning.mockResolvedValue([
+      makeListedRead({
+        workflowType: "write",
+        nodes: [WRITE_CONTRACT_NODE],
+      }),
+    ]);
+
+    const response = await PATCH(createRequest("PATCH", { isListed: true }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBe("write");
+  });
+
+  it("KEEP-1187: a listed 'write' workflow losing its write node is still rejected", async () => {
+    // The mirror direction. deriveWorkflowType never demotes to "read", so
+    // this never reached the freeze — MISSING_WRITE_ACTION owns it, and the
+    // two gates together close both directions on a listed row.
+    mockWorkflowsFindFirst.mockResolvedValue(
+      makeListedRead({
+        listedSlug: "live-write",
+        workflowType: "write",
+        nodes: [WRITE_CONTRACT_NODE],
+      })
+    );
+
+    const response = await PATCH(
+      createRequest("PATCH", { nodes: [READ_ONLY_NODE], edges: [] }),
+      { params: mockParams }
+    );
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.error).toBe("MISSING_WRITE_ACTION");
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it("KEEP-1187: an edit that does not touch nodes on a diverged listed row neither flips nor bumps", async () => {
+    // A listed row whose stored type already disagreed with its nodes before
+    // this PATCH (set out-of-band, or by a path that does not derive). The
+    // rename must go through untouched: repairing the type would republish a
+    // different contract as a side effect of a rename, and rejecting would
+    // leave the owner unable to edit their own workflow at all.
+    mockWorkflowsFindFirst.mockResolvedValue(
+      makeListedRead({ nodes: [WRITE_CONTRACT_NODE] })
+    );
+    mockUpdateReturning.mockResolvedValue([
+      makeListedRead({ nodes: [WRITE_CONTRACT_NODE], name: "Renamed" }),
+    ]);
+
+    const response = await PATCH(createRequest("PATCH", { name: "Renamed" }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(200);
+    expect(capturedSet.data?.workflowType).toBeUndefined();
+    expect(capturedSet.data?.listingVersion).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Issue

KEEP-1187 — https://linear.app/keeperhubapp/issue/KEEP-1187

## What this changes

`PATCH /api/workflows/[workflowId]` derived `workflowType` from node content and
persisted the result unconditionally. Adding a `web3/write-contract` node to a
**listed, priced `read` workflow** therefore flipped the row to `write` on an
ordinary editor save, with no gate and no notification. That changes live paid
behaviour on a published listing:

- `POST /api/mcp/workflows/<slug>/call` switches from `handleReadWorkflow`
  (server executes with the owner's wallet, returns results) to
  `handleWriteWorkflow` (returns unsigned calldata the caller must sign and
  send themselves).
- The advertised x402 output example switches from `WORKFLOW_OUTPUT_EXAMPLE` to
  `CALLDATA_OUTPUT_EXAMPLE`, the published OpenAPI response shape changes, and
  `readOnlyHint` flips to `false`.
- A `listingVersion` bump was the only signal callers received.

The rule is now: **derive freely until the workflow is published, freeze
afterwards.** On a row that is already listed, an edit that would change
`workflowType` is rejected with `422 WORKFLOW_TYPE_FROZEN` and the row is left
unchanged. This mirrors the existing `MISSING_WRITE_ACTION` gate, which already
guards the opposite direction, and matches the "or unlist the workflow before
saving these changes" wording of `SLUG_REQUIRED` / `INPUT_SCHEMA_REQUIRED`.

Three behaviours a reader would not predict from the title:

- **The freeze does not cover the PATCH that lists the workflow.** That request
  is the publish event itself — there is no prior contract to protect, and the
  curator publish path (`lib/mcp/listing.ts::listWorkflow`) derives at exactly
  the same moment. Blocking it would strand the row with a type its own nodes
  contradict.
- **A PATCH that unlists on the way out still derives**, consistent with the
  unlist-and-clean-up bypass the other listed-workflow gates already grant.
- **A listed row whose stored type already disagreed with its nodes is left
  alone** when the PATCH does not touch nodes. Repairing it would republish a
  different contract as a side effect of a rename; rejecting it would lock the
  owner out of editing their own workflow. The gate is keyed to `checkNodes`, so
  it answers only for the edits that introduce the change.

The `listingVersion` bump is now keyed to the type actually **persisted** rather
than the type **derived**, so a frozen row cannot advertise a change that was
refused.

## Scope

One change. The gate, the derive it constrains, and the `listingVersion` term
that fed off the old unconditional derive are interdependent: leaving the bump
keyed to `workflowTypeChanged` would announce a version change on a row whose
type this PR deliberately declines to persist.

Not addressed here, and deliberately so:

- The **up-only ratchet** — `deriveWorkflowType` never demotes `write` back to
  `read`, so an unlisted row that loses its write node keeps its `write` type.
  That is issue #2014's subject.
- `updateWorkflowListing` (`lib/mcp/listing.ts:409`) is a second door: a curator
  can pass an explicit `patch.workflowType` on a listed row. In practice the
  derive plus the `MISSING_WRITE_ACTION` guard below it block the reachable
  cases, but the freeze rule is not applied there. Worth a follow-up if the
  broader freeze proposed on #2014 lands.

## How it was verified

Six regression tests in `tests/integration/workflow-listing-route.test.ts`,
covering both directions and each carve-out above.

Reverting only `route.ts` fails exactly two of them — the two that encode the
bug:

- `expected 200 to be 422` — the listed `read` workflow gaining a write node is
  accepted instead of rejected.
- `expected 'write' to be undefined` — the diverged listed row is silently
  repaired by an unrelated rename.

The other four assert behaviour the fix must preserve (publish-time derive,
unlist-then-edit, unlist-in-the-same-PATCH, and the `MISSING_WRITE_ACTION`
mirror direction) and pass either way by design.

Commands run:

- `vitest run tests/integration/workflow-listing-route.test.ts` — 52 passed
- Related suites (`workflow-listing-lifecycle`, `mcp-workflow-server`,
  `mcp-curator-tools`, `mcp-tool-annotations`, `mcp-workflow-route`) — 148
  passed in total
- `tsc --noEmit` — clean
- `biome check` on the test file — clean. `app/api/workflows` is excluded from
  biome in `biome.json`, so the route file is not linted by `pnpm check`.

## Screenshots

Nothing renders. The change is a 422 on an API route.

---

- [x] Targets `staging`
- [x] Title carries the ticket number
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
