### PR TITLE
fix(spend-cap): show the platform default the limits dashboard called "no cap"

### DIFF
--- a/components/settings/hub/hooks/use-spend-caps.ts
+++ b/components/settings/hub/hooks/use-spend-caps.ts
@@ -53,7 +53,9 @@ export function useSpendCaps(): SpendCapsState {
           // Read the saved value back rather than patching a copy, so the
           // cache other sections read from holds what the server has.
           await refetch();
-          toast.success(base ? "Cap saved" : "Cap cleared");
+          toast.success(
+            base ? "Cap saved" : "Cap cleared - the platform default applies"
+          );
           return;
         }
         toast.error(

--- a/components/settings/hub/limits-section.tsx
+++ b/components/settings/hub/limits-section.tsx
@@ -16,7 +16,7 @@ export function LimitsSection(): React.ReactElement {
       />
 
       <SettingsCard
-        description="EVM and Solana are capped separately, each in its own currency. Leave a field empty for no cap."
+        description="EVM and Solana are capped separately, each in its own currency. Leave a field empty to fall back to the platform default; there is no uncapped setting."
         title="Daily value caps"
       >
         {loading ? (

--- a/components/settings/hub/limits/cap-row.tsx
+++ b/components/settings/hub/limits/cap-row.tsx
@@ -35,24 +35,32 @@ export function CapRow({
   }, [cap.cap, cap.decimals]);
 
   const used = fromBase(cap.used, cap.decimals);
-  const pct = cap.cap
-    ? Math.min(
-        100,
-        (Number(used) / Number(fromBase(cap.cap, cap.decimals))) * 100
-      )
-    : 0;
+  // The platform default governs an org that set no cap of its own, so it is
+  // the denominator here too. Showing "no cap" for that state made a request
+  // the default refused look like the dashboard had not reached the API.
+  const limit = cap.cap ?? cap.effectiveCap;
+  const limitDisplay = limit ? fromBase(limit, cap.decimals) : null;
+  const limitNumber = limitDisplay ? Number(limitDisplay) : 0;
+  const pct =
+    limitNumber > 0 ? Math.min(100, (Number(used) / limitNumber) * 100) : 0;
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border p-4">
       <div className="flex items-baseline justify-between gap-4">
         <span className="font-medium text-sm">{cap.label}</span>
         <span className="font-mono text-muted-foreground text-xs">
-          {used} / {cap.cap ? fromBase(cap.cap, cap.decimals) : "no cap"}{" "}
-          {cap.symbol} today
+          {used} / {limitDisplay ?? "-"} {cap.symbol} today
         </span>
       </div>
 
-      {cap.cap && (
+      {cap.usingDefault && limitDisplay && (
+        <p className="text-muted-foreground text-xs">
+          No cap of your own is set, so the platform default of {limitDisplay}{" "}
+          {cap.symbol} per day applies. There is no uncapped setting.
+        </p>
+      )}
+
+      {limitDisplay && (
         <div className="h-1.5 overflow-hidden rounded-full bg-muted">
           <div
             className="h-full rounded-full bg-foreground/70"
@@ -67,7 +75,7 @@ export function CapRow({
           disabled={disabled}
           id={`cap-${cap.id}`}
           onChange={(e) => setInput(e.target.value)}
-          placeholder="No cap"
+          placeholder="Platform default"
           value={input}
         />
         <span className="text-muted-foreground text-xs">

--- a/lib/wallet/spend-cap.ts
+++ b/lib/wallet/spend-cap.ts
@@ -8,6 +8,13 @@ export type SpendCapResponse = {
   dailyUsedWei: string;
   dailySolanaCapLamports: string | null;
   dailySolanaUsedLamports: string;
+  // What enforcement actually compares against: the org's own cap when it set
+  // one, the platform default otherwise. A null configured cap means the org
+  // set nothing, never that spending is uncapped.
+  effectiveDailyCapWei: string;
+  effectiveDailySolanaCapLamports: string;
+  usingDefaultDailyCap: boolean;
+  usingDefaultDailySolanaCap: boolean;
 };
 
 export type SpendCap = {
@@ -15,7 +22,12 @@ export type SpendCap = {
   label: string;
   symbol: string;
   decimals: number;
+  /** The org's own cap, or null when it set none. */
   cap: string | null;
+  /** The figure enforcement uses. Null only while the response is missing. */
+  effectiveCap: string | null;
+  /** True when `effectiveCap` is the platform default rather than the org's. */
+  usingDefault: boolean;
   used: string;
 };
 
@@ -34,17 +46,21 @@ export function toSpendCaps(data: SpendCapResponse | null): SpendCap[] {
     {
       cap: data?.dailyCapWei ?? null,
       decimals: EVM_DECIMALS,
+      effectiveCap: data?.effectiveDailyCapWei ?? null,
       id: "evm",
       label: "EVM networks",
       symbol: "ETH",
+      usingDefault: data?.usingDefaultDailyCap ?? false,
       used: data?.dailyUsedWei ?? "0",
     },
     {
       cap: data?.dailySolanaCapLamports ?? null,
       decimals: SOLANA_DECIMALS,
+      effectiveCap: data?.effectiveDailySolanaCapLamports ?? null,
       id: "solana",
       label: "Solana",
       symbol: "SOL",
+      usingDefault: data?.usingDefaultDailySolanaCap ?? false,
       used: data?.dailySolanaUsedLamports ?? "0",
     },
   ];

--- a/tests/unit/spend-cap-mapping.test.ts
+++ b/tests/unit/spend-cap-mapping.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { toSpendCaps } from "@/lib/wallet/spend-cap";
+
+const RESPONSE = {
+  dailyCapWei: null,
+  dailyUsedWei: "5000000000000000",
+  dailySolanaCapLamports: "1000000000",
+  dailySolanaUsedLamports: "250000000",
+  effectiveDailyCapWei: "20000000000000000",
+  effectiveDailySolanaCapLamports: "1000000000",
+  usingDefaultDailyCap: true,
+  usingDefaultDailySolanaCap: false,
+};
+
+describe("toSpendCaps", () => {
+  it("carries the enforced figure through for a chain family with no cap of its own", () => {
+    const [evm] = toSpendCaps(RESPONSE);
+
+    // An unset cap is not an uncapped one: the row has to be able to show the
+    // platform default the API is enforcing.
+    expect(evm.cap).toBeNull();
+    expect(evm.effectiveCap).toBe("20000000000000000");
+    expect(evm.usingDefault).toBe(true);
+  });
+
+  it("reports a configured cap as the org's own", () => {
+    const [, solana] = toSpendCaps(RESPONSE);
+
+    expect(solana.cap).toBe("1000000000");
+    expect(solana.effectiveCap).toBe("1000000000");
+    expect(solana.usingDefault).toBe(false);
+  });
+
+  it("claims no default when the response is missing", () => {
+    for (const cap of toSpendCaps(null)) {
+      expect(cap.effectiveCap).toBeNull();
+      expect(cap.usingDefault).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What was reported

Setting the EVM daily spending cap to "no cap" in the dashboard did not appear to reach the API for several hours, and only seemed to take effect after a UTC day reset.

## What is actually happening

The cap does reach the API immediately. There is no propagation delay and no cache: `checkAndReserveExecution` and `reserveOrgValue` read `organization_spend_caps` inside the reserving transaction on every request.

The problem is that the dashboard offers a state the API does not have. `components/settings/hub/limits-section.tsx` said "Leave a field empty for no cap", `cap-row.tsx` rendered an unset cap as `used / no cap` with `No cap` as the input placeholder and no usage bar. But an organization that sets no cap of its own is enforced against the platform default in `lib/execute/spend-cap-defaults.ts`, currently 0.02 ETH per day for EVM. `null` means "this organization configured nothing", never "unlimited".

So clearing the cap did nothing the operator expected. The default kept refusing native value above its ceiling, and the refusals stopped at the next UTC midnight, when `sumOrgValueTodayWei` rolls the daily total rather than when the setting propagated. That is what made a same-second write look like a multi-hour delay.

The older `components/organization/spend-cap-section.tsx` already words this correctly ("No cap set - the platform default applies"), and the `get_spending_limits` MCP tool description spells it out for agents. The settings hub is the surface that lost it.

## The change

The GET on `/api/analytics/spend-cap` already returns `effectiveDailyCapWei`, `effectiveDailySolanaCapLamports`, `usingDefaultDailyCap` and `usingDefaultDailySolanaCap`. The client-side `SpendCapResponse` type dropped all four, so the UI had no way to show what is enforced.

- `lib/wallet/spend-cap.ts`: carry the effective figure and the default flag through `SpendCapResponse` and `SpendCap`.
- `cap-row.tsx`: use the effective cap as the denominator and draw the usage bar against it, so an organization on the default can see how close it is. Add a line naming it as the platform default and stating there is no uncapped setting. Placeholder becomes "Platform default".
- `limits-section.tsx`: the card description now says an empty field falls back to the platform default.
- `use-spend-caps.ts`: the clear toast says the platform default applies.
- New unit test covering the mapping, so the effective figure cannot be silently dropped from the client type again.

No server or enforcement behaviour changes.