### PR TITLE
fix(analytics): show the gas executed nodes spent, and the chain it was spent on

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1386,7 +1386,16 @@ export async function getStepLogs(
   // runs table, so a row the backfill has reached and one it has not resolve
   // the same way.
   const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
-  const stepOwnGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(${logOutputField("gasUsed")} AS NUMERIC))`;
+  // `triggerGasUsed` is the last arm on purpose: it is the fee on the
+  // transaction that fired an on-chain trigger, which the keeper did not send.
+  // It is deliberately absent from `gasUsed` so no rollup counts it as the
+  // organization's spend, and is read here only so the trigger's own row shows
+  // what that transaction cost. See lib/workflow/nodes/trigger-gas.
+  const stepOwnGasWei = sql`COALESCE(
+    ${workflowExecutionLogs.gasUsedWei},
+    CAST(${logOutputField("gasUsed")} AS NUMERIC),
+    CAST(${logOutputField("triggerGasUsed")} AS NUMERIC)
+  )`;
 
   const result = await db
     .select({

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1382,6 +1382,12 @@ export async function getStepLogs(
   executionId: string,
   organizationId: string
 ): Promise<StepLog[]> {
+  // Both read the denormalised column first and the JSONB second, matching the
+  // runs table, so a row the backfill has reached and one it has not resolve
+  // the same way.
+  const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
+  const stepOwnGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(${logOutputField("gasUsed")} AS NUMERIC))`;
+
   const result = await db
     .select({
       id: workflowExecutionLogs.id,
@@ -1395,19 +1401,22 @@ export async function getStepLogs(
       error: workflowExecutionLogs.error,
       iterationIndex: workflowExecutionLogs.iterationIndex,
       forEachNodeId: workflowExecutionLogs.forEachNodeId,
-      network: sql<string | null>`${logInputField("network")}`,
-      // Native gas cost this step's transaction incurred, from the sponsorship
-      // ledger. Present only for sponsored transactions, which is also how we
-      // mark a step as sponsored. Matched by (execution, chain) rather than tx
-      // hash, so a run with multiple on-chain writes on the same chain would
-      // show that chain's combined total on each of those steps; correct for
-      // the common one-tx-per-chain case.
-      gasCostWei: sql<string | null>`(
+      network: sql<string | null>`${stepNetwork}`,
+      // Native gas cost this step's transaction incurred, preferring the
+      // sponsorship ledger and falling back to what the step itself reported.
+      // The ledger covers only transactions KeeperHub paid for, so reading it
+      // alone left every directly-paid write showing no gas at all, even though
+      // its own receipt recorded the cost and the run total already counted it.
+      // The ledger is still matched by (execution, chain) rather than tx hash,
+      // so a run with multiple writes on one chain shows that chain's combined
+      // total on each of them; correct for the common one-tx-per-chain case.
+      sponsoredGasWei: sql<string | null>`(
         SELECT SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC))::text
         FROM ${gasCreditUsage}
         WHERE ${gasCreditUsage.executionId} = ${workflowExecutionLogs.executionId}
-        AND ${gasCreditUsage.chainId}::text = ${logInputField("network")}
+        AND ${gasCreditUsage.chainId}::text = ${stepNetwork}
       )`,
+      stepGasWei: sql<string | null>`${stepOwnGasWei}::text`,
     })
     .from(workflowExecutionLogs)
     .innerJoin(
@@ -1439,8 +1448,10 @@ export async function getStepLogs(
     iterationIndex: row.iterationIndex,
     forEachNodeId: row.forEachNodeId,
     network: row.network,
-    gasCostWei: row.gasCostWei,
-    sponsored: row.gasCostWei !== null,
+    gasCostWei: row.sponsoredGasWei ?? row.stepGasWei,
+    // Only ledger-backed gas is sponsored; a step's own receipt means the
+    // organization's wallet paid for it.
+    sponsored: row.sponsoredGasWei !== null,
   }));
 }
 

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -533,6 +533,19 @@ async function getSponsoredGasTotal(
   return result[0]?.totalWei ?? "0";
 }
 
+/**
+ * Chains a run touched, from two sources that each miss cases the other covers:
+ * the step logs name a chain only when the step's own input carried one, and
+ * the sponsorship ledger names one only for transactions KeeperHub paid for.
+ * A run whose spend is ledger-only would otherwise have no chain at all.
+ */
+function unionNetworks(
+  fromLogs: string[] | null,
+  fromLedger: string[] | null
+): string[] {
+  return [...new Set([...(fromLogs ?? []), ...(fromLedger ?? [])])];
+}
+
 function computeAvgDuration(sum: number, durationCount: number): number | null {
   if (durationCount === 0) {
     return null;
@@ -832,10 +845,11 @@ async function computeNetworkBreakdown(
   }
 
   for (const row of workflowResult) {
-    const { network } = row;
-    if (!network) {
-      continue;
-    }
+    // A gas-bearing step whose chain was never recorded used to be skipped
+    // outright, so its gas vanished from the breakdown rather than showing up
+    // anywhere. Bucket it the way the direct arm above already buckets its
+    // own unnamed chains, so the totals stay whole.
+    const network = row.network ?? "unknown";
     const existing = networkMap.get(network);
     if (existing) {
       existing.totalGasWei = addBigIntStrings(
@@ -1094,6 +1108,15 @@ async function fetchWorkflowRuns(
         sql<string>`COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0)::text`.as(
           "gasCostWei"
         ),
+      // The ledger records the chain of every sponsored transaction, which is
+      // the only place a run's spend names a chain when the step that made it
+      // logged none. Without it a ledger-only run had no chain to denominate
+      // its own gas in and the cell fell back to guessing from `networks`.
+      ledgerNetworks: sql<
+        string[]
+      >`COALESCE(ARRAY_AGG(DISTINCT ${gasCreditUsage.chainId}::text), '{}')`.as(
+        "ledgerNetworks"
+      ),
     })
     .from(gasCreditUsage)
     .where(sql`${gasCreditUsage.executionId} IN (${pagedExecutionIds})`)
@@ -1116,6 +1139,7 @@ async function fetchWorkflowRuns(
       networks: logSummary.networks,
       gasNetworks: logSummary.gasNetworks,
       gasCostWei: gasCostSummary.gasCostWei,
+      ledgerNetworks: gasCostSummary.ledgerNetworks,
       transactionHashes: workflowExecutions.transactionHashes,
       error: workflowExecutions.error,
       errorCode: workflowExecutions.errorCode,
@@ -1145,9 +1169,9 @@ async function fetchWorkflowRuns(
     workflowId: row.workflowId,
     workflowName: row.workflowName ?? "(Deleted)",
     directType: null,
-    network: row.network ?? null,
-    networks: row.networks ?? [],
-    gasNetworks: row.gasNetworks ?? [],
+    network: row.network ?? row.ledgerNetworks?.[0] ?? null,
+    networks: unionNetworks(row.networks, row.ledgerNetworks),
+    gasNetworks: unionNetworks(row.gasNetworks, row.ledgerNetworks),
     gasCostWei:
       row.gasCostWei && row.gasCostWei !== "0" ? row.gasCostWei : null,
     transactionHashes: row.transactionHashes,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -3060,6 +3060,10 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
           timestamp: Date.now(),
           triggeredAt: new Date().toISOString(),
         };
+        // Gas burned by the transaction that fired an on-chain trigger. Held
+        // apart from triggerData so it reaches the log as its own field rather
+        // than as trigger output a template could read.
+        let triggerGasUsed: string | undefined;
 
         // Handle webhook mock request for test runs
         if (
@@ -3108,6 +3112,21 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
               } catch {
                 // Non-critical: skip explorer links if lookup fails
               }
+
+              if (typeof triggerData.transactionHash === "string") {
+                try {
+                  const { fetchTriggerTransactionGas } = await import(
+                    "@/lib/workflow/nodes/trigger-gas/step"
+                  );
+                  triggerGasUsed =
+                    (await fetchTriggerTransactionGas(
+                      triggerData.transactionHash,
+                      config.network as string | number
+                    )) ?? undefined;
+                } catch {
+                  // Non-critical: the trigger simply reports no gas.
+                }
+              }
             }
           } else if (
             triggerType === "Schedule" &&
@@ -3136,6 +3155,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         const triggerResult = await triggerStep({
           triggerData,
           network: triggerConfigNetwork(config),
+          triggerGasUsed,
           _context: triggerContext,
         });
 

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -397,6 +397,23 @@ function renderConditionLiteral(value: unknown): string {
 }
 
 /**
+ * The chain a Block/Event/Transfer trigger watches, as the text form the
+ * execution log's `network` column holds. That config is the only place an
+ * on-chain trigger names its chain, so without logging it a run whose later
+ * steps name no chain of their own reaches /analytics with no Network at all.
+ * A trigger with no chain (Manual, Schedule, Webhook) yields undefined.
+ */
+// Exported for testing
+export function triggerConfigNetwork(
+  config: Record<string, unknown>
+): string | undefined {
+  const raw = config.network;
+  return typeof raw === "string" || typeof raw === "number"
+    ? String(raw)
+    : undefined;
+}
+
+/**
  * Evaluate condition expression with template variable replacement.
  *
  * Security (A-01): The transformed expression is evaluated by a safe AST
@@ -3118,6 +3135,7 @@ export async function executeWorkflow(input: WorkflowExecutionInput) {
         // Execute trigger step (handles logging internally)
         const triggerResult = await triggerStep({
           triggerData,
+          network: triggerConfigNetwork(config),
           _context: triggerContext,
         });
 

--- a/lib/workflow/nodes/trigger-gas/step.ts
+++ b/lib/workflow/nodes/trigger-gas/step.ts
@@ -1,0 +1,57 @@
+import "server-only";
+
+import { ErrorCategory, logSystemWarn } from "@/lib/logging";
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { getRpcProvider, isSolanaChain } from "@/lib/rpc/provider-factory";
+
+/**
+ * Native cost, in wei, of the transaction that fired an on-chain trigger.
+ *
+ * The keeper did not send that transaction, so this is deliberately kept apart
+ * from the gas the run itself spent: the executor reports it under
+ * `triggerGasUsed` rather than `gasUsed`, which is the key every gas rollup
+ * reads (lib/workflow/executor/logging.ts resolveGasTotal, the runs
+ * aggregation, and the Gas by Network breakdown). Counting it there would
+ * report a third party's spend as the organization's own, and the Gas Spent
+ * KPI derives the wallet share by subtracting the sponsorship ledger from that
+ * total, so it would skew the split as well.
+ *
+ * Best-effort: a chain we cannot reach, a Solana trigger, or a receipt that has
+ * not propagated yields null and the trigger simply reports no gas.
+ */
+export async function fetchTriggerTransactionGas(
+  transactionHash: string,
+  network: string | number
+): Promise<string | null> {
+  "use step";
+
+  try {
+    const chainId = getChainIdFromNetwork(network);
+    if (isSolanaChain(chainId)) {
+      return null;
+    }
+
+    const manager = await getRpcProvider({ chainId });
+    const receipt = await manager.executeWithFailover(
+      (provider) => provider.getTransactionReceipt(transactionHash),
+      "read"
+    );
+    if (!receipt) {
+      return null;
+    }
+
+    // ethers exposes the total fee (gasUsed * gasPrice) directly, in wei,
+    // which is the same figure the write steps record as their own gasUsed.
+    return receipt.fee.toString();
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.NETWORK_RPC,
+      "[Trigger Gas] Could not read the receipt for the triggering transaction",
+      error,
+      { transaction_hash: transactionHash }
+    );
+    return null;
+  }
+}
+
+fetchTriggerTransactionGas.maxRetries = 0;

--- a/lib/workflow/nodes/trigger/step.ts
+++ b/lib/workflow/nodes/trigger/step.ts
@@ -24,6 +24,8 @@ import {
 type TriggerResult = {
   success: true;
   data: Record<string, unknown>;
+  /** See TriggerInput.triggerGasUsed. Omitted when there is nothing to report. */
+  triggerGasUsed?: string;
 };
 
 export type TriggerInput = StepInput & {
@@ -35,6 +37,13 @@ export type TriggerInput = StepInput & {
    * the Network column from.
    */
   network?: string;
+  /**
+   * Native cost, in wei, of the transaction that fired an on-chain trigger.
+   * Reported under its own key rather than `gasUsed` on purpose: that key is
+   * what every gas rollup sums, and this transaction was sent by whoever
+   * emitted the event, not by the keeper. See lib/workflow/nodes/trigger-gas.
+   */
+  triggerGasUsed?: string;
   /** If set, this call is just to log workflow completion (no trigger execution) */
   _workflowComplete?: {
     executionId: string;
@@ -77,6 +86,7 @@ function executeTrigger(input: TriggerInput): TriggerResult {
   return {
     success: true,
     data: input.triggerData,
+    ...(input.triggerGasUsed ? { triggerGasUsed: input.triggerGasUsed } : {}),
   };
 }
 

--- a/lib/workflow/nodes/trigger/step.ts
+++ b/lib/workflow/nodes/trigger/step.ts
@@ -28,6 +28,13 @@ type TriggerResult = {
 
 export type TriggerInput = StepInput & {
   triggerData: Record<string, unknown>;
+  /**
+   * The chain the trigger node is configured against, when it has one. Logged
+   * rather than executed: it is what puts an on-chain trigger's network into
+   * the run's `workflow_execution_logs` row, which is where /analytics reads
+   * the Network column from.
+   */
+  network?: string;
   /** If set, this call is just to log workflow completion (no trigger execution) */
   _workflowComplete?: {
     executionId: string;

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -234,6 +234,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         nodeType: "trigger",
         status: "success",
         input: { network: "8453" },
+        output: { triggerGasUsed: "77000" },
         startedAt: now,
         network: "8453",
         gasUsedWei: null,
@@ -374,9 +375,20 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
 
     // A read makes no transaction, so no gas is the right answer, not a gap.
     expect(byNode.get("read-1")?.gasCostWei).toBeNull();
-    // The trigger names the chain it watches but spends nothing itself.
+    // The event's own transaction: shown on the trigger row, and not sponsored,
+    // because whoever emitted the event paid for it.
     expect(byNode.get("trigger-1")?.network).toBe("8453");
-    expect(byNode.get("trigger-1")?.gasCostWei).toBeNull();
+    expect(byNode.get("trigger-1")?.gasCostWei).toBe("77000");
+    expect(byNode.get("trigger-1")?.sponsored).toBe(false);
+  });
+
+  it("keeps the triggering transaction's gas out of the run's own total", async () => {
+    const run = await runById(STEPS_ID);
+    // Only the write's 41000. Counting the trigger's 77000 here would report a
+    // third party's spend as the organization's own, and the Gas Spent KPI
+    // derives the wallet share from this figure.
+    expect(run.gasUsedWei).toBe("41000");
+    expect(run.gasNetworks).toEqual(["8453"]);
   });
 
   it("backfills a gas-free legacy row, so the read moves onto the column", async () => {

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -10,6 +10,7 @@ import {
   workflowExecutions,
   workflows,
 } from "../../../lib/db/schema";
+import { gasCreditUsage } from "../../../lib/db/schema-extensions";
 
 // vitest runs in Node, not an SSR context.
 vi.mock("server-only", () => ({}));
@@ -38,6 +39,8 @@ const LEGACY_ID = `${PREFIX}exec_legacy`;
 const LEGACY_GAS_ID = `${PREFIX}exec_legacy_gas`;
 /** Same shape as LEGACY_ID, reserved for the backfill to repair in place. */
 const BACKFILL_ID = `${PREFIX}exec_backfill`;
+/** A run whose only record of spend is the sponsorship ledger, not a step. */
+const SPONSORED_ID = `${PREFIX}exec_sponsored`;
 
 // Log ids are the backfill's keyset cursor, so they are chosen, not incidental:
 // the backfill case runs one batch from the cursor below, and every other
@@ -60,6 +63,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
   let applyBatch: (afterId: string, batchSize: number) => Promise<number>;
 
   async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM gas_credit_usage WHERE execution_id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
     await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
@@ -124,6 +128,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         execution(LEGACY_ID, "Insufficient BASE balance"),
         execution(LEGACY_GAS_ID),
         execution(BACKFILL_ID, "Insufficient BASE balance"),
+        execution(SPONSORED_ID),
       ]);
 
     // Two row shapes matter here, and they are seeded separately on purpose.
@@ -214,7 +219,35 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         network: null,
         gasUsedWei: null,
       },
+      {
+        id: `${PREFIX}log_sponsored`,
+        executionId: SPONSORED_ID,
+        nodeId: "call-1",
+        nodeName: "Contract call",
+        nodeType: "web3",
+        status: "success",
+        input: {},
+        startedAt: now,
+        network: null,
+        gasUsedWei: null,
+      },
     ]);
+
+    // The sponsored leg: KeeperHub paid, so the chain and the cost are in the
+    // ledger and nowhere else on this run.
+    await db.insert(gasCreditUsage).values({
+      id: `${PREFIX}ledger_sponsored`,
+      organizationId: ORG_ID,
+      chainId: 8453,
+      txHash: `0x${"a".repeat(64)}`,
+      executionId: SPONSORED_ID,
+      gasUsed: "21000",
+      gasPriceWei: "1000000000",
+      gasCostWei: "50000",
+      gasCostMicroUsd: "1",
+      ethPriceUsd: "3000",
+      createdAt: now,
+    });
 
     ({ getUnifiedRuns } = await import("@/lib/analytics/queries"));
     ({ applyBatch } = await import(
@@ -272,6 +305,17 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     expect(run.network).toBe("base");
     // The COALESCE arm feeds gasNetworks too, not just the scalar network.
     expect(run.gasNetworks).toEqual(["base"]);
+  });
+
+  it("names the chain a ledger-only sponsored run spent on", async () => {
+    const run = await runById(SPONSORED_ID);
+    // No step logged a chain or any gas, so before the ledger was read this run
+    // had a cost to show and no chain to denominate it in.
+    expect(run.gasUsedWei).toBeNull();
+    expect(run.gasCostWei).toBe("50000");
+    expect(run.gasNetworks).toEqual(["8453"]);
+    expect(run.networks).toEqual(["8453"]);
+    expect(run.network).toBe("8453");
   });
 
   it("backfills a gas-free legacy row, so the read moves onto the column", async () => {

--- a/tests/e2e/vitest/analytics-run-network.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-network.db.test.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import type { UnifiedRun } from "../../../lib/analytics/types";
+import type { StepLog, UnifiedRun } from "../../../lib/analytics/types";
 import {
   organization,
   users,
@@ -41,6 +41,8 @@ const LEGACY_GAS_ID = `${PREFIX}exec_legacy_gas`;
 const BACKFILL_ID = `${PREFIX}exec_backfill`;
 /** A run whose only record of spend is the sponsorship ledger, not a step. */
 const SPONSORED_ID = `${PREFIX}exec_sponsored`;
+/** An event-triggered run: trigger, a write that pays its own gas, a read. */
+const STEPS_ID = `${PREFIX}exec_steps`;
 
 // Log ids are the backfill's keyset cursor, so they are chosen, not incidental:
 // the backfill case runs one batch from the cursor below, and every other
@@ -61,6 +63,10 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     options?: { limit?: number }
   ) => Promise<{ runs: UnifiedRun[] }>;
   let applyBatch: (afterId: string, batchSize: number) => Promise<number>;
+  let getStepLogs: (
+    executionId: string,
+    organizationId: string
+  ) => Promise<StepLog[]>;
 
   async function cleanup(): Promise<void> {
     await queryClient`DELETE FROM gas_credit_usage WHERE execution_id LIKE ${`${PREFIX}%`}`;
@@ -129,6 +135,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         execution(LEGACY_GAS_ID),
         execution(BACKFILL_ID, "Insufficient BASE balance"),
         execution(SPONSORED_ID),
+        { ...execution(STEPS_ID), totalSteps: "3", completedSteps: "3" },
       ]);
 
     // Two row shapes matter here, and they are seeded separately on purpose.
@@ -220,6 +227,43 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
         gasUsedWei: null,
       },
       {
+        id: `${PREFIX}log_steps_a_trigger`,
+        executionId: STEPS_ID,
+        nodeId: "trigger-1",
+        nodeName: "Event",
+        nodeType: "trigger",
+        status: "success",
+        input: { network: "8453" },
+        startedAt: now,
+        network: "8453",
+        gasUsedWei: null,
+      },
+      {
+        id: `${PREFIX}log_steps_b_write`,
+        executionId: STEPS_ID,
+        nodeId: "write-1",
+        nodeName: "Write contract",
+        nodeType: "web3/write-contract",
+        status: "success",
+        input: { network: "8453" },
+        output: { gasUsed: "41000" },
+        startedAt: now,
+        network: "8453",
+        gasUsedWei: "41000",
+      },
+      {
+        id: `${PREFIX}log_steps_c_read`,
+        executionId: STEPS_ID,
+        nodeId: "read-1",
+        nodeName: "Read contract",
+        nodeType: "web3/read-contract",
+        status: "success",
+        input: { network: "8453" },
+        startedAt: now,
+        network: "8453",
+        gasUsedWei: null,
+      },
+      {
         id: `${PREFIX}log_sponsored`,
         executionId: SPONSORED_ID,
         nodeId: "call-1",
@@ -249,7 +293,7 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
       createdAt: now,
     });
 
-    ({ getUnifiedRuns } = await import("@/lib/analytics/queries"));
+    ({ getUnifiedRuns, getStepLogs } = await import("@/lib/analytics/queries"));
     ({ applyBatch } = await import(
       "@/scripts/lib/exec-log-network-gas-backfill"
     ));
@@ -316,6 +360,23 @@ describe.skipIf(SKIP)("run network on a pre-broadcast failure", () => {
     expect(run.gasNetworks).toEqual(["8453"]);
     expect(run.networks).toEqual(["8453"]);
     expect(run.network).toBe("8453");
+  });
+
+  it("shows per-node gas the organization's own wallet paid for", async () => {
+    const steps = await getStepLogs(STEPS_ID, ORG_ID);
+    const byNode = new Map(steps.map((step) => [step.nodeId, step]));
+
+    // The write spent gas and nothing sponsored it, so the ledger holds no row
+    // for it. Its own receipt is the only record, and reading the ledger alone
+    // left this cell empty.
+    expect(byNode.get("write-1")?.gasCostWei).toBe("41000");
+    expect(byNode.get("write-1")?.sponsored).toBe(false);
+
+    // A read makes no transaction, so no gas is the right answer, not a gap.
+    expect(byNode.get("read-1")?.gasCostWei).toBeNull();
+    // The trigger names the chain it watches but spends nothing itself.
+    expect(byNode.get("trigger-1")?.network).toBe("8453");
+    expect(byNode.get("trigger-1")?.gasCostWei).toBeNull();
   });
 
   it("backfills a gas-free legacy row, so the read moves onto the column", async () => {

--- a/tests/unit/trigger-network-log.test.ts
+++ b/tests/unit/trigger-network-log.test.ts
@@ -1,0 +1,102 @@
+/**
+ * An on-chain trigger holds its chain in its own node config and nowhere else,
+ * so unless the trigger's step log carries it, a run whose later steps name no
+ * chain (a notification, an HTTP call) reaches /analytics with an empty Network
+ * column. The executor passes `network` alongside `triggerData`; these cover
+ * that it survives to the logged input, and that the writer turns that input
+ * into the denormalised `network` column /analytics reads.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const logStepStartDb = vi.fn();
+const logStepCompleteDb = vi.fn();
+const incrementCompletedSteps = vi.fn();
+const logWorkflowCompleteDb = vi.fn();
+const updateCurrentStep = vi.fn();
+const updateForEachLogToError = vi.fn();
+
+vi.mock("@/lib/workflow/executor/logging", () => ({
+  logStepStartDb,
+  logStepCompleteDb,
+  incrementCompletedSteps,
+  logWorkflowCompleteDb,
+  updateCurrentStep,
+  updateForEachLogToError,
+}));
+
+const { triggerStep } = await import("@/lib/workflow/nodes/trigger/step");
+const { extractLogNetwork } = await import("@/lib/db/execution-log-fields");
+const { triggerConfigNetwork } = await import(
+  "@/lib/workflow/executor/executor.workflow"
+);
+
+const context = {
+  executionId: "exec-1",
+  nodeId: "trigger_1",
+  nodeName: "Event",
+  nodeType: "trigger",
+};
+
+function loggedInput(): unknown {
+  return logStepStartDb.mock.calls[0][0].input;
+}
+
+describe("triggerConfigNetwork", () => {
+  it("reads the chain an on-chain trigger is configured against", () => {
+    expect(
+      triggerConfigNetwork({ triggerType: "Event", network: "8453" })
+    ).toBe("8453");
+  });
+
+  it("normalises a numeric chain id to the text the log column holds", () => {
+    expect(triggerConfigNetwork({ triggerType: "Block", network: 8453 })).toBe(
+      "8453"
+    );
+  });
+
+  it("yields nothing for a trigger with no chain", () => {
+    expect(triggerConfigNetwork({ triggerType: "Schedule" })).toBeUndefined();
+  });
+});
+
+describe("trigger step network logging", () => {
+  beforeEach(() => {
+    logStepStartDb.mockReset();
+    logStepCompleteDb.mockReset();
+    updateCurrentStep.mockReset();
+    logStepStartDb.mockResolvedValue({ logId: "log-1", startTime: 100 });
+    logStepCompleteDb.mockResolvedValue(undefined);
+  });
+
+  it("logs the trigger's chain so analytics can read it", async () => {
+    await triggerStep({
+      triggerData: { triggered: true, from: "0xabc" },
+      network: "8453",
+      _context: context,
+    });
+
+    expect(extractLogNetwork(loggedInput())).toBe("8453");
+  });
+
+  it("still returns only the trigger data to downstream steps", async () => {
+    const result = await triggerStep({
+      triggerData: { triggered: true, amount: 5 },
+      network: "8453",
+      _context: context,
+    });
+
+    expect(result.data).toEqual({ triggered: true, amount: 5 });
+  });
+
+  it("records no chain for a trigger that has none", async () => {
+    await triggerStep({
+      triggerData: { triggered: true },
+      _context: context,
+    });
+
+    expect(extractLogNetwork(loggedInput())).toBeNull();
+  });
+});

--- a/tests/unit/trigger-network-log.test.ts
+++ b/tests/unit/trigger-network-log.test.ts
@@ -28,7 +28,9 @@ vi.mock("@/lib/workflow/executor/logging", () => ({
 }));
 
 const { triggerStep } = await import("@/lib/workflow/nodes/trigger/step");
-const { extractLogNetwork } = await import("@/lib/db/execution-log-fields");
+const { extractLogGasUsedWei, extractLogNetwork } = await import(
+  "@/lib/db/execution-log-fields"
+);
 const { triggerConfigNetwork } = await import(
   "@/lib/workflow/executor/executor.workflow"
 );
@@ -89,6 +91,30 @@ describe("trigger step network logging", () => {
     });
 
     expect(result.data).toEqual({ triggered: true, amount: 5 });
+  });
+
+  it("reports the triggering transaction's gas under its own key", async () => {
+    const result = await triggerStep({
+      triggerData: { triggered: true, transactionHash: "0xabc" },
+      network: "8453",
+      triggerGasUsed: "77000",
+      _context: context,
+    });
+
+    // Never as `gasUsed`: that is the key resolveGasTotal and the analytics
+    // rollups sum, and this fee was paid by whoever emitted the event.
+    expect(extractLogGasUsedWei(result)).toBeNull();
+    expect(result.triggerGasUsed).toBe("77000");
+  });
+
+  it("omits the key entirely when no gas could be read", async () => {
+    const result = await triggerStep({
+      triggerData: { triggered: true },
+      network: "8453",
+      _context: context,
+    });
+
+    expect(result).not.toHaveProperty("triggerGasUsed");
   });
 
   it("records no chain for a trigger that has none", async () => {


### PR DESCRIPTION
## Problem

For an event-triggered keeper, Analytics showed no network, and gas was missing in several places. Four separate causes, all on the read path.

**Per-node gas was ledger-only.** The run detail's per-step gas came solely from `gas_credit_usage`, which holds a row only for transactions KeeperHub sponsored. A write funded by the organization's own wallet showed no gas on its node at all, even though its receipt recorded the cost and the run-level total already counted it.

**Gas discarded outright.** The Gas by Network breakdown grouped workflow step rows by the chain recorded on the row, then skipped any group whose chain was null. A step that spent gas but recorded no chain had its gas dropped from the chart rather than shown anywhere. The direct-execution arm of the same function already buckets its unnamed chains as `unknown`.

**The ledger's chain was never read.** `gas_credit_usage` records `chain_id` for every sponsored transaction, the authoritative record of what the wallet paid and where. The runs query read that table for the amount only and dropped the chain, so a run whose spend is ledger-only had a cost to show and no chain to denominate it in, and the gas cell fell back to guessing from whichever chain the run's steps happened to mention.

**On-chain triggers never recorded their chain.** The network on a step's log row comes from the step's resolved input. Action steps resolve their node config into that input; the trigger step's logged input is only the trigger data, so Event, Block and Transfer triggers recorded nothing despite each holding a network in its node config.

## Change

Per-step gas reads the ledger first and falls back to the step's own recorded gas, so a directly-paid write shows what it spent. Sponsorship is derived from the ledger value alone, so a self-funded step is no longer mislabelled as sponsored. Both the step's chain and its gas now read the denormalised column before the JSONB, matching the runs table, which also makes the ledger's per-chain match work on backfilled rows.

The breakdown buckets null-chain gas as `unknown` instead of skipping it.

The runs query aggregates `gas_credit_usage.chain_id` alongside the cost and folds it into the run's network sets.

The executor passes the trigger node's configured network into the trigger step, where the existing extraction picks it up. The trigger's output is unchanged, so template resolution and the run detail view are unaffected.

## Resulting behaviour on an event-triggered run

| Node | Network | Gas |
|---|---|---|
| Event trigger | the chain it watches | none, it spends nothing itself |
| Write contract | its chain | its cost, marked sponsored only when the ledger funded it |
| Read contract | its chain | none, it makes no transaction |

## Scope

Rows written before this stay as they are, so a keeper's chain appears from its next run. The gas the event transaction itself burned is not counted: that transaction was sent by whoever emitted the event, and folding it into the run's gas would report a third party's spend as the organization's own in the Gas Spent KPI and the sponsored-versus-wallet split.

## Verification

Three DB tests, each verified to fail without its fix. `graceful-shutdown.test.ts` fails on this branch, but it fails identically on a clean `staging` worktree once the plugin registry is generated, so it is pre-existing and unrelated.