### PR TITLE
fix(executor): let the drain watchdog fire before the runner pod is killed

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -1014,9 +1014,13 @@ executor:
     JOB_TTL_SECONDS:
       type: kv
       value: "300"
+    # Hard cap on a single runner pod. A workflow that iterates a large
+    # collection (dozens of items, several nodes each) does not fit in 300s, and
+    # the pod is SIGKILLed mid-run with no error recorded. The drain watchdog is
+    # derived as two thirds of this value, so raising it raises both together.
     JOB_ACTIVE_DEADLINE:
       type: kv
-      value: "300"
+      value: "600"
     # Ephemeral-storage guardrail for runner Job pods (mirrored by the runner's
     # /tmp emptyDir sizeLimit). Runners use ~2 MiB each, so the 1Gi limit is a
     # runaway-/tmp guard, not the disk-pressure fix (that is node image GC + disk

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -954,9 +954,13 @@ executor:
     JOB_TTL_SECONDS:
       type: kv
       value: "120"
+    # Hard cap on a single runner pod. A workflow that iterates a large
+    # collection (dozens of items, several nodes each) does not fit in 300s, and
+    # the pod is SIGKILLed mid-run with no error recorded. The drain watchdog is
+    # derived as two thirds of this value, so raising it raises both together.
     JOB_ACTIVE_DEADLINE:
       type: kv
-      value: "300"
+      value: "600"
     # Ephemeral-storage guardrail for runner Job pods (mirrored by the runner's
     # /tmp emptyDir sizeLimit). Live staging runners use ~2 MiB each, so the 1Gi
     # limit is a runaway-/tmp guard, not the disk-pressure fix (that is node image

--- a/keeperhub-executor/config.ts
+++ b/keeperhub-executor/config.ts
@@ -8,6 +8,28 @@ function parseSqsHmacMode(value: string | undefined): SqsHmacMode {
   return value === "off" || value === "enforce" ? value : "warn";
 }
 
+// Fraction of the pod's active deadline handed to the runner's drain watchdog.
+// The remaining third is the budget for logging the leak and writing the
+// terminal execution status before the pod is killed.
+const DRAIN_TIMEOUT_FRACTION = 2 / 3;
+
+// The drain watchdog must fire while the pod is still alive. Once
+// activeDeadlineSeconds expires the pod is SIGKILLed, so a drain timeout at or
+// past the deadline never fires: no leak log, no terminal status, and the
+// execution row is orphaned "running" until the reaper closes it half an hour
+// later. Deriving it from the deadline keeps the two from ever being equal
+// again, and an explicit override is clamped to the same rule.
+function resolveDrainTimeoutMs(deadlineSeconds: number): number {
+  const ceilingMs = Math.floor(
+    deadlineSeconds * DRAIN_TIMEOUT_FRACTION * 1000
+  );
+  const override = Number(process.env.KH_EXECUTOR_DRAIN_TIMEOUT_MS);
+  if (Number.isFinite(override) && override > 0) {
+    return Math.min(override, ceilingMs);
+  }
+  return ceilingMs;
+}
+
 // Parse a non-negative integer env var, falling back on unset/blank/non-numeric.
 // Unlike `Number(x) || fallback`, this honours an explicit 0 rather than
 // treating it as falsy.
@@ -71,10 +93,13 @@ export const CONFIG = {
   // Finished runner pods hold their /tmp emptyDir + logs on the node until the
   // TTL controller deletes them. Kept short so a busy node reclaims that disk in
   // minutes rather than accumulating an hour of churn (the DiskPressure flap on
-  // 2026-07-07). activeDeadlineSeconds caps a live run at 300s, so 300s here means
-  // a pod is gone ~5 min after it finishes.
+  // 2026-07-07). This is time after a pod finishes, so it is independent of
+  // activeDeadlineSeconds: 300s here means a pod is gone ~5 min after it ends.
   jobTtlSeconds: Number(process.env.JOB_TTL_SECONDS) || 300,
   jobActiveDeadline: Number(process.env.JOB_ACTIVE_DEADLINE) || 300,
+  jobDrainTimeoutMs: resolveDrainTimeoutMs(
+    Number(process.env.JOB_ACTIVE_DEADLINE) || 300
+  ),
   maxConcurrentJobs: Number(process.env.MAX_CONCURRENT_JOBS) || 1,
 
   keeperhubApiUrl: process.env.KEEPERHUB_API_URL || "http://localhost:3000",

--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -37,7 +37,8 @@ vi.mock("./config", () => ({
     runnerEphemeralStorageRequest: "64Mi",
     runnerEphemeralStorageLimit: "1Gi",
     jobTtlSeconds: 300,
-    jobActiveDeadline: 300,
+    jobActiveDeadline: 600,
+    jobDrainTimeoutMs: 400_000,
     maxConcurrentJobs: 5,
   },
 }));
@@ -416,5 +417,35 @@ describe("createWorkflowJob", () => {
     });
 
     expect(getSubmittedJob().spec?.ttlSecondsAfterFinished).toBe(300);
+  });
+
+  it("gives the drain watchdog a budget that expires before the pod is killed", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const job = getSubmittedJob();
+    const drainMs = Number(
+      getEnvVar(getJobEnvVars(job), "KH_EXECUTOR_DRAIN_TIMEOUT_MS")
+    );
+    const deadlineMs = (job.spec?.activeDeadlineSeconds ?? 0) * 1000;
+
+    expect(drainMs).toBe(400_000);
+    expect(drainMs).toBeLessThan(deadlineMs);
+  });
+
+  it("caps the runner heap below the container memory limit", async () => {
+    await createWorkflowJob({
+      workflowId: "wf-1",
+      executionId: "exec-1234abcd",
+      input: {},
+      triggerType: "schedule",
+    });
+
+    const envVars = getJobEnvVars(getSubmittedJob());
+    expect(getEnvVar(envVars, "NODE_OPTIONS")).toBe("--max-old-space-size=224");
   });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -118,6 +118,19 @@ export async function createWorkflowJob(params: {
     // below. tsx/esbuild and any plugin temp writes resolve through TMPDIR, so
     // point it there to keep the runner working under the hardened context.
     { name: "TMPDIR", value: "/tmp" },
+    // Node sizes its heap from the host's RAM, not the container's cgroup
+    // limit, so on a large node it grows past the memory limit below and the
+    // kernel SIGKILLs the pod mid-run with no error and no terminal status,
+    // orphaning another execution row. Capping the heap under the limit turns
+    // that silent kill into a recorded JS heap error, and leaves the remainder
+    // for off-heap RSS (the binary, buffers, native memory).
+    { name: "NODE_OPTIONS", value: "--max-old-space-size=224" },
+    // Derived from activeDeadlineSeconds so the drain watchdog always fires
+    // while the pod is alive. See resolveDrainTimeoutMs in config.ts.
+    {
+      name: "KH_EXECUTOR_DRAIN_TIMEOUT_MS",
+      value: String(CONFIG.jobDrainTimeoutMs),
+    },
     // SSRF guard: runner pods enforce by default. safeFetch's shadow-mode
     // opt-in (SAFE_FETCH_SHADOW) is neither injected here nor listed in
     // RUNNER_SYSTEM_ENV_VARS, so a controller's env can never relax the

--- a/lib/workflow/executor/pending-tasks.ts
+++ b/lib/workflow/executor/pending-tasks.ts
@@ -27,6 +27,12 @@
  * context. The leaked promises are NOT cancelled (no AbortController plumbing
  * here) -- they continue running in the background and the platform-level
  * workflow timeout will eventually clean them up.
+ *
+ * The timeout MUST stay below the runner pod's activeDeadlineSeconds. At or
+ * past it the pod is SIGKILLed before `onTimeout` runs, so the leak is never
+ * logged, no terminal status is written, and the execution row is orphaned
+ * "running" until the reaper closes it. The k8s-job dispatcher derives the env
+ * var from the deadline for exactly this reason (see config.ts).
  */
 
 const DEFAULT_DRAIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes


### PR DESCRIPTION
## Problem

A workflow run froze 1.4 seconds in and sat at `running` for 30 minutes with no error, no terminal status, and no partial row. Both parallel branches stopped on the same millisecond, so the process was killed rather than crashed. Nothing was recorded about why.

Two things caused that, and the first one destroyed the evidence for the second.

### The drain watchdog can never fire

`DEFAULT_DRAIN_TIMEOUT_MS` is `5 * 60 * 1000`, and the runner Job carries `activeDeadlineSeconds: 300` with `backoffLimit: 0`. The two are equal, so the pod is SIGKILLed at exactly the moment the watchdog would fire. `onTimeout` never logs the leak and no terminal status is written.

`KH_EXECUTOR_DRAIN_TIMEOUT_MS` was also not in `RUNNER_SYSTEM_ENV_VARS`, so setting it in Helm would have done nothing. The override existed but could not reach the process that reads it.

The result: any hang in the executor becomes a silent stuck row, closed 30 minutes later by the reaper as `system_error` / E-0001, with nothing explaining the cause.

### The runner heap is not capped

The runner container has a 320Mi memory limit and no `--max-old-space-size`. Node sizes its heap from the host's RAM, not the container's cgroup limit, so on a large node it grows past 320Mi and the kernel kills it. That produces exactly the observed signature: instant death on all branches, nothing written.

## Change

- Derive `jobDrainTimeoutMs` from `jobActiveDeadline` (two thirds of it) and inject it on the runner Job env. The two values can no longer be equal. An explicit `KH_EXECUTOR_DRAIN_TIMEOUT_MS` is clamped to the same ceiling.
- Raise `JOB_ACTIVE_DEADLINE` from 300 to 600 in staging and prod. With the derivation above the drain budget becomes 400s and the pod deadline 600s. A loop over dozens of items with several nodes each does not fit in 300s.
- Set `NODE_OPTIONS=--max-old-space-size=224` on the runner, leaving ~96Mi under the limit for off-heap RSS. This converts a silent kernel kill into a reported JS heap error.
- Correct a stale comment on `jobTtlSeconds` that tied it to `activeDeadlineSeconds`. TTL applies after a pod finishes, so the two are independent.

## Tradeoffs

Runner pods can now live twice as long, so a burst of slow workflows holds more pods at once. `JOB_TTL_SECONDS` is unchanged, so finished pods are still reclaimed on the same schedule.

The heap cap can surface as a JS heap error on a workflow that previously survived by exceeding the limit on a large node. That is the intended behavior: a recorded error instead of a vanished run.

`deploy/pr-environment` and `deploy/keeperhub-stack/self-hosted` still use 300s. The derivation applies there too, so drain stays below the deadline in both.

## Tests

`keeperhub-executor/k8s-job.test.ts` gains two cases: the injected drain budget is strictly less than `activeDeadlineSeconds`, and the heap cap is set. 161 tests pass across the executor and drain suites. `pnpm check` and `pnpm type-check` are clean.