### PR TITLE
feat(analytics): multi-select run filters and correct digest failure counts

### DIFF
--- a/app/api/analytics/facets/route.ts
+++ b/app/api/analytics/facets/route.ts
@@ -1,13 +1,18 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { parseRunFilters } from "@/lib/analytics/parse-run-filters";
-import { getUnifiedRuns } from "@/lib/analytics/queries";
+import { getStatusFacets } from "@/lib/analytics/queries";
 import { parseTimeRange } from "@/lib/analytics/time-range";
 import { apiError } from "@/lib/api-error";
 import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
 import { requireScope } from "@/lib/middleware/require-scope";
 
+/**
+ * Run counts per status for the runs filter. Takes the same query string the
+ * runs listing takes, so the counts sit under the filters the reader already
+ * has applied.
+ */
 export async function GET(req: NextRequest): Promise<Response> {
   const authCtx = await resolveOrganizationId(req);
   if ("error" in authCtx) {
@@ -25,31 +30,18 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   try {
     const params = req.nextUrl.searchParams;
-    const range = parseTimeRange(params.get("range"));
-    const customStart = params.get("customStart") ?? undefined;
-    const customEnd = params.get("customEnd") ?? undefined;
-    const cursor = params.get("cursor") ?? undefined;
-
-    const pageParam = params.get("page");
-    const page = pageParam ? Math.max(1, Number(pageParam)) : undefined;
-
-    const limitParam = params.get("limit");
-    const limit = limitParam ? Number(limitParam) : undefined;
-
-    const projectId = params.get("projectId") ?? undefined;
-
-    const result = await getUnifiedRuns(authCtx.organizationId, range, {
-      cursor,
-      page,
-      limit,
-      customStart,
-      customEnd,
-      projectId,
-      ...parseRunFilters(params),
-    });
-
-    return NextResponse.json(result);
+    const statusCounts = await getStatusFacets(
+      authCtx.organizationId,
+      parseTimeRange(params.get("range")),
+      {
+        customStart: params.get("customStart") ?? undefined,
+        customEnd: params.get("customEnd") ?? undefined,
+        projectId: params.get("projectId") ?? undefined,
+        ...parseRunFilters(params),
+      }
+    );
+    return NextResponse.json({ statusCounts });
   } catch (error: unknown) {
-    return apiError(error, "Failed to fetch analytics runs");
+    return apiError(error, "Failed to fetch analytics facets");
   }
 }

--- a/components/analytics/analytics-header.tsx
+++ b/components/analytics/analytics-header.tsx
@@ -2,7 +2,7 @@
 
 import { useAtom, useAtomValue } from "jotai";
 import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -15,18 +15,12 @@ import {
   analyticsRangeAtom,
 } from "@/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
-import { FilterRadio, ValuePopover } from "./filter-popover";
 
-// `label` is what the trigger shows once chosen, `option` what the list reads.
-const RANGE_OPTIONS: Array<{
-  value: TimeRange;
-  label: string;
-  option: string;
-}> = [
-  { value: "1h", label: "1h", option: "Last hour" },
-  { value: "24h", label: "24h", option: "Last 24 hours" },
-  { value: "7d", label: "7d", option: "Last 7 days" },
-  { value: "30d", label: "30d", option: "Last 30 days" },
+const RANGE_OPTIONS: Array<{ value: TimeRange; label: string }> = [
+  { value: "1h", label: "1h" },
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
 ];
 
 function formatTimeAgo(date: Date): string {
@@ -96,8 +90,20 @@ export function AnalyticsHeader({
     [setRange]
   );
 
-  const rangeLabel =
-    RANGE_OPTIONS.find((option) => option.value === range)?.label ?? "Custom";
+  const rangeButtons = useMemo(
+    () =>
+      RANGE_OPTIONS.map((option) => (
+        <Button
+          key={option.value}
+          onClick={() => handleRangeChange(option.value)}
+          size="sm"
+          variant={range === option.value ? "default" : "outline"}
+        >
+          {option.label}
+        </Button>
+      )),
+    [range, handleRangeChange]
+  );
 
   return (
     <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -106,21 +112,9 @@ export function AnalyticsHeader({
       </div>
 
       <div className="flex items-center gap-3">
-        <ValuePopover label="Time" value={rangeLabel}>
-          {(close) =>
-            RANGE_OPTIONS.map((option) => (
-              <FilterRadio
-                checked={range === option.value}
-                key={option.value}
-                label={option.option}
-                onSelect={() => {
-                  handleRangeChange(option.value);
-                  close();
-                }}
-              />
-            ))
-          }
-        </ValuePopover>
+        <nav aria-label="Time range" className="flex items-center gap-1">
+          {rangeButtons}
+        </nav>
 
         {onRefetch ? (
           <Tooltip>

--- a/components/analytics/analytics-header.tsx
+++ b/components/analytics/analytics-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -11,10 +11,13 @@ import {
 } from "@/components/ui/tooltip";
 import type { TimeRange } from "@/lib/analytics/types";
 import {
+  analyticsCustomEndAtom,
+  analyticsCustomStartAtom,
   analyticsLastUpdatedAtom,
   analyticsRangeAtom,
 } from "@/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
+import { DateRangeFilter } from "./date-range-filter";
 
 const RANGE_OPTIONS: Array<{ value: TimeRange; label: string }> = [
   { value: "1h", label: "1h" },
@@ -50,6 +53,8 @@ export function AnalyticsHeader({
   onRefetch,
 }: AnalyticsHeaderProps): React.ReactNode {
   const [range, setRange] = useAtom(analyticsRangeAtom);
+  const setCustomStart = useSetAtom(analyticsCustomStartAtom);
+  const setCustomEnd = useSetAtom(analyticsCustomEndAtom);
   const lastUpdated = useAtomValue(analyticsLastUpdatedAtom);
   const [timeAgo, setTimeAgo] = useState<string>("");
   const [refreshing, setRefreshing] = useState(false);
@@ -85,9 +90,13 @@ export function AnalyticsHeader({
 
   const handleRangeChange = useCallback(
     (value: TimeRange): void => {
+      // A preset and a hand-picked window are the same setting, so choosing one
+      // has to drop the other or the range would keep the stale dates.
+      setCustomStart(null);
+      setCustomEnd(null);
       setRange(value);
     },
-    [setRange]
+    [setRange, setCustomStart, setCustomEnd]
   );
 
   const rangeButtons = useMemo(
@@ -114,6 +123,7 @@ export function AnalyticsHeader({
       <div className="flex items-center gap-3">
         <nav aria-label="Time range" className="flex items-center gap-1">
           {rangeButtons}
+          <DateRangeFilter />
         </nav>
 
         {onRefetch ? (

--- a/components/analytics/analytics-header.tsx
+++ b/components/analytics/analytics-header.tsx
@@ -2,7 +2,7 @@
 
 import { useAtom, useAtomValue } from "jotai";
 import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -15,12 +15,18 @@ import {
   analyticsRangeAtom,
 } from "@/lib/atoms/analytics";
 import { cn } from "@/lib/utils";
+import { FilterRadio, ValuePopover } from "./filter-popover";
 
-const RANGE_OPTIONS: Array<{ value: TimeRange; label: string }> = [
-  { value: "1h", label: "1h" },
-  { value: "24h", label: "24h" },
-  { value: "7d", label: "7d" },
-  { value: "30d", label: "30d" },
+// `label` is what the trigger shows once chosen, `option` what the list reads.
+const RANGE_OPTIONS: Array<{
+  value: TimeRange;
+  label: string;
+  option: string;
+}> = [
+  { value: "1h", label: "1h", option: "Last hour" },
+  { value: "24h", label: "24h", option: "Last 24 hours" },
+  { value: "7d", label: "7d", option: "Last 7 days" },
+  { value: "30d", label: "30d", option: "Last 30 days" },
 ];
 
 function formatTimeAgo(date: Date): string {
@@ -90,20 +96,8 @@ export function AnalyticsHeader({
     [setRange]
   );
 
-  const rangeButtons = useMemo(
-    () =>
-      RANGE_OPTIONS.map((option) => (
-        <Button
-          key={option.value}
-          onClick={() => handleRangeChange(option.value)}
-          size="sm"
-          variant={range === option.value ? "default" : "outline"}
-        >
-          {option.label}
-        </Button>
-      )),
-    [range, handleRangeChange]
-  );
+  const rangeLabel =
+    RANGE_OPTIONS.find((option) => option.value === range)?.label ?? "Custom";
 
   return (
     <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -112,9 +106,21 @@ export function AnalyticsHeader({
       </div>
 
       <div className="flex items-center gap-3">
-        <nav aria-label="Time range" className="flex items-center gap-1">
-          {rangeButtons}
-        </nav>
+        <ValuePopover label="Time" value={rangeLabel}>
+          {(close) =>
+            RANGE_OPTIONS.map((option) => (
+              <FilterRadio
+                checked={range === option.value}
+                key={option.value}
+                label={option.option}
+                onSelect={() => {
+                  handleRangeChange(option.value);
+                  close();
+                }}
+              />
+            ))
+          }
+        </ValuePopover>
 
         {onRefetch ? (
           <Tooltip>

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -13,6 +13,11 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+  endOfDay,
+  nextRangeStep,
+  startOfDay,
+} from "@/lib/analytics/date-range-selection";
+import {
   analyticsCustomEndAtom,
   analyticsCustomStartAtom,
   analyticsRangeAtom,
@@ -30,18 +35,9 @@ const MONTH_LABEL = new Intl.DateTimeFormat("en-US", { month: "long" });
 // Where clearing lands, matching the range the page opens in.
 const DEFAULT_RANGE = "24h" as const;
 
-function startOfDay(date: Date): Date {
-  const copy = new Date(date);
-  copy.setHours(0, 0, 0, 0);
-  return copy;
-}
-
-/** Exclusive end: the instant after the chosen day, so that day is included. */
-function endOfDay(date: Date): Date {
-  const copy = new Date(date);
-  copy.setHours(23, 59, 59, 999);
-  return copy;
-}
+const NOOP = (): void => {
+  // Selection is handled in onDayClick.
+};
 
 type Preset = { key: string; label: string; from: Date; to: Date };
 
@@ -101,18 +97,25 @@ export function DateRangeFilter(): ReactNode {
     [setCustomStart, setCustomEnd, setRange]
   );
 
-  // The first click of a range only names its start, so the picker holds the
-  // half-made selection itself and commits once both ends are known. Applying
-  // on the first click would close the popover with a one-day window and leave
-  // no way to reach the second date.
-  const onSelect = useCallback(
-    (selected: DateRange | undefined): void => {
-      setDraft(selected);
-      if (selected?.from && selected.to) {
-        apply(startOfDay(selected.from), endOfDay(selected.to));
+  /**
+   * Selection is driven from the raw day click rather than the library's range
+   * accumulation. Handed an already-committed range as its current value, that
+   * accumulation reads the next click as closing that range, so it reported
+   * both ends at once and the popover applied and shut on every single click.
+   *
+   * Here the first click after opening always starts a new range and the second
+   * closes it, whatever was selected before.
+   */
+  const onDayClick = useCallback(
+    (day: Date): void => {
+      const step = nextRangeStep(draft, day);
+      if (step.kind === "start") {
+        setDraft({ from: step.from, to: undefined });
+        return;
       }
+      apply(step.from, step.to);
     },
-    [apply]
+    [draft, apply]
   );
 
   const active = range === "custom" && customStart !== null;
@@ -199,11 +202,13 @@ export function DateRangeFilter(): ReactNode {
           </div>
         </div>
         <Calendar
-          autoFocus
           defaultMonth={selected?.from}
           mode="range"
           numberOfMonths={2}
-          onSelect={onSelect}
+          onDayClick={onDayClick}
+          // Required by the range mode's types; the click handler above owns
+          // the transitions, so this deliberately does nothing.
+          onSelect={NOOP}
           selected={selected}
         />
       </PopoverContent>

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -83,6 +83,7 @@ export function DateRangeFilter(): ReactNode {
   const setCustomEnd = useSetAtom(analyticsCustomEndAtom);
   const [customEnd] = useAtom(analyticsCustomEndAtom);
   const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState<DateRange | undefined>(undefined);
 
   const presets = useMemo(() => buildPresets(new Date()), []);
 
@@ -91,19 +92,22 @@ export function DateRangeFilter(): ReactNode {
       setCustomStart(from.toISOString());
       setCustomEnd(to.toISOString());
       setRange("custom");
+      setDraft(undefined);
       setOpen(false);
     },
     [setCustomStart, setCustomEnd, setRange]
   );
 
+  // The first click of a range only names its start, so the picker holds the
+  // half-made selection itself and commits once both ends are known. Applying
+  // on the first click would close the popover with a one-day window and leave
+  // no way to reach the second date.
   const onSelect = useCallback(
     (selected: DateRange | undefined): void => {
-      if (!selected?.from) {
-        return;
+      setDraft(selected);
+      if (selected?.from && selected.to) {
+        apply(startOfDay(selected.from), endOfDay(selected.to));
       }
-      // One click is a single day until a second lands, so the picker is
-      // usable for "one specific day" without a second click.
-      apply(startOfDay(selected.from), endOfDay(selected.to ?? selected.from));
     },
     [apply]
   );
@@ -123,6 +127,9 @@ export function DateRangeFilter(): ReactNode {
   }, [active, customStart, customEnd]);
 
   const selected = useMemo((): DateRange | undefined => {
+    if (draft) {
+      return draft;
+    }
     if (!(active && customStart)) {
       return undefined;
     }
@@ -130,10 +137,17 @@ export function DateRangeFilter(): ReactNode {
       from: new Date(customStart),
       to: customEnd ? new Date(customEnd) : undefined,
     };
-  }, [active, customStart, customEnd]);
+  }, [draft, active, customStart, customEnd]);
+
+  const onOpenChange = useCallback((next: boolean): void => {
+    setOpen(next);
+    if (!next) {
+      setDraft(undefined);
+    }
+  }, []);
 
   return (
-    <Popover onOpenChange={setOpen} open={open}>
+    <Popover onOpenChange={onOpenChange} open={open}>
       <PopoverTrigger asChild>
         <Button
           aria-label="Custom date range"

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -27,6 +27,9 @@ const DAY_LABEL = new Intl.DateTimeFormat("en-US", {
 
 const MONTH_LABEL = new Intl.DateTimeFormat("en-US", { month: "long" });
 
+// Where clearing lands, matching the range the page opens in.
+const DEFAULT_RANGE = "24h" as const;
+
 function startOfDay(date: Date): Date {
   const copy = new Date(date);
   copy.setHours(0, 0, 0, 0);
@@ -139,6 +142,17 @@ export function DateRangeFilter(): ReactNode {
     };
   }, [draft, active, customStart, customEnd]);
 
+  // Drops the hand-picked window and falls back to the default preset, which is
+  // the state the page opens in. Without this the only way out of a custom
+  // range is to pick a preset, which is not obviously a way out.
+  const clear = useCallback((): void => {
+    setCustomStart(null);
+    setCustomEnd(null);
+    setRange(DEFAULT_RANGE);
+    setDraft(undefined);
+    setOpen(false);
+  }, [setCustomStart, setCustomEnd, setRange]);
+
   const onOpenChange = useCallback((next: boolean): void => {
     setOpen(next);
     if (!next) {
@@ -172,6 +186,17 @@ export function DateRangeFilter(): ReactNode {
               {preset.label}
             </Button>
           ))}
+          <div className="mt-1 border-t pt-1">
+            <Button
+              className="h-7 w-full justify-start px-2 text-muted-foreground text-xs"
+              disabled={!active}
+              onClick={clear}
+              size="sm"
+              variant="ghost"
+            >
+              Clear range
+            </Button>
+          </div>
         </div>
         <Calendar
           autoFocus

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -86,13 +86,16 @@ export function DateRangeFilter(): ReactNode {
 
   const presets = useMemo(() => buildPresets(new Date()), []);
 
+  // Applying deliberately leaves the popover open. Picking a window is often
+  // several attempts at the same question, and closing on the second click cost
+  // a reopen every time. It closes on a click outside or on Escape, like any
+  // other popover.
   const apply = useCallback(
     (from: Date, to: Date): void => {
       setCustomStart(from.toISOString());
       setCustomEnd(to.toISOString());
       setRange("custom");
       setDraft(undefined);
-      setOpen(false);
     },
     [setCustomStart, setCustomEnd, setRange]
   );
@@ -153,7 +156,6 @@ export function DateRangeFilter(): ReactNode {
     setCustomEnd(null);
     setRange(DEFAULT_RANGE);
     setDraft(undefined);
-    setOpen(false);
   }, [setCustomStart, setCustomEnd, setRange]);
 
   const onOpenChange = useCallback((next: boolean): void => {

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useAtom, useSetAtom } from "jotai";
+import { CalendarDays } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCallback, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  analyticsCustomEndAtom,
+  analyticsCustomStartAtom,
+  analyticsRangeAtom,
+} from "@/lib/atoms/analytics";
+import { cn } from "@/lib/utils";
+
+const DAY_LABEL = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+const MONTH_LABEL = new Intl.DateTimeFormat("en-US", { month: "long" });
+
+function startOfDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+/** Exclusive end: the instant after the chosen day, so that day is included. */
+function endOfDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(23, 59, 59, 999);
+  return copy;
+}
+
+type Preset = { key: string; label: string; from: Date; to: Date };
+
+/**
+ * Whole calendar months back from this one, which is the shape of the ask:
+ * "all of August" rather than "the last 31 days".
+ */
+function buildPresets(now: Date): Preset[] {
+  const presets: Preset[] = [
+    { key: "today", label: "Today", from: startOfDay(now), to: endOfDay(now) },
+  ];
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  presets.push({
+    key: "yesterday",
+    label: "Yesterday",
+    from: startOfDay(yesterday),
+    to: endOfDay(yesterday),
+  });
+
+  for (let back = 0; back < 4; back += 1) {
+    const first = new Date(now.getFullYear(), now.getMonth() - back, 1);
+    const last = new Date(now.getFullYear(), now.getMonth() - back + 1, 0);
+    presets.push({
+      key: `month-${back}`,
+      label: back === 0 ? "This month" : MONTH_LABEL.format(first),
+      from: startOfDay(first),
+      to: endOfDay(last),
+    });
+  }
+  return presets;
+}
+
+/**
+ * Arbitrary windows, alongside the preset buttons rather than replacing them.
+ * Choosing here switches the range to `custom`; choosing a preset button
+ * clears the dates again.
+ */
+export function DateRangeFilter(): ReactNode {
+  const [range, setRange] = useAtom(analyticsRangeAtom);
+  const [customStart, setCustomStart] = useAtom(analyticsCustomStartAtom);
+  const setCustomEnd = useSetAtom(analyticsCustomEndAtom);
+  const [customEnd] = useAtom(analyticsCustomEndAtom);
+  const [open, setOpen] = useState(false);
+
+  const presets = useMemo(() => buildPresets(new Date()), []);
+
+  const apply = useCallback(
+    (from: Date, to: Date): void => {
+      setCustomStart(from.toISOString());
+      setCustomEnd(to.toISOString());
+      setRange("custom");
+      setOpen(false);
+    },
+    [setCustomStart, setCustomEnd, setRange]
+  );
+
+  const onSelect = useCallback(
+    (selected: DateRange | undefined): void => {
+      if (!selected?.from) {
+        return;
+      }
+      // One click is a single day until a second lands, so the picker is
+      // usable for "one specific day" without a second click.
+      apply(startOfDay(selected.from), endOfDay(selected.to ?? selected.from));
+    },
+    [apply]
+  );
+
+  const active = range === "custom" && customStart !== null;
+
+  const label = useMemo((): string => {
+    if (!(active && customStart && customEnd)) {
+      return "Custom";
+    }
+    const from = new Date(customStart);
+    const to = new Date(customEnd);
+    const sameDay = from.toDateString() === to.toDateString();
+    return sameDay
+      ? DAY_LABEL.format(from)
+      : `${DAY_LABEL.format(from)} - ${DAY_LABEL.format(to)}`;
+  }, [active, customStart, customEnd]);
+
+  const selected = useMemo((): DateRange | undefined => {
+    if (!(active && customStart)) {
+      return undefined;
+    }
+    return {
+      from: new Date(customStart),
+      to: customEnd ? new Date(customEnd) : undefined,
+    };
+  }, [active, customStart, customEnd]);
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label="Custom date range"
+          className={cn("gap-1.5", active && "border-primary/40")}
+          size="sm"
+          variant={active ? "default" : "outline"}
+        >
+          <CalendarDays className="size-4" />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="flex w-auto gap-0 p-0">
+        <div className="flex w-36 flex-col gap-0.5 border-r p-2">
+          {presets.map((preset) => (
+            <Button
+              className="h-7 justify-start px-2 text-xs"
+              key={preset.key}
+              onClick={() => apply(preset.from, preset.to)}
+              size="sm"
+              variant="ghost"
+            >
+              {preset.label}
+            </Button>
+          ))}
+        </div>
+        <Calendar
+          autoFocus
+          defaultMonth={selected?.from}
+          mode="range"
+          numberOfMonths={2}
+          onSelect={onSelect}
+          selected={selected}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -17,6 +17,8 @@ type FilterPopoverProps = {
   /** Number of values held in this dimension; 0 renders no badge. */
   selectedCount: number;
   onClear: () => void;
+  /** Omitted by a single-choice dimension, which has nothing to select all of. */
+  onSelectAll?: () => void;
   children: ReactNode;
 };
 
@@ -25,6 +27,7 @@ export function FilterPopover({
   label,
   selectedCount,
   onClear,
+  onSelectAll,
   children,
 }: FilterPopoverProps): ReactNode {
   return (
@@ -53,15 +56,27 @@ export function FilterPopover({
           <span className="text-[11px] text-muted-foreground">
             {selectedCount > 0 ? `${selectedCount} selected` : "Showing all"}
           </span>
-          <Button
-            className="h-6 px-2 text-xs"
-            disabled={selectedCount === 0}
-            onClick={onClear}
-            size="sm"
-            variant="ghost"
-          >
-            Clear
-          </Button>
+          <div className="flex items-center gap-1">
+            {onSelectAll ? (
+              <Button
+                className="h-6 px-2 text-xs"
+                onClick={onSelectAll}
+                size="sm"
+                variant="ghost"
+              >
+                Select all
+              </Button>
+            ) : null}
+            <Button
+              className="h-6 px-2 text-xs"
+              disabled={selectedCount === 0}
+              onClick={onClear}
+              size="sm"
+              variant="ghost"
+            >
+              Clear
+            </Button>
+          </div>
         </div>
       </PopoverContent>
     </Popover>
@@ -70,6 +85,8 @@ export function FilterPopover({
 
 type FilterCheckboxProps = {
   label: string;
+  /** Tailwind background class for the status swatch, when the row has one. */
+  dot?: string;
   count?: number;
   checked: boolean;
   /** Some but not all of a group's members are selected. */
@@ -80,6 +97,7 @@ type FilterCheckboxProps = {
 
 export function FilterCheckbox({
   label,
+  dot,
   count,
   checked,
   indeterminate = false,
@@ -100,6 +118,9 @@ export function FilterCheckbox({
         className="pointer-events-none"
         tabIndex={-1}
       />
+      {dot ? (
+        <span className={cn("size-2 shrink-0 rounded-full", dot)} />
+      ) : null}
       <span className={cn("flex-1", !indented && "font-medium")}>{label}</span>
       {count !== undefined && (
         <span className="text-[11px] text-muted-foreground tabular-nums">

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -2,6 +2,7 @@
 
 import { Check, ChevronDown, X } from "lucide-react";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -63,6 +64,47 @@ export function FilterPopover({
             Clear
           </Button>
         </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+type ValuePopoverProps = {
+  label: string;
+  /** The current choice, shown on the trigger so the bar reads at a glance. */
+  value: string;
+  /** Receives a closer, because picking a single choice should dismiss it. */
+  children: (close: () => void) => ReactNode;
+};
+
+/**
+ * Single-choice dimension: the trigger carries the current value rather than a
+ * count, and picking an option closes the panel, since there is nothing more to
+ * choose.
+ */
+export function ValuePopover({
+  label,
+  value,
+  children,
+}: ValuePopoverProps): ReactNode {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={label}
+          className="h-8 gap-1.5 px-2.5 text-xs"
+          size="sm"
+          variant="outline"
+        >
+          <span className="text-muted-foreground">{label}:</span>
+          {value}
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-48 p-1.5">
+        {children(() => setOpen(false))}
       </PopoverContent>
     </Popover>
   );

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Check, ChevronDown, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+type FilterPopoverProps = {
+  label: string;
+  /** Number of values held in this dimension; 0 renders no badge. */
+  selectedCount: number;
+  onClear: () => void;
+  children: ReactNode;
+};
+
+/** A filter dimension: a trigger showing how many values it holds, and a panel. */
+export function FilterPopover({
+  label,
+  selectedCount,
+  onClear,
+  children,
+}: FilterPopoverProps): ReactNode {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          className={cn(
+            "h-8 gap-1.5 px-2.5 text-xs",
+            selectedCount > 0 && "border-primary/40"
+          )}
+          size="sm"
+          variant="outline"
+        >
+          {label}
+          {selectedCount > 0 && (
+            <Badge className="h-4 px-1 text-[10px]" variant="secondary">
+              {selectedCount}
+            </Badge>
+          )}
+          <ChevronDown className="size-3.5 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-0">
+        <div className="max-h-80 overflow-y-auto p-1.5">{children}</div>
+        <div className="flex items-center justify-between border-t px-2 py-1.5">
+          <span className="text-[11px] text-muted-foreground">
+            {selectedCount > 0 ? `${selectedCount} selected` : "Showing all"}
+          </span>
+          <Button
+            className="h-6 px-2 text-xs"
+            disabled={selectedCount === 0}
+            onClick={onClear}
+            size="sm"
+            variant="ghost"
+          >
+            Clear
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+type FilterCheckboxProps = {
+  label: string;
+  count?: number;
+  checked: boolean;
+  /** Some but not all of a group's members are selected. */
+  indeterminate?: boolean;
+  indented?: boolean;
+  onToggle: () => void;
+};
+
+export function FilterCheckbox({
+  label,
+  count,
+  checked,
+  indeterminate = false,
+  indented = false,
+  onToggle,
+}: FilterCheckboxProps): ReactNode {
+  return (
+    <button
+      className={cn(
+        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent",
+        indented && "pl-7"
+      )}
+      onClick={onToggle}
+      type="button"
+    >
+      <Checkbox
+        checked={indeterminate ? "indeterminate" : checked}
+        className="pointer-events-none"
+        tabIndex={-1}
+      />
+      <span className={cn("flex-1", !indented && "font-medium")}>{label}</span>
+      {count !== undefined && (
+        <span className="text-[11px] text-muted-foreground tabular-nums">
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+type FilterRadioProps = {
+  label: string;
+  checked: boolean;
+  onSelect: () => void;
+};
+
+export function FilterRadio({
+  label,
+  checked,
+  onSelect,
+}: FilterRadioProps): ReactNode {
+  return (
+    <button
+      className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent"
+      onClick={onSelect}
+      type="button"
+    >
+      <Check
+        className={cn("size-3.5", checked ? "opacity-100" : "opacity-0")}
+      />
+      <span className="flex-1">{label}</span>
+    </button>
+  );
+}
+
+type FilterChipProps = {
+  label: string;
+  onRemove: () => void;
+};
+
+/** One applied filter, shown under the bar so the narrowing stays visible. */
+export function FilterChip({ label, onRemove }: FilterChipProps): ReactNode {
+  return (
+    <Badge className="gap-1 pr-1 font-normal" variant="secondary">
+      {label}
+      <button
+        aria-label={`Remove ${label} filter`}
+        className="rounded-sm p-0.5 hover:bg-background/60"
+        onClick={onRemove}
+        type="button"
+      >
+        <X className="size-3" />
+      </button>
+    </Badge>
+  );
+}

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { Check, ChevronDown, X } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import type { ReactNode } from "react";
-import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -64,47 +63,6 @@ export function FilterPopover({
             Clear
           </Button>
         </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-type ValuePopoverProps = {
-  label: string;
-  /** The current choice, shown on the trigger so the bar reads at a glance. */
-  value: string;
-  /** Receives a closer, because picking a single choice should dismiss it. */
-  children: (close: () => void) => ReactNode;
-};
-
-/**
- * Single-choice dimension: the trigger carries the current value rather than a
- * count, and picking an option closes the panel, since there is nothing more to
- * choose.
- */
-export function ValuePopover({
-  label,
-  value,
-  children,
-}: ValuePopoverProps): ReactNode {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Popover onOpenChange={setOpen} open={open}>
-      <PopoverTrigger asChild>
-        <Button
-          aria-label={label}
-          className="h-8 gap-1.5 px-2.5 text-xs"
-          size="sm"
-          variant="outline"
-        >
-          <span className="text-muted-foreground">{label}:</span>
-          {value}
-          <ChevronDown className="size-3.5 text-muted-foreground" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" className="w-48 p-1.5">
-        {children(() => setOpen(false))}
       </PopoverContent>
     </Popover>
   );
@@ -174,27 +132,5 @@ export function FilterRadio({
       />
       <span className="flex-1">{label}</span>
     </button>
-  );
-}
-
-type FilterChipProps = {
-  label: string;
-  onRemove: () => void;
-};
-
-/** One applied filter, shown under the bar so the narrowing stays visible. */
-export function FilterChip({ label, onRemove }: FilterChipProps): ReactNode {
-  return (
-    <Badge className="gap-1 pr-1 font-normal" variant="secondary">
-      {label}
-      <button
-        aria-label={`Remove ${label} filter`}
-        className="rounded-sm p-0.5 hover:bg-background/60"
-        onClick={onRemove}
-        type="button"
-      >
-        <X className="size-3" />
-      </button>
-    </Badge>
   );
 }

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { Search } from "lucide-react";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -9,7 +9,6 @@ import { Input } from "@/components/ui/input";
 import {
   DURATION_PRESETS,
   type DurationPresetId,
-  durationPreset,
 } from "@/lib/analytics/duration-presets";
 import type { NormalizedStatus, RunSource } from "@/lib/analytics/types";
 import {
@@ -25,12 +24,7 @@ import {
   ChainDisplayProvider,
   useChainDisplay,
 } from "@/lib/hooks/use-chain-display";
-import {
-  FilterCheckbox,
-  FilterChip,
-  FilterPopover,
-  FilterRadio,
-} from "./filter-popover";
+import { FilterCheckbox, FilterPopover, FilterRadio } from "./filter-popover";
 
 type StatusGroup = {
   key: string;
@@ -38,18 +32,10 @@ type StatusGroup = {
   members: Array<{ value: NormalizedStatus; label: string }>;
 };
 
-// Errors group first, and its three statuses sit under one parent: ticking
-// "Errors" is the whole reason the status filter had to become a multi-select.
+// Ordered by how often a reader reaches for them: the healthy case, then what
+// is still in flight, then the failures with their three subtypes nested under
+// one parent so all of them can be selected in a single click.
 const STATUS_GROUPS: StatusGroup[] = [
-  {
-    key: "errors",
-    label: "Errors",
-    members: [
-      { value: "error", label: "User" },
-      { value: "external_error", label: "External" },
-      { value: "system_error", label: "System" },
-    ],
-  },
   {
     key: "success",
     label: "Success",
@@ -64,6 +50,15 @@ const STATUS_GROUPS: StatusGroup[] = [
     ],
   },
   {
+    key: "errors",
+    label: "Errors",
+    members: [
+      { value: "error", label: "User" },
+      { value: "external_error", label: "External" },
+      { value: "system_error", label: "System" },
+    ],
+  },
+  {
     key: "cancelled",
     label: "Cancelled",
     members: [{ value: "cancelled", label: "Cancelled" }],
@@ -74,17 +69,6 @@ const STATUS_GROUPS: StatusGroup[] = [
     members: [{ value: "skipped", label: "Skipped" }],
   },
 ];
-
-const STATUS_CHIP_LABELS: Record<NormalizedStatus, string> = {
-  error: "Error: User",
-  external_error: "Error: External",
-  system_error: "Error: System",
-  success: "Success",
-  pending: "Pending",
-  running: "Running",
-  cancelled: "Cancelled",
-  skipped: "Skipped",
-};
 
 const SOURCE_OPTIONS: Array<{ value: RunSource; label: string }> = [
   { value: "workflow", label: "Workflow" },
@@ -307,92 +291,17 @@ function SearchBox(): ReactNode {
   );
 }
 
-type Chip = { key: string; label: string; onRemove: () => void };
-
-function useFilterChips(): Chip[] {
+/**
+ * One control to drop every narrowing at once. The dropdown triggers already
+ * show what is selected, so there is no chip row restating it; this is only the
+ * escape hatch out of a combination.
+ */
+function ClearAllButton(): ReactNode {
   const [statuses, setStatuses] = useAtom(analyticsStatusFiltersAtom);
   const [sources, setSources] = useAtom(analyticsSourceFiltersAtom);
   const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
   const [duration, setDuration] = useAtom(analyticsDurationFilterAtom);
   const [search, setSearch] = useAtom(analyticsSearchAtom);
-  const chains = useChainDisplay();
-
-  const chips: Chip[] = [];
-
-  for (const group of STATUS_GROUPS) {
-    const members = group.members.map((member) => member.value);
-    const selected = members.filter((value) => statuses.includes(value));
-    if (selected.length === 0) {
-      continue;
-    }
-    // A fully-ticked group collapses to one chip so "Errors" reads as one
-    // decision rather than three.
-    if (selected.length === members.length && members.length > 1) {
-      chips.push({
-        key: group.key,
-        label: `${group.label} (${members.length})`,
-        onRemove: () =>
-          setStatuses((current) =>
-            current.filter((value) => !members.includes(value))
-          ),
-      });
-      continue;
-    }
-    for (const value of selected) {
-      chips.push({
-        key: value,
-        label: STATUS_CHIP_LABELS[value],
-        onRemove: () =>
-          setStatuses((current) => current.filter((entry) => entry !== value)),
-      });
-    }
-  }
-
-  for (const source of sources) {
-    chips.push({
-      key: `source-${source}`,
-      label: source === "workflow" ? "Workflow" : "Direct",
-      onRemove: () =>
-        setSources((current) => current.filter((entry) => entry !== source)),
-    });
-  }
-
-  for (const network of networks) {
-    chips.push({
-      key: `network-${network}`,
-      label: chains.name(network),
-      onRemove: () =>
-        setNetworks((current) => current.filter((entry) => entry !== network)),
-    });
-  }
-
-  const preset = durationPreset(duration);
-  if (preset) {
-    chips.push({
-      key: "duration",
-      label: preset.label,
-      onRemove: () => setDuration(null),
-    });
-  }
-
-  if (search.trim()) {
-    chips.push({
-      key: "search",
-      label: `"${search.trim()}"`,
-      onRemove: () => setSearch(""),
-    });
-  }
-
-  return chips;
-}
-
-function ActiveFilters(): ReactNode {
-  const chips = useFilterChips();
-  const setStatuses = useSetAtom(analyticsStatusFiltersAtom);
-  const setSources = useSetAtom(analyticsSourceFiltersAtom);
-  const setNetworks = useSetAtom(analyticsNetworkFiltersAtom);
-  const setDuration = useSetAtom(analyticsDurationFilterAtom);
-  const setSearch = useSetAtom(analyticsSearchAtom);
 
   const clearAll = useCallback((): void => {
     setStatuses([]);
@@ -402,44 +311,40 @@ function ActiveFilters(): ReactNode {
     setSearch("");
   }, [setStatuses, setSources, setNetworks, setDuration, setSearch]);
 
-  if (chips.length === 0) {
+  const active =
+    statuses.length > 0 ||
+    sources.length > 0 ||
+    networks.length > 0 ||
+    duration !== null ||
+    search.trim().length > 0;
+
+  if (!active) {
     return null;
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
-      {chips.map((chip) => (
-        <FilterChip
-          key={chip.key}
-          label={chip.label}
-          onRemove={chip.onRemove}
-        />
-      ))}
-      <Button
-        className="h-6 px-2 text-xs text-muted-foreground"
-        onClick={clearAll}
-        size="sm"
-        variant="ghost"
-      >
-        Clear all
-      </Button>
-    </div>
+    <Button
+      className="h-8 px-2 text-muted-foreground text-xs"
+      onClick={clearAll}
+      size="sm"
+      variant="ghost"
+    >
+      Clear all
+    </Button>
   );
 }
 
 export function RunsFilters(): ReactNode {
   return (
     <ChainDisplayProvider>
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <SearchBox />
-          <div className="h-5 w-px bg-border" />
-          <StatusFilter />
-          <SourceFilter />
-          <NetworkFilter />
-          <DurationFilter />
-        </div>
-        <ActiveFilters />
+      <div className="flex flex-wrap items-center gap-2">
+        <SearchBox />
+        <div className="h-5 w-px bg-border" />
+        <StatusFilter />
+        <NetworkFilter />
+        <DurationFilter />
+        <SourceFilter />
+        <ClearAllButton />
       </div>
     </ChainDisplayProvider>
   );

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -1,125 +1,446 @@
 "use client";
 
-import { useAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { Search } from "lucide-react";
 import type { ReactNode } from "react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  DURATION_PRESETS,
+  type DurationPresetId,
+  durationPreset,
+} from "@/lib/analytics/duration-presets";
 import type { NormalizedStatus, RunSource } from "@/lib/analytics/types";
 import {
+  analyticsDurationFilterAtom,
+  analyticsNetworkFiltersAtom,
+  analyticsNetworksAtom,
   analyticsSearchAtom,
-  analyticsSourceFilterAtom,
-  analyticsStatusFilterAtom,
+  analyticsSourceFiltersAtom,
+  analyticsStatusFacetsAtom,
+  analyticsStatusFiltersAtom,
 } from "@/lib/atoms/analytics";
-import { cn } from "@/lib/utils";
+import {
+  ChainDisplayProvider,
+  useChainDisplay,
+} from "@/lib/hooks/use-chain-display";
+import {
+  FilterCheckbox,
+  FilterChip,
+  FilterPopover,
+  FilterRadio,
+} from "./filter-popover";
 
-const STATUS_OPTIONS: Array<{
-  value: NormalizedStatus | undefined;
+type StatusGroup = {
+  key: string;
   label: string;
-}> = [
-  { value: undefined, label: "All" },
-  { value: "success", label: "Success" },
-  { value: "error", label: "Error" },
-  { value: "external_error", label: "External" },
-  { value: "system_error", label: "System Error" },
-  { value: "cancelled", label: "Cancelled" },
-  { value: "skipped", label: "Skipped" },
-  { value: "running", label: "Running" },
-  { value: "pending", label: "Pending" },
+  members: Array<{ value: NormalizedStatus; label: string }>;
+};
+
+// Errors group first, and its three statuses sit under one parent: ticking
+// "Errors" is the whole reason the status filter had to become a multi-select.
+const STATUS_GROUPS: StatusGroup[] = [
+  {
+    key: "errors",
+    label: "Errors",
+    members: [
+      { value: "error", label: "User" },
+      { value: "external_error", label: "External" },
+      { value: "system_error", label: "System" },
+    ],
+  },
+  {
+    key: "success",
+    label: "Success",
+    members: [{ value: "success", label: "Success" }],
+  },
+  {
+    key: "in-flight",
+    label: "In flight",
+    members: [
+      { value: "pending", label: "Pending" },
+      { value: "running", label: "Running" },
+    ],
+  },
+  {
+    key: "cancelled",
+    label: "Cancelled",
+    members: [{ value: "cancelled", label: "Cancelled" }],
+  },
+  {
+    key: "skipped",
+    label: "Skipped",
+    members: [{ value: "skipped", label: "Skipped" }],
+  },
 ];
 
-const SOURCE_OPTIONS: Array<{
-  value: RunSource | undefined;
-  label: string;
-}> = [
-  { value: undefined, label: "All" },
+const STATUS_CHIP_LABELS: Record<NormalizedStatus, string> = {
+  error: "Error: User",
+  external_error: "Error: External",
+  system_error: "Error: System",
+  success: "Success",
+  pending: "Pending",
+  running: "Running",
+  cancelled: "Cancelled",
+  skipped: "Skipped",
+};
+
+const SOURCE_OPTIONS: Array<{ value: RunSource; label: string }> = [
   { value: "workflow", label: "Workflow" },
   { value: "direct", label: "Direct" },
 ];
 
-type FilterGroupProps<T> = {
-  label: string;
-  options: Array<{ value: T; label: string }>;
-  current: T;
-  onChange: (value: T) => void;
-};
+const SEARCH_DEBOUNCE_MS = 300;
 
-function FilterGroup<T>({
-  label,
-  options,
-  current,
-  onChange,
-}: FilterGroupProps<T>): ReactNode {
+function toggle<T>(values: T[], value: T): T[] {
+  return values.includes(value)
+    ? values.filter((entry) => entry !== value)
+    : [...values, value];
+}
+
+function StatusFilter(): ReactNode {
+  const [statuses, setStatuses] = useAtom(analyticsStatusFiltersAtom);
+  const facets = useAtomValue(analyticsStatusFacetsAtom);
+
+  const toggleMember = useCallback(
+    (value: NormalizedStatus): void => {
+      setStatuses((current) => toggle(current, value));
+    },
+    [setStatuses]
+  );
+
+  const toggleGroup = useCallback(
+    (group: StatusGroup): void => {
+      const members = group.members.map((member) => member.value);
+      setStatuses((current) => {
+        const allOn = members.every((value) => current.includes(value));
+        if (allOn) {
+          return current.filter((value) => !members.includes(value));
+        }
+        return [...new Set([...current, ...members])];
+      });
+    },
+    [setStatuses]
+  );
+
+  const clear = useCallback((): void => setStatuses([]), [setStatuses]);
+
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs font-medium text-muted-foreground">
-        {label}:
-      </span>
-      <nav aria-label={label} className="flex items-center gap-1">
-        {options.map((option) => (
-          <Button
-            className={cn(
-              "h-7 px-2.5 text-xs",
-              current === option.value && "pointer-events-none"
-            )}
-            key={option.label}
-            onClick={() => onChange(option.value)}
-            size="sm"
-            variant={current === option.value ? "default" : "ghost"}
-          >
-            {option.label}
-          </Button>
-        ))}
-      </nav>
+    <FilterPopover
+      label="Status"
+      onClear={clear}
+      selectedCount={statuses.length}
+    >
+      {STATUS_GROUPS.map((group) => {
+        const members = group.members.map((member) => member.value);
+        const selected = members.filter((value) => statuses.includes(value));
+        const groupCount = members.reduce(
+          (sum, value) => sum + (facets[value] ?? 0),
+          0
+        );
+        return (
+          <div key={group.key}>
+            <FilterCheckbox
+              checked={selected.length === members.length}
+              count={groupCount}
+              indeterminate={
+                selected.length > 0 && selected.length < members.length
+              }
+              label={group.label}
+              onToggle={() => toggleGroup(group)}
+            />
+            {group.members.length > 1 &&
+              group.members.map((member) => (
+                <FilterCheckbox
+                  checked={statuses.includes(member.value)}
+                  count={facets[member.value] ?? 0}
+                  indented
+                  key={member.value}
+                  label={member.label}
+                  onToggle={() => toggleMember(member.value)}
+                />
+              ))}
+          </div>
+        );
+      })}
+    </FilterPopover>
+  );
+}
+
+function SourceFilter(): ReactNode {
+  const [sources, setSources] = useAtom(analyticsSourceFiltersAtom);
+  const clear = useCallback((): void => setSources([]), [setSources]);
+
+  return (
+    <FilterPopover
+      label="Source"
+      onClear={clear}
+      selectedCount={sources.length}
+    >
+      {SOURCE_OPTIONS.map((option) => (
+        <FilterCheckbox
+          checked={sources.includes(option.value)}
+          key={option.value}
+          label={option.label}
+          onToggle={() =>
+            setSources((current) => toggle(current, option.value))
+          }
+        />
+      ))}
+    </FilterPopover>
+  );
+}
+
+function NetworkFilter(): ReactNode {
+  const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
+  const breakdown = useAtomValue(analyticsNetworksAtom);
+  const chains = useChainDisplay();
+  const clear = useCallback((): void => setNetworks([]), [setNetworks]);
+
+  // Chains the window actually saw, busiest first. A chain with no runs in the
+  // window is not an option, because selecting it could only return nothing.
+  const options = useMemo(
+    () =>
+      [...breakdown]
+        .sort((a, b) => b.executionCount - a.executionCount)
+        .map((entry) => ({
+          value: entry.network,
+          label: chains.name(entry.network),
+          count: entry.executionCount,
+        })),
+    [breakdown, chains]
+  );
+
+  return (
+    <FilterPopover
+      label="Network"
+      onClear={clear}
+      selectedCount={networks.length}
+    >
+      {options.length === 0 ? (
+        <p className="px-2 py-3 text-center text-muted-foreground text-xs">
+          No networks in this period
+        </p>
+      ) : (
+        options.map((option) => (
+          <FilterCheckbox
+            checked={networks.includes(option.value)}
+            count={option.count}
+            key={option.value}
+            label={option.label}
+            onToggle={() =>
+              setNetworks((current) => toggle(current, option.value))
+            }
+          />
+        ))
+      )}
+    </FilterPopover>
+  );
+}
+
+function DurationFilter(): ReactNode {
+  const [duration, setDuration] = useAtom(analyticsDurationFilterAtom);
+  const clear = useCallback((): void => setDuration(null), [setDuration]);
+
+  const select = useCallback(
+    (id: DurationPresetId): void => {
+      setDuration((current) => (current === id ? null : id));
+    },
+    [setDuration]
+  );
+
+  return (
+    <FilterPopover
+      label="Duration"
+      onClear={clear}
+      selectedCount={duration ? 1 : 0}
+    >
+      {DURATION_PRESETS.map((preset) => (
+        <FilterRadio
+          checked={duration === preset.id}
+          key={preset.id}
+          label={preset.label}
+          onSelect={() => select(preset.id)}
+        />
+      ))}
+    </FilterPopover>
+  );
+}
+
+function SearchBox(): ReactNode {
+  const [search, setSearch] = useAtom(analyticsSearchAtom);
+  const [draft, setDraft] = useState(search);
+  const pushed = useRef(search);
+
+  // Typing narrows a server-side query now, so hold the keystrokes back until
+  // the reader pauses rather than refetching the listing on every character.
+  useEffect(() => {
+    if (draft === search) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      pushed.current = draft;
+      setSearch(draft);
+    }, SEARCH_DEBOUNCE_MS);
+    return (): void => clearTimeout(timer);
+  }, [draft, search, setSearch]);
+
+  // Someone else cleared the term (the chip, or Clear all), so follow it.
+  useEffect(() => {
+    if (search !== pushed.current) {
+      pushed.current = search;
+      setDraft(search);
+    }
+  }, [search]);
+
+  return (
+    <div className="relative w-56">
+      <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        className="h-8 pl-9 text-sm"
+        onChange={(e) => setDraft(e.target.value)}
+        placeholder="Search name or run id..."
+        value={draft}
+      />
+    </div>
+  );
+}
+
+type Chip = { key: string; label: string; onRemove: () => void };
+
+function useFilterChips(): Chip[] {
+  const [statuses, setStatuses] = useAtom(analyticsStatusFiltersAtom);
+  const [sources, setSources] = useAtom(analyticsSourceFiltersAtom);
+  const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
+  const [duration, setDuration] = useAtom(analyticsDurationFilterAtom);
+  const [search, setSearch] = useAtom(analyticsSearchAtom);
+  const chains = useChainDisplay();
+
+  const chips: Chip[] = [];
+
+  for (const group of STATUS_GROUPS) {
+    const members = group.members.map((member) => member.value);
+    const selected = members.filter((value) => statuses.includes(value));
+    if (selected.length === 0) {
+      continue;
+    }
+    // A fully-ticked group collapses to one chip so "Errors" reads as one
+    // decision rather than three.
+    if (selected.length === members.length && members.length > 1) {
+      chips.push({
+        key: group.key,
+        label: `${group.label} (${members.length})`,
+        onRemove: () =>
+          setStatuses((current) =>
+            current.filter((value) => !members.includes(value))
+          ),
+      });
+      continue;
+    }
+    for (const value of selected) {
+      chips.push({
+        key: value,
+        label: STATUS_CHIP_LABELS[value],
+        onRemove: () =>
+          setStatuses((current) => current.filter((entry) => entry !== value)),
+      });
+    }
+  }
+
+  for (const source of sources) {
+    chips.push({
+      key: `source-${source}`,
+      label: source === "workflow" ? "Workflow" : "Direct",
+      onRemove: () =>
+        setSources((current) => current.filter((entry) => entry !== source)),
+    });
+  }
+
+  for (const network of networks) {
+    chips.push({
+      key: `network-${network}`,
+      label: chains.name(network),
+      onRemove: () =>
+        setNetworks((current) => current.filter((entry) => entry !== network)),
+    });
+  }
+
+  const preset = durationPreset(duration);
+  if (preset) {
+    chips.push({
+      key: "duration",
+      label: preset.label,
+      onRemove: () => setDuration(null),
+    });
+  }
+
+  if (search.trim()) {
+    chips.push({
+      key: "search",
+      label: `"${search.trim()}"`,
+      onRemove: () => setSearch(""),
+    });
+  }
+
+  return chips;
+}
+
+function ActiveFilters(): ReactNode {
+  const chips = useFilterChips();
+  const setStatuses = useSetAtom(analyticsStatusFiltersAtom);
+  const setSources = useSetAtom(analyticsSourceFiltersAtom);
+  const setNetworks = useSetAtom(analyticsNetworkFiltersAtom);
+  const setDuration = useSetAtom(analyticsDurationFilterAtom);
+  const setSearch = useSetAtom(analyticsSearchAtom);
+
+  const clearAll = useCallback((): void => {
+    setStatuses([]);
+    setSources([]);
+    setNetworks([]);
+    setDuration(null);
+    setSearch("");
+  }, [setStatuses, setSources, setNetworks, setDuration, setSearch]);
+
+  if (chips.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {chips.map((chip) => (
+        <FilterChip
+          key={chip.key}
+          label={chip.label}
+          onRemove={chip.onRemove}
+        />
+      ))}
+      <Button
+        className="h-6 px-2 text-xs text-muted-foreground"
+        onClick={clearAll}
+        size="sm"
+        variant="ghost"
+      >
+        Clear all
+      </Button>
     </div>
   );
 }
 
 export function RunsFilters(): ReactNode {
-  const [statusFilter, setStatusFilter] = useAtom(analyticsStatusFilterAtom);
-  const [sourceFilter, setSourceFilter] = useAtom(analyticsSourceFilterAtom);
-  const [search, setSearch] = useAtom(analyticsSearchAtom);
-
-  const handleStatusChange = useCallback(
-    (value: NormalizedStatus | undefined): void => {
-      setStatusFilter(value);
-    },
-    [setStatusFilter]
-  );
-
-  const handleSourceChange = useCallback(
-    (value: RunSource | undefined): void => {
-      setSourceFilter(value);
-    },
-    [setSourceFilter]
-  );
-
   return (
-    <div className="flex flex-wrap items-center gap-4">
-      <div className="relative w-56">
-        <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          className="h-8 pl-9 text-sm"
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search runs..."
-          value={search}
-        />
+    <ChainDisplayProvider>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <SearchBox />
+          <div className="h-5 w-px bg-border" />
+          <StatusFilter />
+          <SourceFilter />
+          <NetworkFilter />
+          <DurationFilter />
+        </div>
+        <ActiveFilters />
       </div>
-      <div className="h-5 w-px bg-border" />
-      <FilterGroup
-        current={statusFilter}
-        label="Status"
-        onChange={handleStatusChange}
-        options={STATUS_OPTIONS}
-      />
-      <div className="h-5 w-px bg-border" />
-      <FilterGroup
-        current={sourceFilter}
-        label="Source"
-        onChange={handleSourceChange}
-        options={SOURCE_OPTIONS}
-      />
-    </div>
+    </ChainDisplayProvider>
   );
 }

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -10,9 +10,15 @@ import {
   DURATION_PRESETS,
   type DurationPresetId,
 } from "@/lib/analytics/duration-presets";
-import type { NormalizedStatus, RunSource } from "@/lib/analytics/types";
+import { STATUS_DISPLAY } from "@/lib/analytics/status-display";
+import type {
+  GasSpend,
+  NormalizedStatus,
+  RunSource,
+} from "@/lib/analytics/types";
 import {
   analyticsDurationFilterAtom,
+  analyticsGasFiltersAtom,
   analyticsNetworkFiltersAtom,
   analyticsNetworksAtom,
   analyticsSearchAtom,
@@ -20,6 +26,7 @@ import {
   analyticsStatusFacetsAtom,
   analyticsStatusFiltersAtom,
 } from "@/lib/atoms/analytics";
+import { sortChainsByName } from "@/lib/chains/sort-chains";
 import {
   ChainDisplayProvider,
   useChainDisplay,
@@ -110,10 +117,19 @@ function StatusFilter(): ReactNode {
 
   const clear = useCallback((): void => setStatuses([]), [setStatuses]);
 
+  const selectAll = useCallback((): void => {
+    setStatuses(
+      STATUS_GROUPS.flatMap((group) =>
+        group.members.map((member) => member.value)
+      )
+    );
+  }, [setStatuses]);
+
   return (
     <FilterPopover
       label="Status"
       onClear={clear}
+      onSelectAll={selectAll}
       selectedCount={statuses.length}
     >
       {STATUS_GROUPS.map((group) => {
@@ -128,6 +144,11 @@ function StatusFilter(): ReactNode {
             <FilterCheckbox
               checked={selected.length === members.length}
               count={groupCount}
+              dot={
+                members.length === 1
+                  ? STATUS_DISPLAY[members[0]].dot
+                  : undefined
+              }
               indeterminate={
                 selected.length > 0 && selected.length < members.length
               }
@@ -139,6 +160,7 @@ function StatusFilter(): ReactNode {
                 <FilterCheckbox
                   checked={statuses.includes(member.value)}
                   count={facets[member.value] ?? 0}
+                  dot={STATUS_DISPLAY[member.value].dot}
                   indented
                   key={member.value}
                   label={member.label}
@@ -155,11 +177,16 @@ function StatusFilter(): ReactNode {
 function SourceFilter(): ReactNode {
   const [sources, setSources] = useAtom(analyticsSourceFiltersAtom);
   const clear = useCallback((): void => setSources([]), [setSources]);
+  const selectAll = useCallback(
+    (): void => setSources(SOURCE_OPTIONS.map((option) => option.value)),
+    [setSources]
+  );
 
   return (
     <FilterPopover
       label="Source"
       onClear={clear}
+      onSelectAll={selectAll}
       selectedCount={sources.length}
     >
       {SOURCE_OPTIONS.map((option) => (
@@ -182,24 +209,33 @@ function NetworkFilter(): ReactNode {
   const chains = useChainDisplay();
   const clear = useCallback((): void => setNetworks([]), [setNetworks]);
 
-  // Chains the window actually saw, busiest first. A chain with no runs in the
-  // window is not an option, because selecting it could only return nothing.
+  // Chains the window actually saw. A chain with no runs in the window is not
+  // an option, because selecting it could only return nothing. Ordered through
+  // the same comparator the chain picker on a web3 node uses, so the two lists
+  // read the same way.
   const options = useMemo(
     () =>
-      [...breakdown]
-        .sort((a, b) => b.executionCount - a.executionCount)
-        .map((entry) => ({
+      sortChainsByName(
+        breakdown.map((entry) => ({
           value: entry.network,
           label: chains.name(entry.network),
           count: entry.executionCount,
         })),
+        (option) => option.label
+      ),
     [breakdown, chains]
+  );
+
+  const selectAll = useCallback(
+    (): void => setNetworks(options.map((option) => option.value)),
+    [setNetworks, options]
   );
 
   return (
     <FilterPopover
       label="Network"
       onClear={clear}
+      onSelectAll={options.length > 0 ? selectAll : undefined}
       selectedCount={networks.length}
     >
       {options.length === 0 ? (
@@ -223,6 +259,42 @@ function NetworkFilter(): ReactNode {
   );
 }
 
+const GAS_OPTIONS: Array<{ value: GasSpend; label: string }> = [
+  { value: "paid", label: "Used gas" },
+  { value: "free", label: "No gas" },
+];
+
+/**
+ * Whether a run spent anything on chain. Sponsored runs count as paid: the org
+ * drew on gas credit for them, so they are not free.
+ */
+function GasFilter(): ReactNode {
+  const [gas, setGas] = useAtom(analyticsGasFiltersAtom);
+  const clear = useCallback((): void => setGas([]), [setGas]);
+  const selectAll = useCallback(
+    (): void => setGas(GAS_OPTIONS.map((option) => option.value)),
+    [setGas]
+  );
+
+  return (
+    <FilterPopover
+      label="Gas"
+      onClear={clear}
+      onSelectAll={selectAll}
+      selectedCount={gas.length}
+    >
+      {GAS_OPTIONS.map((option) => (
+        <FilterCheckbox
+          checked={gas.includes(option.value)}
+          key={option.value}
+          label={option.label}
+          onToggle={() => setGas((current) => toggle(current, option.value))}
+        />
+      ))}
+    </FilterPopover>
+  );
+}
+
 function DurationFilter(): ReactNode {
   const [duration, setDuration] = useAtom(analyticsDurationFilterAtom);
   const clear = useCallback((): void => setDuration(null), [setDuration]);
@@ -240,6 +312,7 @@ function DurationFilter(): ReactNode {
       onClear={clear}
       selectedCount={duration ? 1 : 0}
     >
+      <FilterRadio checked={duration === null} label="Any" onSelect={clear} />
       {DURATION_PRESETS.map((preset) => (
         <FilterRadio
           checked={duration === preset.id}
@@ -301,6 +374,7 @@ function ClearAllButton(): ReactNode {
   const [sources, setSources] = useAtom(analyticsSourceFiltersAtom);
   const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
   const [duration, setDuration] = useAtom(analyticsDurationFilterAtom);
+  const [gas, setGas] = useAtom(analyticsGasFiltersAtom);
   const [search, setSearch] = useAtom(analyticsSearchAtom);
 
   const clearAll = useCallback((): void => {
@@ -308,14 +382,16 @@ function ClearAllButton(): ReactNode {
     setSources([]);
     setNetworks([]);
     setDuration(null);
+    setGas([]);
     setSearch("");
-  }, [setStatuses, setSources, setNetworks, setDuration, setSearch]);
+  }, [setStatuses, setSources, setNetworks, setDuration, setGas, setSearch]);
 
   const active =
     statuses.length > 0 ||
     sources.length > 0 ||
     networks.length > 0 ||
     duration !== null ||
+    gas.length > 0 ||
     search.trim().length > 0;
 
   if (!active) {
@@ -343,6 +419,7 @@ export function RunsFilters(): ReactNode {
         <StatusFilter />
         <NetworkFilter />
         <DurationFilter />
+        <GasFilter />
         <SourceFilter />
         <ClearAllButton />
       </div>

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -259,10 +259,32 @@ function NetworkFilter(): ReactNode {
   );
 }
 
-const GAS_OPTIONS: Array<{ value: GasSpend; label: string }> = [
-  { value: "paid", label: "Used gas" },
-  { value: "free", label: "No gas" },
+// Grouped like the statuses: one click for "it cost something", with who paid
+// nested under it. Sponsored and wallet overlap on a run that started sponsored
+// and fell back, which is why they are separate ticks rather than a toggle.
+const GAS_GROUPS: Array<{
+  key: string;
+  label: string;
+  members: Array<{ value: GasSpend; label: string }>;
+}> = [
+  {
+    key: "spent",
+    label: "Used gas",
+    members: [
+      { value: "sponsored", label: "Sponsored" },
+      { value: "wallet", label: "Wallet paid" },
+    ],
+  },
+  {
+    key: "free",
+    label: "No gas",
+    members: [{ value: "free", label: "No gas" }],
+  },
 ];
+
+const ALL_GAS: GasSpend[] = GAS_GROUPS.flatMap((group) =>
+  group.members.map((member) => member.value)
+);
 
 /**
  * Whether a run spent anything on chain. Sponsored runs count as paid: the org
@@ -271,8 +293,18 @@ const GAS_OPTIONS: Array<{ value: GasSpend; label: string }> = [
 function GasFilter(): ReactNode {
   const [gas, setGas] = useAtom(analyticsGasFiltersAtom);
   const clear = useCallback((): void => setGas([]), [setGas]);
-  const selectAll = useCallback(
-    (): void => setGas(GAS_OPTIONS.map((option) => option.value)),
+  const selectAll = useCallback((): void => setGas(ALL_GAS), [setGas]);
+
+  const toggleGroup = useCallback(
+    (members: GasSpend[]): void => {
+      setGas((current) => {
+        const allOn = members.every((value) => current.includes(value));
+        if (allOn) {
+          return current.filter((value) => !members.includes(value));
+        }
+        return [...new Set([...current, ...members])];
+      });
+    },
     [setGas]
   );
 
@@ -283,14 +315,34 @@ function GasFilter(): ReactNode {
       onSelectAll={selectAll}
       selectedCount={gas.length}
     >
-      {GAS_OPTIONS.map((option) => (
-        <FilterCheckbox
-          checked={gas.includes(option.value)}
-          key={option.value}
-          label={option.label}
-          onToggle={() => setGas((current) => toggle(current, option.value))}
-        />
-      ))}
+      {GAS_GROUPS.map((group) => {
+        const members = group.members.map((member) => member.value);
+        const selected = members.filter((value) => gas.includes(value));
+        return (
+          <div key={group.key}>
+            <FilterCheckbox
+              checked={selected.length === members.length}
+              indeterminate={
+                selected.length > 0 && selected.length < members.length
+              }
+              label={group.label}
+              onToggle={() => toggleGroup(members)}
+            />
+            {group.members.length > 1 &&
+              group.members.map((member) => (
+                <FilterCheckbox
+                  checked={gas.includes(member.value)}
+                  indented
+                  key={member.value}
+                  label={member.label}
+                  onToggle={() =>
+                    setGas((current) => toggle(current, member.value))
+                  }
+                />
+              ))}
+          </div>
+        );
+      })}
     </FilterPopover>
   );
 }

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -26,6 +26,7 @@ import {
   normalizeRunsResponse,
   type WireRunsResponse,
 } from "@/lib/analytics/runs-response";
+import { STATUS_DISPLAY } from "@/lib/analytics/status-display";
 import type {
   NormalizedStatus,
   StepLog,
@@ -33,6 +34,7 @@ import type {
 } from "@/lib/analytics/types";
 import {
   analyticsDurationFilterAtom,
+  analyticsGasFiltersAtom,
   analyticsLoadingAtom,
   analyticsNetworkFiltersAtom,
   analyticsProjectIdAtom,
@@ -237,28 +239,6 @@ function formatTimeAgo(dateString: string): string {
   return `${days}d ago`;
 }
 
-const STATUS_STYLES: Record<NormalizedStatus, string> = {
-  success:
-    "bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20",
-  error: "bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20",
-  system_error:
-    "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20",
-  external_error:
-    "bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/20",
-  cancelled:
-    "bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-500/20",
-  // Refused before it started: neutral, not a failure colour.
-  skipped: "bg-muted text-muted-foreground border-border",
-  running: "bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20",
-  pending: "bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20",
-} as const;
-
-const STATUS_LABELS: Partial<Record<NormalizedStatus, string>> = {
-  system_error: "System Error",
-  external_error: "External",
-  skipped: "Skipped",
-};
-
 // The four outcome badges a user cannot tell apart from the label alone. Each
 // one answers "whose fault is it and what do I do about it".
 const STATUS_TOOLTIPS: Partial<Record<NormalizedStatus, string>> = {
@@ -275,10 +255,10 @@ const STATUS_TOOLTIPS: Partial<Record<NormalizedStatus, string>> = {
 function StatusBadge({ status }: { status: NormalizedStatus }): ReactNode {
   const badge = (
     <Badge
-      className={cn("capitalize", STATUS_STYLES[status])}
+      className={cn("capitalize", STATUS_DISPLAY[status].badge)}
       variant="outline"
     >
-      {STATUS_LABELS[status] ?? status}
+      {STATUS_DISPLAY[status].label}
     </Badge>
   );
 
@@ -719,6 +699,7 @@ export function RunsTable(): ReactNode {
   const statuses = useAtomValue(analyticsStatusFiltersAtom);
   const sources = useAtomValue(analyticsSourceFiltersAtom);
   const networks = useAtomValue(analyticsNetworkFiltersAtom);
+  const gas = useAtomValue(analyticsGasFiltersAtom);
   const duration = useAtomValue(analyticsDurationFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
@@ -748,6 +729,7 @@ export function RunsTable(): ReactNode {
           statuses,
           sources,
           networks,
+          gas,
           duration,
           search,
           projectId,
@@ -772,6 +754,7 @@ export function RunsTable(): ReactNode {
       statuses,
       sources,
       networks,
+      gas,
       duration,
       search,
       projectId,

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { MouseEvent, ReactNode } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { buildRunsQuery } from "@/lib/analytics/runs-query";
 import {
   normalizeRunsResponse,
   type WireRunsResponse,
@@ -31,12 +32,15 @@ import type {
   UnifiedRun,
 } from "@/lib/analytics/types";
 import {
+  analyticsDurationFilterAtom,
   analyticsLoadingAtom,
+  analyticsNetworkFiltersAtom,
+  analyticsProjectIdAtom,
   analyticsRangeAtom,
   analyticsRunsAtom,
   analyticsSearchAtom,
-  analyticsSourceFilterAtom,
-  analyticsStatusFilterAtom,
+  analyticsSourceFiltersAtom,
+  analyticsStatusFiltersAtom,
 } from "@/lib/atoms/analytics";
 import { getCustomerRunErrorMessage } from "@/lib/errors/customer-message";
 import type { ChainDisplay } from "@/lib/hooks/use-chain-display";
@@ -48,7 +52,6 @@ import {
 import { cn } from "@/lib/utils";
 import { ProjectDrawer } from "./project-drawer";
 
-const WHITESPACE_RE = /\s+/;
 const LEADING_ZEROS_RE = /^0+(?=\d)/;
 const TRAILING_ZEROS_RE = /0+$/;
 const NON_DIGIT_RE = /\D/;
@@ -713,9 +716,12 @@ export function RunsTable(): ReactNode {
   const [runsData, setRunsData] = useAtom(analyticsRunsAtom);
   const loading = useAtomValue(analyticsLoadingAtom);
   const range = useAtomValue(analyticsRangeAtom);
-  const statusFilter = useAtomValue(analyticsStatusFilterAtom);
-  const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
+  const statuses = useAtomValue(analyticsStatusFiltersAtom);
+  const sources = useAtomValue(analyticsSourceFiltersAtom);
+  const networks = useAtomValue(analyticsNetworkFiltersAtom);
+  const duration = useAtomValue(analyticsDurationFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
+  const projectId = useAtomValue(analyticsProjectIdAtom);
   const router = useRouter();
   const searchParams = useSearchParams();
   const [pageLoading, setPageLoading] = useState(false);
@@ -737,20 +743,18 @@ export function RunsTable(): ReactNode {
       router.replace(url.pathname + url.search, { scroll: false });
 
       try {
-        const params = new URLSearchParams({
+        const query = buildRunsQuery({
           range,
-          page: String(newPage),
+          statuses,
+          sources,
+          networks,
+          duration,
+          search,
+          projectId,
+          page: newPage,
         });
-        if (statusFilter) {
-          params.set("status", statusFilter);
-        }
-        if (sourceFilter) {
-          params.set("source", sourceFilter);
-        }
 
-        const response = await fetch(
-          `/api/analytics/runs?${params.toString()}`
-        );
+        const response = await fetch(`/api/analytics/runs?${query}`);
         if (response.ok) {
           const data = (await response.json()) as WireRunsResponse;
           setRunsData(normalizeRunsResponse(data));
@@ -763,7 +767,17 @@ export function RunsTable(): ReactNode {
         setPageLoading(false);
       }
     },
-    [range, statusFilter, sourceFilter, setRunsData, router]
+    [
+      range,
+      statuses,
+      sources,
+      networks,
+      duration,
+      search,
+      projectId,
+      setRunsData,
+      router,
+    ]
   );
 
   // Restore page from URL ?page= param once after initial data load
@@ -779,23 +793,10 @@ export function RunsTable(): ReactNode {
     });
   }, [urlPage, runsData, handlePageChange]);
 
-  const allRuns = runsData?.runs ?? [];
-
-  const runs = useMemo((): UnifiedRun[] => {
-    const query = search.trim().toLowerCase();
-    if (!query) {
-      return allRuns;
-    }
-    const terms = query.split(WHITESPACE_RE);
-    return allRuns.filter((run) => {
-      const name = (run.workflowName ?? run.directType ?? "").toLowerCase();
-      const network = (run.network ?? "").toLowerCase();
-      const status = run.status.toLowerCase();
-      const id = run.id.toLowerCase();
-      const searchable = `${name} ${network} ${status} ${id}`;
-      return terms.every((term) => searchable.includes(term));
-    });
-  }, [allRuns, search]);
+  // Every filter, search included, now narrows the query, so the page the
+  // server returned is the page to render. Filtering it again here would make
+  // the row count disagree with the pagination total.
+  const runs = runsData?.runs ?? [];
 
   const isEmpty = runs.length === 0;
   const isReady = !(loading && isEmpty);

--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -33,6 +33,8 @@ import type {
   UnifiedRun,
 } from "@/lib/analytics/types";
 import {
+  analyticsCustomEndAtom,
+  analyticsCustomStartAtom,
   analyticsDurationFilterAtom,
   analyticsGasFiltersAtom,
   analyticsLoadingAtom,
@@ -703,6 +705,8 @@ export function RunsTable(): ReactNode {
   const duration = useAtomValue(analyticsDurationFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
+  const customStart = useAtomValue(analyticsCustomStartAtom);
+  const customEnd = useAtomValue(analyticsCustomEndAtom);
   const router = useRouter();
   const searchParams = useSearchParams();
   const [pageLoading, setPageLoading] = useState(false);
@@ -733,6 +737,8 @@ export function RunsTable(): ReactNode {
           duration,
           search,
           projectId,
+          customStart,
+          customEnd,
           page: newPage,
         });
 
@@ -758,6 +764,8 @@ export function RunsTable(): ReactNode {
       duration,
       search,
       projectId,
+      customStart,
+      customEnd,
       setRunsData,
       router,
     ]

--- a/components/analytics/time-series-chart.tsx
+++ b/components/analytics/time-series-chart.tsx
@@ -13,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { STATUS_DISPLAY } from "@/lib/analytics/status-display";
 import type { TimeRange } from "@/lib/analytics/types";
 import {
   analyticsLoadingAtom,
@@ -20,14 +21,15 @@ import {
   analyticsTimeSeriesAtom,
 } from "@/lib/atoms/analytics";
 
+// Colours come from the shared status palette, so a band on this chart is the
+// same hue as that status's badge in the table and its swatch in the filter.
 const CHART_COLORS = {
-  success: "var(--color-keeperhub-green)",
-  error: "var(--color-orange-500, #f97316)",
-  cancelled: "var(--chart-1)",
-  // Refused before it started: muted, so it never reads as a failure band.
-  skipped: "var(--color-muted-foreground)",
-  running: "var(--chart-2)",
-  pending: "var(--chart-4)",
+  success: STATUS_DISPLAY.success.chartColor,
+  error: STATUS_DISPLAY.error.chartColor,
+  cancelled: STATUS_DISPLAY.cancelled.chartColor,
+  skipped: STATUS_DISPLAY.skipped.chartColor,
+  running: STATUS_DISPLAY.running.chartColor,
+  pending: STATUS_DISPLAY.pending.chartColor,
 } as const;
 
 function formatTimestamp(value: string, range: TimeRange): string {

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -2,6 +2,7 @@
 
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
+import { buildRunsQuery } from "@/lib/analytics/runs-query";
 import {
   normalizeRunsResponse,
   type WireRunsResponse,
@@ -9,18 +10,23 @@ import {
 import type {
   AnalyticsSummary,
   NetworkBreakdown,
+  StatusFacets,
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
 import {
+  analyticsDurationFilterAtom,
   analyticsErrorAtom,
   analyticsLastUpdatedAtom,
   analyticsLoadingAtom,
+  analyticsNetworkFiltersAtom,
   analyticsNetworksAtom,
   analyticsProjectIdAtom,
   analyticsRangeAtom,
   analyticsRunsAtom,
-  analyticsSourceFilterAtom,
-  analyticsStatusFilterAtom,
+  analyticsSearchAtom,
+  analyticsSourceFiltersAtom,
+  analyticsStatusFacetsAtom,
+  analyticsStatusFiltersAtom,
   analyticsSummaryAtom,
   analyticsTimeSeriesAtom,
 } from "@/lib/atoms/analytics";
@@ -86,8 +92,11 @@ export function useAnalytics(): UseAnalyticsReturn {
   const activeOrgId = activeOrg?.id ?? null;
 
   const range = useAtomValue(analyticsRangeAtom);
-  const statusFilter = useAtomValue(analyticsStatusFilterAtom);
-  const sourceFilter = useAtomValue(analyticsSourceFilterAtom);
+  const statusFilters = useAtomValue(analyticsStatusFiltersAtom);
+  const sourceFilters = useAtomValue(analyticsSourceFiltersAtom);
+  const networkFilters = useAtomValue(analyticsNetworkFiltersAtom);
+  const durationFilter = useAtomValue(analyticsDurationFilterAtom);
+  const search = useAtomValue(analyticsSearchAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
   const [loading, setLoading] = useAtom(analyticsLoadingAtom);
   const [error, setError] = useAtom(analyticsErrorAtom);
@@ -96,6 +105,7 @@ export function useAnalytics(): UseAnalyticsReturn {
   const setTimeSeries = useSetAtom(analyticsTimeSeriesAtom);
   const setNetworks = useSetAtom(analyticsNetworksAtom);
   const setRuns = useSetAtom(analyticsRunsAtom);
+  const setStatusFacets = useSetAtom(analyticsStatusFacetsAtom);
   const setLastUpdated = useSetAtom(analyticsLastUpdatedAtom);
 
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -115,12 +125,19 @@ export function useAnalytics(): UseAnalyticsReturn {
     setError(null);
 
     const baseQuery = buildQuery({ range, projectId: projectId ?? undefined });
-    const runsQuery = buildQuery({
+    const filters = {
       range,
-      status: statusFilter,
-      source: sourceFilter,
-      projectId: projectId ?? undefined,
-    });
+      statuses: statusFilters,
+      sources: sourceFilters,
+      networks: networkFilters,
+      duration: durationFilter,
+      search,
+      projectId,
+    };
+    const runsQuery = buildRunsQuery(filters);
+    // The status counts sit under every filter except status itself, so the
+    // facets request carries the same query with that one dimension lifted.
+    const facetsQuery = buildRunsQuery({ ...filters, omitStatus: true });
 
     const { signal } = controller;
 
@@ -135,8 +152,11 @@ export function useAnalytics(): UseAnalyticsReturn {
       signal,
     });
     const runsPromise = fetch(`/api/analytics/runs?${runsQuery}`, { signal });
+    const facetsPromise = fetch(`/api/analytics/facets?${facetsQuery}`, {
+      signal,
+    });
 
-    let pendingCount = 4;
+    let pendingCount = 5;
     const ctx: FetchContext = {
       aborted: false,
       onAbort: (message: string): void => {
@@ -215,12 +235,25 @@ export function useAnalytics(): UseAnalyticsReturn {
           setRuns(normalizeRunsResponse(data));
         })
       ),
+      wrapSection(
+        processSection<{ statusCounts: StatusFacets }>(
+          facetsPromise,
+          "Facets",
+          ctx,
+          (data) => {
+            setStatusFacets(data.statusCounts);
+          }
+        )
+      ),
     ]);
   }, [
     activeOrgId,
     range,
-    statusFilter,
-    sourceFilter,
+    statusFilters,
+    sourceFilters,
+    networkFilters,
+    durationFilter,
+    search,
     projectId,
     setLoading,
     setError,
@@ -228,6 +261,7 @@ export function useAnalytics(): UseAnalyticsReturn {
     setTimeSeries,
     setNetworks,
     setRuns,
+    setStatusFacets,
     setLastUpdated,
   ]);
 

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -16,6 +16,7 @@ import type {
 import {
   analyticsDurationFilterAtom,
   analyticsErrorAtom,
+  analyticsGasFiltersAtom,
   analyticsLastUpdatedAtom,
   analyticsLoadingAtom,
   analyticsNetworkFiltersAtom,
@@ -95,6 +96,7 @@ export function useAnalytics(): UseAnalyticsReturn {
   const statusFilters = useAtomValue(analyticsStatusFiltersAtom);
   const sourceFilters = useAtomValue(analyticsSourceFiltersAtom);
   const networkFilters = useAtomValue(analyticsNetworkFiltersAtom);
+  const gasFilters = useAtomValue(analyticsGasFiltersAtom);
   const durationFilter = useAtomValue(analyticsDurationFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
@@ -130,6 +132,7 @@ export function useAnalytics(): UseAnalyticsReturn {
       statuses: statusFilters,
       sources: sourceFilters,
       networks: networkFilters,
+      gas: gasFilters,
       duration: durationFilter,
       search,
       projectId,
@@ -252,6 +255,7 @@ export function useAnalytics(): UseAnalyticsReturn {
     statusFilters,
     sourceFilters,
     networkFilters,
+    gasFilters,
     durationFilter,
     search,
     projectId,

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -14,6 +14,8 @@ import type {
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
 import {
+  analyticsCustomEndAtom,
+  analyticsCustomStartAtom,
   analyticsDurationFilterAtom,
   analyticsErrorAtom,
   analyticsGasFiltersAtom,
@@ -100,6 +102,8 @@ export function useAnalytics(): UseAnalyticsReturn {
   const durationFilter = useAtomValue(analyticsDurationFilterAtom);
   const search = useAtomValue(analyticsSearchAtom);
   const projectId = useAtomValue(analyticsProjectIdAtom);
+  const customStart = useAtomValue(analyticsCustomStartAtom);
+  const customEnd = useAtomValue(analyticsCustomEndAtom);
   const [loading, setLoading] = useAtom(analyticsLoadingAtom);
   const [error, setError] = useAtom(analyticsErrorAtom);
 
@@ -126,7 +130,12 @@ export function useAnalytics(): UseAnalyticsReturn {
     setLoading(true);
     setError(null);
 
-    const baseQuery = buildQuery({ range, projectId: projectId ?? undefined });
+    const baseQuery = buildQuery({
+      range,
+      projectId: projectId ?? undefined,
+      customStart: customStart ?? undefined,
+      customEnd: customEnd ?? undefined,
+    });
     const filters = {
       range,
       statuses: statusFilters,
@@ -136,6 +145,8 @@ export function useAnalytics(): UseAnalyticsReturn {
       duration: durationFilter,
       search,
       projectId,
+      customStart,
+      customEnd,
     };
     const runsQuery = buildRunsQuery(filters);
     // The status counts sit under every filter except status itself, so the
@@ -259,6 +270,8 @@ export function useAnalytics(): UseAnalyticsReturn {
     durationFilter,
     search,
     projectId,
+    customStart,
+    customEnd,
     setLoading,
     setError,
     setSummary,
@@ -295,7 +308,12 @@ export function useAnalytics(): UseAnalyticsReturn {
   const startSSE = useCallback((): void => {
     cleanupSSE();
 
-    const query = buildQuery({ range, projectId: projectId ?? undefined });
+    const query = buildQuery({
+      range,
+      projectId: projectId ?? undefined,
+      customStart: customStart ?? undefined,
+      customEnd: customEnd ?? undefined,
+    });
     const source = new EventSource(`/api/analytics/stream?${query}`);
 
     source.onmessage = (event: MessageEvent): void => {
@@ -327,6 +345,8 @@ export function useAnalytics(): UseAnalyticsReturn {
   }, [
     range,
     projectId,
+    customStart,
+    customEnd,
     cleanupSSE,
     setSummary,
     setLastUpdated,

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
+import { DayPicker } from "react-day-picker";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Calendar surface for the app. Every class here comes from the design tokens
+ * rather than react-day-picker's own stylesheet, so a day cell rounds, hovers
+ * and highlights exactly like a row in any other popover: `rounded-md` for the
+ * control radius, `bg-accent` for hover, `bg-primary` for the chosen day.
+ */
+export function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: ComponentProps<typeof DayPicker>): ReactNode {
+  return (
+    <DayPicker
+      className={cn("p-3", className)}
+      classNames={{
+        months: "relative flex flex-col gap-4 sm:flex-row",
+        month: "flex flex-col gap-4",
+        month_caption: "flex h-7 items-center justify-center",
+        caption_label: "font-medium text-sm",
+        nav: "flex items-center gap-1",
+        button_previous: cn(
+          buttonVariants({ variant: "ghost" }),
+          "absolute left-3 size-7 p-0 opacity-60 hover:opacity-100"
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "ghost" }),
+          "absolute right-3 size-7 p-0 opacity-60 hover:opacity-100"
+        ),
+        month_grid: "w-full border-collapse space-y-1",
+        weekdays: "flex",
+        weekday:
+          "w-8 rounded-md font-normal text-[0.7rem] text-muted-foreground",
+        week: "mt-1 flex w-full",
+        day: cn(
+          "relative p-0 text-center text-sm",
+          // The middle of a range paints the whole cell, so the days have to
+          // sit flush; only the ends keep the control radius.
+          "[&:has([aria-selected])]:bg-accent",
+          "[&:has([aria-selected].day-range-end)]:rounded-r-md",
+          "[&:has([aria-selected].day-range-start)]:rounded-l-md",
+          "first:[&:has([aria-selected])]:rounded-l-md",
+          "last:[&:has([aria-selected])]:rounded-r-md"
+        ),
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-8 p-0 font-normal aria-selected:opacity-100"
+        ),
+        range_start: "day-range-start",
+        range_end: "day-range-end",
+        selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        today: "bg-accent text-accent-foreground",
+        outside: "text-muted-foreground/60 aria-selected:text-muted-foreground",
+        disabled: "text-muted-foreground opacity-50",
+        hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation }) =>
+          orientation === "left" ? (
+            <ChevronLeft className="size-4" />
+          ) : (
+            <ChevronRight className="size-4" />
+          ),
+      }}
+      showOutsideDays={showOutsideDays}
+      {...props}
+    />
+  );
+}

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -24,16 +24,20 @@ export function Calendar({
       classNames={{
         months: "relative flex flex-col gap-4 sm:flex-row",
         month: "flex flex-col gap-4",
-        month_caption: "flex h-7 items-center justify-center",
+        month_caption: "flex h-7 items-center justify-center px-8",
         caption_label: "font-medium text-sm",
-        nav: "flex items-center gap-1",
+        // The nav is one element for the whole grid, so it spans the months
+        // and pins to their top edge. Positioning the buttons individually let
+        // them fall to wherever the nav happened to flow, which was on top of
+        // the first week's dates.
+        nav: "absolute inset-x-0 top-0 flex items-center justify-between",
         button_previous: cn(
           buttonVariants({ variant: "ghost" }),
-          "absolute left-3 size-7 p-0 opacity-60 hover:opacity-100"
+          "size-7 p-0 opacity-60 hover:opacity-100"
         ),
         button_next: cn(
           buttonVariants({ variant: "ghost" }),
-          "absolute right-3 size-7 p-0 opacity-60 hover:opacity-100"
+          "size-7 p-0 opacity-60 hover:opacity-100"
         ),
         month_grid: "w-full border-collapse space-y-1",
         weekdays: "flex",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -44,28 +44,21 @@ export function Calendar({
         weekday:
           "w-8 rounded-md font-normal text-[0.7rem] text-muted-foreground",
         week: "mt-1 flex w-full",
-        day: cn(
-          "relative p-0 text-center text-sm",
-          // The middle of a range paints the whole cell, so the days have to
-          // sit flush; only the ends keep the control radius.
-          "[&:has([aria-selected])]:bg-accent",
-          "[&:has([aria-selected].day-range-end)]:rounded-r-md",
-          "[&:has([aria-selected].day-range-start)]:rounded-l-md",
-          "first:[&:has([aria-selected])]:rounded-l-md",
-          "last:[&:has([aria-selected])]:rounded-r-md"
-        ),
-        day_button: cn(
-          buttonVariants({ variant: "ghost" }),
-          "size-8 p-0 font-normal aria-selected:opacity-100"
-        ),
-        range_start: "day-range-start",
-        range_end: "day-range-end",
+        // v10 puts these modifier classes on the day cell, not on its button.
+        // So the cell carries the band and the button carries the pill: the
+        // ends round because the button rounds, and the middle stays flat so a
+        // run of days reads as one continuous band rather than separate chips.
+        day: "relative p-0 text-center text-sm",
+        day_button:
+          "size-8 rounded-md p-0 font-normal transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "[&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:hover:bg-primary [&>button]:hover:text-primary-foreground",
+        range_start: "rounded-l-md",
+        range_end: "rounded-r-md",
         range_middle:
-          "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        today: "bg-accent text-accent-foreground",
-        outside: "text-muted-foreground/60 aria-selected:text-muted-foreground",
+          "bg-accent [&>button]:bg-transparent [&>button]:text-accent-foreground [&>button]:hover:bg-transparent",
+        today: "[&>button]:ring-1 [&>button]:ring-primary",
+        outside: "text-muted-foreground/60",
         disabled: "text-muted-foreground opacity-50",
         hidden: "invisible",
         ...classNames,

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { CheckIcon } from "lucide-react"
+import { CheckIcon, MinusIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "group peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground dark:data-[state=indeterminate]:bg-primary data-[state=indeterminate]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}
@@ -23,7 +23,8 @@ function Checkbox({
         data-slot="checkbox-indicator"
         className="grid place-content-center text-current transition-none"
       >
-        <CheckIcon className="size-3.5" />
+        <CheckIcon className="size-3.5 group-data-[state=indeterminate]:hidden" />
+        <MinusIcon className="hidden size-3.5 group-data-[state=indeterminate]:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/components/workflow/config/chain-select-field.tsx
+++ b/components/workflow/config/chain-select-field.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { sortChainsByName } from "@/lib/chains/sort-chains";
 import type { ActionConfigFieldBase } from "@/plugins/registry";
 
 type Chain = {
@@ -156,9 +157,16 @@ export function ChainSelectField({
     );
   }
 
-  // Group chains by testnet status for better UX
-  const mainnets = chains.filter((chain) => !chain.isTestnet);
-  const testnets = chains.filter((chain) => chain.isTestnet);
+  // Grouped by testnet status, each group alphabetical. The analytics network
+  // filter sorts through the same comparator so the two lists agree.
+  const mainnets = sortChainsByName(
+    chains.filter((chain) => !chain.isTestnet),
+    (chain) => chain.name
+  );
+  const testnets = sortChainsByName(
+    chains.filter((chain) => chain.isTestnet),
+    (chain) => chain.name
+  );
 
   function onSelectChain(selectValue: string): void {
     const isPrivateVariant = selectValue.endsWith(PRIVATE_SUFFIX);

--- a/lib/analytics/date-range-selection.ts
+++ b/lib/analytics/date-range-selection.ts
@@ -1,0 +1,41 @@
+/**
+ * The state machine behind picking a date range, kept out of the component so
+ * it can be tested directly. Two clicks make a range: the first names a start,
+ * the second closes it. A click on an already-closed range starts over.
+ *
+ * This is deliberately not react-day-picker's own range accumulation. Handed a
+ * committed range as its current value, that reads the next click as closing
+ * the existing range and reports both ends at once, which made the picker apply
+ * and dismiss on every single click.
+ */
+export type RangeStep =
+  | { kind: "start"; from: Date }
+  | { kind: "complete"; from: Date; to: Date };
+
+export type RangeDraft = { from?: Date; to?: Date } | undefined;
+
+export function startOfDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+/** Inclusive end: the last instant of the day, so that day is in the window. */
+export function endOfDay(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(23, 59, 59, 999);
+  return copy;
+}
+
+export function nextRangeStep(draft: RangeDraft, day: Date): RangeStep {
+  // Nothing started, or the last range is already closed: begin a new one.
+  if (!draft?.from || draft.to) {
+    return { kind: "start", from: day };
+  }
+  // Clicking before the start reads as picking the other end, not as a
+  // backwards range, so the two swap rather than producing an empty window.
+  const backwards = day.getTime() < draft.from.getTime();
+  const from = backwards ? day : draft.from;
+  const to = backwards ? draft.from : day;
+  return { kind: "complete", from: startOfDay(from), to: endOfDay(to) };
+}

--- a/lib/analytics/duration-presets.ts
+++ b/lib/analytics/duration-presets.ts
@@ -1,0 +1,28 @@
+/**
+ * Duration buckets offered by the runs filter. Bounds are milliseconds, min
+ * inclusive and max exclusive, so consecutive presets never both match a run.
+ */
+export type DurationPresetId = "under5s" | "5sTo30s" | "over30s" | "over2m";
+
+export type DurationPreset = {
+  id: DurationPresetId;
+  label: string;
+  minMs?: number;
+  maxMs?: number;
+};
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+
+export const DURATION_PRESETS: DurationPreset[] = [
+  { id: "under5s", label: "Under 5s", maxMs: 5 * SECOND },
+  { id: "5sTo30s", label: "5s to 30s", minMs: 5 * SECOND, maxMs: 30 * SECOND },
+  { id: "over30s", label: "Over 30s", minMs: 30 * SECOND },
+  { id: "over2m", label: "Over 2m", minMs: 2 * MINUTE },
+];
+
+export function durationPreset(
+  id: DurationPresetId | null
+): DurationPreset | undefined {
+  return DURATION_PRESETS.find((preset) => preset.id === id);
+}

--- a/lib/analytics/parse-run-filters.ts
+++ b/lib/analytics/parse-run-filters.ts
@@ -1,4 +1,9 @@
-import type { NormalizedStatus, RunQueryFilters, RunSource } from "./types";
+import type {
+  GasSpend,
+  NormalizedStatus,
+  RunQueryFilters,
+  RunSource,
+} from "./types";
 
 const VALID_STATUSES = new Set<NormalizedStatus>([
   "pending",
@@ -12,6 +17,8 @@ const VALID_STATUSES = new Set<NormalizedStatus>([
 ]);
 
 const VALID_SOURCES = new Set<RunSource>(["workflow", "direct"]);
+
+const VALID_GAS = new Set<GasSpend>(["paid", "free"]);
 
 // A search long enough to be a run id is as long as a search ever needs to be,
 // and the cap keeps an ILIKE pattern from being handed an arbitrary payload.
@@ -42,12 +49,16 @@ export function parseRunFilters(params: URLSearchParams): RunQueryFilters {
       VALID_SOURCES.has(value as RunSource)
     );
   const networks = params.getAll("network").filter((value) => value.length > 0);
+  const gas = params
+    .getAll("gas")
+    .filter((value): value is GasSpend => VALID_GAS.has(value as GasSpend));
   const search = params.get("search")?.trim().slice(0, MAX_SEARCH_LENGTH);
 
   return {
     ...(statuses.length > 0 ? { statuses: [...new Set(statuses)] } : {}),
     ...(sources.length > 0 ? { sources: [...new Set(sources)] } : {}),
     ...(networks.length > 0 ? { networks: [...new Set(networks)] } : {}),
+    ...(gas.length > 0 ? { gas: [...new Set(gas)] } : {}),
     ...(parseNonNegativeInt(params.get("durationMin")) === undefined
       ? {}
       : { durationMinMs: parseNonNegativeInt(params.get("durationMin")) }),

--- a/lib/analytics/parse-run-filters.ts
+++ b/lib/analytics/parse-run-filters.ts
@@ -18,7 +18,7 @@ const VALID_STATUSES = new Set<NormalizedStatus>([
 
 const VALID_SOURCES = new Set<RunSource>(["workflow", "direct"]);
 
-const VALID_GAS = new Set<GasSpend>(["paid", "free"]);
+const VALID_GAS = new Set<GasSpend>(["sponsored", "wallet", "free"]);
 
 // A search long enough to be a run id is as long as a search ever needs to be,
 // and the cap keeps an ILIKE pattern from being handed an arbitrary payload.

--- a/lib/analytics/parse-run-filters.ts
+++ b/lib/analytics/parse-run-filters.ts
@@ -1,0 +1,59 @@
+import type { NormalizedStatus, RunQueryFilters, RunSource } from "./types";
+
+const VALID_STATUSES = new Set<NormalizedStatus>([
+  "pending",
+  "running",
+  "success",
+  "error",
+  "system_error",
+  "external_error",
+  "skipped",
+  "cancelled",
+]);
+
+const VALID_SOURCES = new Set<RunSource>(["workflow", "direct"]);
+
+// A search long enough to be a run id is as long as a search ever needs to be,
+// and the cap keeps an ILIKE pattern from being handed an arbitrary payload.
+const MAX_SEARCH_LENGTH = 128;
+
+function parseNonNegativeInt(raw: string | null): number | undefined {
+  if (raw === null) {
+    return undefined;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : undefined;
+}
+
+/**
+ * Read the run filters off a request's query string. Every dimension is
+ * repeatable (`?status=error&status=system_error`), so a single value still
+ * parses the way it always did.
+ */
+export function parseRunFilters(params: URLSearchParams): RunQueryFilters {
+  const statuses = params
+    .getAll("status")
+    .filter((value): value is NormalizedStatus =>
+      VALID_STATUSES.has(value as NormalizedStatus)
+    );
+  const sources = params
+    .getAll("source")
+    .filter((value): value is RunSource =>
+      VALID_SOURCES.has(value as RunSource)
+    );
+  const networks = params.getAll("network").filter((value) => value.length > 0);
+  const search = params.get("search")?.trim().slice(0, MAX_SEARCH_LENGTH);
+
+  return {
+    ...(statuses.length > 0 ? { statuses: [...new Set(statuses)] } : {}),
+    ...(sources.length > 0 ? { sources: [...new Set(sources)] } : {}),
+    ...(networks.length > 0 ? { networks: [...new Set(networks)] } : {}),
+    ...(parseNonNegativeInt(params.get("durationMin")) === undefined
+      ? {}
+      : { durationMinMs: parseNonNegativeInt(params.get("durationMin")) }),
+    ...(parseNonNegativeInt(params.get("durationMax")) === undefined
+      ? {}
+      : { durationMaxMs: parseNonNegativeInt(params.get("durationMax")) }),
+    ...(search ? { search } : {}),
+  };
+}

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -45,6 +45,7 @@ import {
 } from "./time-range";
 import type {
   AnalyticsSummary,
+  GasSpend,
   NetworkBreakdown,
   NormalizedStatus,
   RunQueryFilters,
@@ -226,6 +227,49 @@ function directSearchCondition(term: string): SQL {
 const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
 
 /**
+ * Did this run spend gas? Reads the same two sources the Gas column renders
+ * from: the per-step rollup (which covers every transaction the run made) and
+ * the sponsorship ledger (which covers a leg KeeperHub paid for). A run counts
+ * as paid if either says so, so a sponsored run is not filed as free.
+ */
+function workflowPaidCondition(): SQL {
+  return sql`(
+    EXISTS (
+      SELECT 1
+        FROM ${workflowExecutionLogs}
+       WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+         AND COALESCE(
+               ${workflowExecutionLogs.gasUsedWei},
+               CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
+             ) > 0
+    )
+    OR EXISTS (
+      SELECT 1
+        FROM ${gasCreditUsage}
+       WHERE ${gasCreditUsage.executionId} = ${workflowExecutions.id}
+         AND CAST(${gasCreditUsage.gasCostWei} AS NUMERIC) > 0
+    )
+  )`;
+}
+
+/**
+ * Both values selected is the same as neither, so the predicate is only built
+ * when exactly one side is asked for.
+ */
+function gasCondition(gas: GasSpend[], paid: SQL): SQL | undefined {
+  const wanted = new Set(gas);
+  if (wanted.size !== 1) {
+    return undefined;
+  }
+  return wanted.has("paid") ? paid : sql`NOT ${paid}`;
+}
+
+const directPaidCondition = sql`(
+  ${directExecutions.gasUsedWei} IS NOT NULL
+  AND CAST(NULLIF(${directExecutions.gasUsedWei}, '') AS NUMERIC) > 0
+)`;
+
+/**
  * Every workflow-side predicate for a set of filters. `skipStatuses` lifts the
  * status dimension for the facet counts, which have to count what each status
  * would add rather than what the current status selection already shows.
@@ -257,6 +301,10 @@ function workflowFilterConditions(
   if (search) {
     conditions.push(workflowSearchCondition(search));
   }
+  const gas = gasCondition(filters.gas ?? [], workflowPaidCondition());
+  if (gas) {
+    conditions.push(gas);
+  }
   return conditions;
 }
 
@@ -287,6 +335,10 @@ function directFilterConditions(
   const search = filters.search?.trim();
   if (search) {
     conditions.push(directSearchCondition(search));
+  }
+  const gas = gasCondition(filters.gas ?? [], directPaidCondition);
+  if (gas) {
+    conditions.push(gas);
   }
   return conditions;
 }
@@ -1496,6 +1548,7 @@ function hasFilters(filters: RunQueryFilters): boolean {
       (filters.networks?.length ?? 0) > 0 ||
       filters.durationMinMs !== undefined ||
       filters.durationMaxMs !== undefined ||
+      (filters.gas?.length ?? 0) > 0 ||
       filters.search?.trim()
   );
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -47,7 +47,9 @@ import type {
   AnalyticsSummary,
   NetworkBreakdown,
   NormalizedStatus,
+  RunQueryFilters,
   RunSource,
+  StatusFacets,
   StepLog,
   TimeRange,
   TimeSeriesBucket,
@@ -150,6 +152,158 @@ function workflowStatusCondition(status: NormalizedStatus): SQL {
     return sql`${inClause} AND ${workflowExecutions.errorType} IS DISTINCT FROM ${ExecutionErrorType.EXTERNAL}`;
   }
   return inClause;
+}
+
+/**
+ * OR the per-status predicates together. A status filter holding several values
+ * is a union, which is the whole point of the multi-select: "Errors" ticks
+ * error, external_error and system_error and asks for all three at once.
+ */
+function workflowStatusesCondition(statuses: NormalizedStatus[]): SQL {
+  return sql`(${sql.join(
+    statuses.map((status) => workflowStatusCondition(status)),
+    sql` OR `
+  )})`;
+}
+
+/**
+ * direct_executions carries no error_type, so it has no external or system
+ * failures and no refused runs. Those statuses map to values the column never
+ * holds, which is correct: selecting only them returns no direct runs.
+ */
+function directStatusesCondition(statuses: NormalizedStatus[]): SQL {
+  const dbStatuses = [...new Set(statuses.flatMap(directDbStatuses))];
+  return sql`${directExecutions.status} IN (${sql.join(
+    dbStatuses.map((status) => sql`${status}`),
+    sql`, `
+  )})`;
+}
+
+/**
+ * A workflow run has no chain of its own: its chains live on its step logs, the
+ * same COALESCE(column, JSONB) the listing reads them through. EXISTS keeps a
+ * run that touched any selected chain without multiplying it per matching step.
+ */
+function workflowNetworkCondition(networks: string[]): SQL {
+  return sql`EXISTS (
+    SELECT 1
+      FROM ${workflowExecutionLogs}
+     WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+       AND COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")}) IN (${sql.join(
+         networks.map((network) => sql`${network}`),
+         sql`, `
+       )})
+  )`;
+}
+
+// The name match gets its own alias because both callers already have
+// `workflows` in scope, one through a join and one through a scoping subquery.
+function workflowSearchCondition(term: string): SQL {
+  const pattern = `%${term}%`;
+  return sql`(
+    ${workflowExecutions.id} ILIKE ${pattern}
+    OR EXISTS (
+      SELECT 1
+        FROM ${workflows} AS search_wf
+       WHERE search_wf.id = ${workflowExecutions.workflowId}
+         AND search_wf.name ILIKE ${pattern}
+    )
+  )`;
+}
+
+function directSearchCondition(term: string): SQL {
+  const pattern = `%${term}%`;
+  return sql`(
+    ${directExecutions.id} ILIKE ${pattern}
+    OR ${directExecutions.type} ILIKE ${pattern}
+    OR ${directExecutions.network} ILIKE ${pattern}
+  )`;
+}
+
+// Duration in milliseconds. A run still in flight has no duration, and a NULL
+// comparison is false, so a duration filter drops it - which is what a reader
+// asking for "runs over 30s" means.
+const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
+
+/**
+ * Every workflow-side predicate for a set of filters. `skipStatuses` lifts the
+ * status dimension for the facet counts, which have to count what each status
+ * would add rather than what the current status selection already shows.
+ */
+function workflowFilterConditions(
+  filters: RunQueryFilters,
+  skipStatuses = false
+): SQL[] {
+  const conditions: SQL[] = [];
+  const statuses = filters.statuses ?? [];
+  if (!skipStatuses && statuses.length > 0) {
+    conditions.push(workflowStatusesCondition(statuses));
+  }
+  const networks = filters.networks ?? [];
+  if (networks.length > 0) {
+    conditions.push(workflowNetworkCondition(networks));
+  }
+  if (filters.durationMinMs !== undefined) {
+    conditions.push(
+      sql`${workflowExecutions.duration} >= ${filters.durationMinMs}`
+    );
+  }
+  if (filters.durationMaxMs !== undefined) {
+    conditions.push(
+      sql`${workflowExecutions.duration} < ${filters.durationMaxMs}`
+    );
+  }
+  const search = filters.search?.trim();
+  if (search) {
+    conditions.push(workflowSearchCondition(search));
+  }
+  return conditions;
+}
+
+function directFilterConditions(
+  filters: RunQueryFilters,
+  skipStatuses = false
+): SQL[] {
+  const conditions: SQL[] = [];
+  const statuses = filters.statuses ?? [];
+  if (!skipStatuses && statuses.length > 0) {
+    conditions.push(directStatusesCondition(statuses));
+  }
+  const networks = filters.networks ?? [];
+  if (networks.length > 0) {
+    conditions.push(
+      sql`${directExecutions.network} IN (${sql.join(
+        networks.map((network) => sql`${network}`),
+        sql`, `
+      )})`
+    );
+  }
+  if (filters.durationMinMs !== undefined) {
+    conditions.push(sql`${directDurationMs} >= ${filters.durationMinMs}`);
+  }
+  if (filters.durationMaxMs !== undefined) {
+    conditions.push(sql`${directDurationMs} < ${filters.durationMaxMs}`);
+  }
+  const search = filters.search?.trim();
+  if (search) {
+    conditions.push(directSearchCondition(search));
+  }
+  return conditions;
+}
+
+/** Whether each source is in play, given the source filter and project scope. */
+function resolveSources(
+  sources: RunSource[] | undefined,
+  projectId: string | undefined
+): { workflow: boolean; direct: boolean } {
+  const selected = sources ?? [];
+  const all = selected.length === 0;
+  return {
+    workflow: all || selected.includes("workflow"),
+    // A project scopes to its workflows, and a direct execution belongs to no
+    // workflow, so no direct run can be in a project.
+    direct: (all || selected.includes("direct")) && !projectId,
+  };
 }
 
 /**
@@ -876,12 +1030,10 @@ async function computeNetworkBreakdown(
 export async function getUnifiedRuns(
   organizationId: string,
   range: TimeRange,
-  options: {
+  options: RunQueryFilters & {
     cursor?: string;
     page?: number;
     limit?: number;
-    status?: NormalizedStatus;
-    source?: RunSource;
     customStart?: string;
     customEnd?: string;
     projectId?: string;
@@ -897,16 +1049,15 @@ export async function getUnifiedRuns(
     cursor,
     page = 1,
     limit = 50,
-    status,
-    source,
     customStart,
     customEnd,
     projectId,
+    ...filters
   } = options;
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const pageLimit = Math.min(limit, 100);
-  const skipDirect = Boolean(projectId) || source === "direct";
+  const wanted = resolveSources(filters.sources, projectId);
   const offset = cursor ? 0 : (page - 1) * pageLimit;
 
   // Fetch enough rows from each source to fill the requested page after merging.
@@ -916,33 +1067,32 @@ export async function getUnifiedRuns(
 
   // Fire run fetches and count queries in parallel
   const [workflowRuns, directRuns, total] = await Promise.all([
-    source === "direct"
-      ? ([] as UnifiedRun[])
-      : fetchWorkflowRuns(
+    wanted.workflow
+      ? fetchWorkflowRuns(
           organizationId,
           rangeStart,
           rangeEnd,
-          status,
+          filters,
           cursor,
           fetchLimit,
           projectId
-        ),
-    skipDirect || source === "workflow"
-      ? ([] as UnifiedRun[])
-      : fetchDirectRuns(
+        )
+      : ([] as UnifiedRun[]),
+    wanted.direct
+      ? fetchDirectRuns(
           organizationId,
           rangeStart,
           rangeEnd,
-          status,
+          filters,
           cursor,
           fetchLimit
-        ),
+        )
+      : ([] as UnifiedRun[]),
     getUnifiedRunsTotal(
       organizationId,
       rangeStart,
       rangeEnd,
-      status,
-      source,
+      filters,
       projectId
     ),
   ]);
@@ -965,7 +1115,7 @@ async function fetchWorkflowRuns(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined,
+  filters: RunQueryFilters,
   cursor: string | undefined,
   limit: number,
   projectId?: string
@@ -990,9 +1140,7 @@ async function fetchWorkflowRuns(
     isNull(workflowExecutions.deletedAt),
   ];
 
-  if (status) {
-    conditions.push(workflowStatusCondition(status));
-  }
+  conditions.push(...workflowFilterConditions(filters));
 
   if (cursor) {
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
@@ -1168,7 +1316,7 @@ async function fetchDirectRuns(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined,
+  filters: RunQueryFilters,
   cursor: string | undefined,
   limit: number
 ): Promise<UnifiedRun[]> {
@@ -1176,17 +1324,8 @@ async function fetchDirectRuns(
     eq(directExecutions.organizationId, organizationId),
     gte(directExecutions.createdAt, rangeStart),
     lt(directExecutions.createdAt, rangeEnd),
+    ...directFilterConditions(filters),
   ];
-
-  if (status) {
-    const dbStatuses = directDbStatuses(status);
-    conditions.push(
-      sql`${directExecutions.status} IN (${sql.join(
-        dbStatuses.map((s) => sql`${s}`),
-        sql`, `
-      )})`
-    );
-  }
 
   if (cursor) {
     conditions.push(lt(directExecutions.createdAt, new Date(cursor)));
@@ -1254,7 +1393,7 @@ async function getWorkflowRunsTotal(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined,
+  filters: RunQueryFilters,
   projectId?: string
 ): Promise<number> {
   const conditions = [
@@ -1268,9 +1407,7 @@ async function getWorkflowRunsTotal(
   if (projectId) {
     conditions.push(eq(workflows.projectId, projectId));
   }
-  if (status) {
-    conditions.push(workflowStatusCondition(status));
-  }
+  conditions.push(...workflowFilterConditions(filters));
   const result = await db
     .select({ count: count() })
     .from(workflowExecutions)
@@ -1283,22 +1420,14 @@ async function getDirectRunsTotal(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined
+  filters: RunQueryFilters
 ): Promise<number> {
   const conditions = [
     eq(directExecutions.organizationId, organizationId),
     gte(directExecutions.createdAt, rangeStart),
     lt(directExecutions.createdAt, rangeEnd),
+    ...directFilterConditions(filters),
   ];
-  if (status) {
-    const dbStatuses = directDbStatuses(status);
-    conditions.push(
-      sql`${directExecutions.status} IN (${sql.join(
-        dbStatuses.map((s) => sql`${s}`),
-        sql`, `
-      )})`
-    );
-  }
   const result = await db
     .select({ count: count() })
     .from(directExecutions)
@@ -1306,30 +1435,150 @@ async function getDirectRunsTotal(
   return Number(result[0]?.count) || 0;
 }
 
+/**
+ * The normalized status of a workflow row, expressed in SQL. Mirrors
+ * normalizeStatus so a grouped count and a listed row never disagree about
+ * which bucket a run belongs to.
+ */
+const workflowNormalizedStatus = sql<string>`CASE
+  WHEN ${workflowExecutions.status} = 'error'
+   AND ${workflowExecutions.errorType} = ${ExecutionErrorType.EXTERNAL} THEN 'external_error'
+  WHEN ${workflowExecutions.status} = 'phantom' THEN 'pending'
+  WHEN ${workflowExecutions.status} = 'unconfirmed' THEN 'running'
+  ELSE ${workflowExecutions.status}
+END`;
+
+const directNormalizedStatus = sql<string>`CASE
+  WHEN ${directExecutions.status} = 'completed' THEN 'success'
+  WHEN ${directExecutions.status} = 'failed' THEN 'error'
+  WHEN ${directExecutions.status} = 'unconfirmed' THEN 'running'
+  ELSE ${directExecutions.status}
+END`;
+
+/**
+ * Run counts per normalized status, for the counts beside each option in the
+ * status filter. Every other filter applies; the status filter itself does not,
+ * so a count says how many runs ticking that status would bring in.
+ */
+export function getStatusFacets(
+  organizationId: string,
+  range: TimeRange,
+  options: RunQueryFilters & {
+    customStart?: string;
+    customEnd?: string;
+    projectId?: string;
+  } = {}
+): Promise<StatusFacets> {
+  const { customStart, customEnd, projectId, ...filters } = options;
+  const compute = () =>
+    computeStatusFacets(
+      organizationId,
+      range,
+      filters,
+      customStart,
+      customEnd,
+      projectId
+    );
+  // Only the unfiltered facets are hot enough to cache; a filtered combination
+  // is effectively single-use and would grow the key space for no hit rate.
+  if (!isCacheableRange(range, customStart, customEnd) || hasFilters(filters)) {
+    return compute();
+  }
+  return cachedAnalytics(
+    analyticsCacheKey("facets", [organizationId, range, projectId]),
+    compute
+  );
+}
+
+function hasFilters(filters: RunQueryFilters): boolean {
+  return Boolean(
+    (filters.sources?.length ?? 0) > 0 ||
+      (filters.networks?.length ?? 0) > 0 ||
+      filters.durationMinMs !== undefined ||
+      filters.durationMaxMs !== undefined ||
+      filters.search?.trim()
+  );
+}
+
+async function computeStatusFacets(
+  organizationId: string,
+  range: TimeRange,
+  filters: RunQueryFilters,
+  customStart?: string,
+  customEnd?: string,
+  projectId?: string
+): Promise<StatusFacets> {
+  const rangeStart = getTimeRangeStart(range, customStart);
+  const rangeEnd = customEnd ? new Date(customEnd) : new Date();
+  const wanted = resolveSources(filters.sources, projectId);
+
+  const workflowRows = wanted.workflow
+    ? await db
+        .select({ status: workflowNormalizedStatus, value: count() })
+        .from(workflowExecutions)
+        .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+        .where(
+          and(
+            eq(workflows.organizationId, organizationId),
+            projectId ? eq(workflows.projectId, projectId) : undefined,
+            gte(workflowExecutions.startedAt, rangeStart),
+            lt(workflowExecutions.startedAt, rangeEnd),
+            isNull(workflowExecutions.deletedAt),
+            ...workflowFilterConditions(filters, true)
+          )
+        )
+        // Group by the select ordinal: the CASE carries a bound parameter, and
+        // repeating the expression here would bind a second placeholder that
+        // Postgres does not recognise as the same expression.
+        .groupBy(sql`1`)
+    : [];
+
+  const directRows = wanted.direct
+    ? await db
+        .select({ status: directNormalizedStatus, value: count() })
+        .from(directExecutions)
+        .where(
+          and(
+            eq(directExecutions.organizationId, organizationId),
+            gte(directExecutions.createdAt, rangeStart),
+            lt(directExecutions.createdAt, rangeEnd),
+            ...directFilterConditions(filters, true)
+          )
+        )
+        .groupBy(sql`1`)
+    : [];
+
+  const facets: StatusFacets = {};
+  for (const row of [...workflowRows, ...directRows]) {
+    const status = row.status as NormalizedStatus;
+    facets[status] = (facets[status] ?? 0) + (Number(row.value) || 0);
+  }
+  return facets;
+}
+
 async function getUnifiedRunsTotal(
   organizationId: string,
   rangeStart: Date,
   rangeEnd: Date,
-  status: NormalizedStatus | undefined,
-  source: RunSource | undefined,
+  filters: RunQueryFilters,
   projectId?: string
 ): Promise<number> {
-  const skipDirect = Boolean(projectId);
+  const wanted = resolveSources(filters.sources, projectId);
 
   // Run both count queries in parallel
   const [workflowTotal, directTotal] = await Promise.all([
-    source === "direct"
-      ? 0
-      : getWorkflowRunsTotal(
+    wanted.workflow
+      ? getWorkflowRunsTotal(
           organizationId,
           rangeStart,
           rangeEnd,
-          status,
+          filters,
           projectId
-        ),
-    skipDirect || source === "workflow"
-      ? 0
-      : getDirectRunsTotal(organizationId, rangeStart, rangeEnd, status),
+        )
+      : 0,
+    wanted.direct
+      ? getDirectRunsTotal(organizationId, rangeStart, rangeEnd, filters)
+      : 0,
   ]);
 
   return workflowTotal + directTotal;

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -226,48 +226,98 @@ function directSearchCondition(term: string): SQL {
 // asking for "runs over 30s" means.
 const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
 
+// Wei the run's steps burned, and the slice of it gas credit covered. The step
+// rollup is the total, not the unsponsored remainder, so the wallet's share is
+// the difference rather than the whole.
+const workflowStepGasWei = sql`COALESCE((
+  SELECT SUM(COALESCE(
+           ${workflowExecutionLogs.gasUsedWei},
+           CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
+         ))
+    FROM ${workflowExecutionLogs}
+   WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+), 0)`;
+
+const workflowSponsoredGasWei = sql`COALESCE((
+  SELECT SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC))
+    FROM ${gasCreditUsage}
+   WHERE ${gasCreditUsage.executionId} = ${workflowExecutions.id}
+), 0)`;
+
+// The same marker the sponsored chip on a run reads: a web3 step core writes
+// `sponsored: true` into its output when the gas station covered the gas. Taken
+// alongside the ledger rather than instead of it, so a run is still sponsored
+// if only one of the two recorded it.
+const workflowSponsoredStep = sql`EXISTS (
+  SELECT 1
+    FROM ${workflowExecutionLogs}
+   WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+     AND ${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'
+)`;
+
 /**
- * Did this run spend gas? Reads the same two sources the Gas column renders
- * from: the per-step rollup (which covers every transaction the run made) and
- * the sponsorship ledger (which covers a leg KeeperHub paid for). A run counts
- * as paid if either says so, so a sponsored run is not filed as free.
+ * One predicate per gas category. Sponsored is "gas credit covered a leg";
+ * wallet is "the run burned more than credit covered", which is what makes a
+ * part-sponsored run answer to both.
  */
-function workflowPaidCondition(): SQL {
+function workflowGasCondition(value: GasSpend): SQL {
+  if (value === "sponsored") {
+    return sql`(${workflowSponsoredStep} OR ${workflowSponsoredGasWei} > 0)`;
+  }
+  if (value === "wallet") {
+    // Both signals have to agree there is an unsponsored share: a step that
+    // burned gas without the sponsored marker, and a total the ledger did not
+    // fully cover. Either alone misfiles a run that only one of the two
+    // recorded.
+    return sql`(
+      EXISTS (
+        SELECT 1
+          FROM ${workflowExecutionLogs}
+         WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+           AND COALESCE(
+                 ${workflowExecutionLogs.gasUsedWei},
+                 CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
+               ) > 0
+           AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
+      )
+      AND ${workflowStepGasWei} > ${workflowSponsoredGasWei}
+    )`;
+  }
   return sql`(
-    EXISTS (
-      SELECT 1
-        FROM ${workflowExecutionLogs}
-       WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
-         AND COALESCE(
-               ${workflowExecutionLogs.gasUsedWei},
-               CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
-             ) > 0
-    )
-    OR EXISTS (
-      SELECT 1
-        FROM ${gasCreditUsage}
-       WHERE ${gasCreditUsage.executionId} = ${workflowExecutions.id}
-         AND CAST(${gasCreditUsage.gasCostWei} AS NUMERIC) > 0
-    )
+    ${workflowStepGasWei} = 0
+    AND ${workflowSponsoredGasWei} = 0
+    AND NOT ${workflowSponsoredStep}
   )`;
 }
 
-/**
- * Both values selected is the same as neither, so the predicate is only built
- * when exactly one side is asked for.
- */
-function gasCondition(gas: GasSpend[], paid: SQL): SQL | undefined {
-  const wanted = new Set(gas);
-  if (wanted.size !== 1) {
-    return undefined;
+// A direct execution carries no link into the gas-credit ledger, so its spend
+// can only be read as the wallet's. Selecting "sponsored" therefore returns no
+// direct runs rather than guessing at them.
+function directGasCondition(value: GasSpend): SQL {
+  const spent = sql`(
+    ${directExecutions.gasUsedWei} IS NOT NULL
+    AND CAST(NULLIF(${directExecutions.gasUsedWei}, '') AS NUMERIC) > 0
+  )`;
+  if (value === "wallet") {
+    return spent;
   }
-  return wanted.has("paid") ? paid : sql`NOT ${paid}`;
+  if (value === "free") {
+    return sql`NOT ${spent}`;
+  }
+  return sql`false`;
 }
 
-const directPaidCondition = sql`(
-  ${directExecutions.gasUsedWei} IS NOT NULL
-  AND CAST(NULLIF(${directExecutions.gasUsedWei}, '') AS NUMERIC) > 0
-)`;
+/** The chosen categories OR together, like every other dimension. */
+function gasCondition(
+  gas: GasSpend[],
+  predicate: (value: GasSpend) => SQL
+): SQL | undefined {
+  const wanted = [...new Set(gas)];
+  if (wanted.length === 0 || wanted.length === 3) {
+    return undefined;
+  }
+  return sql`(${sql.join(wanted.map(predicate), sql` OR `)})`;
+}
 
 /**
  * Every workflow-side predicate for a set of filters. `skipStatuses` lifts the
@@ -301,7 +351,7 @@ function workflowFilterConditions(
   if (search) {
     conditions.push(workflowSearchCondition(search));
   }
-  const gas = gasCondition(filters.gas ?? [], workflowPaidCondition());
+  const gas = gasCondition(filters.gas ?? [], workflowGasCondition);
   if (gas) {
     conditions.push(gas);
   }
@@ -336,7 +386,7 @@ function directFilterConditions(
   if (search) {
     conditions.push(directSearchCondition(search));
   }
-  const gas = gasCondition(filters.gas ?? [], directPaidCondition);
+  const gas = gasCondition(filters.gas ?? [], directGasCondition);
   if (gas) {
     conditions.push(gas);
   }

--- a/lib/analytics/runs-query.ts
+++ b/lib/analytics/runs-query.ts
@@ -1,11 +1,12 @@
 import { type DurationPresetId, durationPreset } from "./duration-presets";
-import type { NormalizedStatus, RunSource, TimeRange } from "./types";
+import type { GasSpend, NormalizedStatus, RunSource, TimeRange } from "./types";
 
 export type RunsQueryInput = {
   range: TimeRange;
   statuses?: NormalizedStatus[];
   sources?: RunSource[];
   networks?: string[];
+  gas?: GasSpend[];
   duration?: DurationPresetId | null;
   search?: string;
   projectId?: string | null;
@@ -33,6 +34,9 @@ export function buildRunsQuery(input: RunsQueryInput): string {
   }
   for (const network of input.networks ?? []) {
     params.append("network", network);
+  }
+  for (const value of input.gas ?? []) {
+    params.append("gas", value);
   }
 
   const preset = durationPreset(input.duration ?? null);

--- a/lib/analytics/runs-query.ts
+++ b/lib/analytics/runs-query.ts
@@ -10,6 +10,9 @@ export type RunsQueryInput = {
   duration?: DurationPresetId | null;
   search?: string;
   projectId?: string | null;
+  /** ISO bounds, sent only for the custom range. */
+  customStart?: string | null;
+  customEnd?: string | null;
   page?: number;
   /** Drop the status dimension, for the facet request that counts each status. */
   omitStatus?: boolean;
@@ -53,6 +56,12 @@ export function buildRunsQuery(input: RunsQueryInput): string {
   }
   if (input.projectId) {
     params.set("projectId", input.projectId);
+  }
+  if (input.customStart) {
+    params.set("customStart", input.customStart);
+  }
+  if (input.customEnd) {
+    params.set("customEnd", input.customEnd);
   }
   if (input.page !== undefined && input.page > 1) {
     params.set("page", String(input.page));

--- a/lib/analytics/runs-query.ts
+++ b/lib/analytics/runs-query.ts
@@ -1,0 +1,58 @@
+import { type DurationPresetId, durationPreset } from "./duration-presets";
+import type { NormalizedStatus, RunSource, TimeRange } from "./types";
+
+export type RunsQueryInput = {
+  range: TimeRange;
+  statuses?: NormalizedStatus[];
+  sources?: RunSource[];
+  networks?: string[];
+  duration?: DurationPresetId | null;
+  search?: string;
+  projectId?: string | null;
+  page?: number;
+  /** Drop the status dimension, for the facet request that counts each status. */
+  omitStatus?: boolean;
+};
+
+/**
+ * The query string for the runs listing and its facets. One builder so the
+ * first page, a later page and the counts can never disagree about what is
+ * being filtered.
+ */
+export function buildRunsQuery(input: RunsQueryInput): string {
+  const params = new URLSearchParams();
+  params.set("range", input.range);
+
+  if (!input.omitStatus) {
+    for (const status of input.statuses ?? []) {
+      params.append("status", status);
+    }
+  }
+  for (const source of input.sources ?? []) {
+    params.append("source", source);
+  }
+  for (const network of input.networks ?? []) {
+    params.append("network", network);
+  }
+
+  const preset = durationPreset(input.duration ?? null);
+  if (preset?.minMs !== undefined) {
+    params.set("durationMin", String(preset.minMs));
+  }
+  if (preset?.maxMs !== undefined) {
+    params.set("durationMax", String(preset.maxMs));
+  }
+
+  const search = input.search?.trim();
+  if (search) {
+    params.set("search", search);
+  }
+  if (input.projectId) {
+    params.set("projectId", input.projectId);
+  }
+  if (input.page !== undefined && input.page > 1) {
+    params.set("page", String(input.page));
+  }
+
+  return params.toString();
+}

--- a/lib/analytics/status-display.ts
+++ b/lib/analytics/status-display.ts
@@ -1,0 +1,75 @@
+import type { NormalizedStatus } from "./types";
+
+/**
+ * The one place a run status gets its name and its colour. The runs table, the
+ * status filter and the chart above it all read from here, so a colour a reader
+ * learns in one of them means the same thing in the other two.
+ *
+ * `chartColor` is a CSS value because recharts takes a fill, not a class; it is
+ * the same hue as `dot` so the band and the swatch match.
+ */
+export type StatusDisplay = {
+  label: string;
+  /** Swatch class for the filter list. */
+  dot: string;
+  /** Badge classes for a run row. */
+  badge: string;
+  chartColor: string;
+};
+
+export const STATUS_DISPLAY: Record<NormalizedStatus, StatusDisplay> = {
+  success: {
+    label: "Success",
+    dot: "bg-green-500",
+    badge:
+      "bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20",
+    chartColor: "var(--color-green-500)",
+  },
+  error: {
+    label: "Error",
+    dot: "bg-red-500",
+    badge: "bg-red-500/10 text-red-700 dark:text-red-400 border-red-500/20",
+    chartColor: "var(--color-red-500)",
+  },
+  external_error: {
+    label: "External",
+    dot: "bg-purple-500",
+    badge:
+      "bg-purple-500/10 text-purple-700 dark:text-purple-400 border-purple-500/20",
+    chartColor: "var(--color-purple-500)",
+  },
+  system_error: {
+    label: "System Error",
+    dot: "bg-amber-500",
+    badge:
+      "bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20",
+    chartColor: "var(--color-amber-500)",
+  },
+  cancelled: {
+    label: "Cancelled",
+    dot: "bg-orange-500",
+    badge:
+      "bg-orange-500/10 text-orange-700 dark:text-orange-400 border-orange-500/20",
+    chartColor: "var(--color-orange-500)",
+  },
+  // Refused before it started: neutral everywhere, so it never reads as a
+  // failure, in a badge or as a band on the chart.
+  skipped: {
+    label: "Skipped",
+    dot: "bg-muted-foreground",
+    badge: "bg-muted text-muted-foreground border-border",
+    chartColor: "var(--color-muted-foreground)",
+  },
+  running: {
+    label: "Running",
+    dot: "bg-blue-500",
+    badge: "bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20",
+    chartColor: "var(--color-blue-500)",
+  },
+  pending: {
+    label: "Pending",
+    dot: "bg-gray-500",
+    badge: "bg-gray-500/10 text-gray-700 dark:text-gray-400 border-gray-500/20",
+    chartColor: "var(--color-gray-500)",
+  },
+};

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -142,11 +142,16 @@ export type NetworkBreakdown = {
  * dimensions AND together.
  */
 /**
- * Whether a run spent gas. "paid" is a run that put native currency on chain,
- * whether the org's wallet or KeeperHub's gas credit covered it; "free" is a
- * run that only read, or never reached a broadcast.
+ * How a run's on-chain cost was met. "sponsored" is a run with a leg KeeperHub
+ * covered from gas credit; "wallet" is a run that spent more than the credit
+ * covered, so the org's own funds paid for part of it; "free" is a run that
+ * only read, or never reached a broadcast.
+ *
+ * Sponsored and wallet deliberately overlap. A run that starts sponsored and
+ * falls back to direct signing genuinely is both, and filing it under only one
+ * would hide it from the other filter.
  */
-export type GasSpend = "paid" | "free";
+export type GasSpend = "sponsored" | "wallet" | "free";
 
 export type RunQueryFilters = {
   statuses?: NormalizedStatus[];

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -135,10 +135,34 @@ export type NetworkBreakdown = {
   errorCount: number;
 };
 
-export type RunsFilters = {
+/**
+ * Server-side filters the runs listing accepts. Every dimension is a set, so a
+ * reader can hold several values of one dimension open at once (all three error
+ * statuses, two networks). Values inside a dimension OR together; the
+ * dimensions AND together.
+ */
+export type RunQueryFilters = {
+  statuses?: NormalizedStatus[];
+  sources?: RunSource[];
+  networks?: string[];
+  /** Inclusive lower bound on run duration, in milliseconds. */
+  durationMinMs?: number;
+  /** Exclusive upper bound on run duration, in milliseconds. */
+  durationMaxMs?: number;
+  /** Matches a workflow name or a run id, case-insensitively. */
+  search?: string;
+};
+
+/**
+ * Run count per normalized status over the current window, used for the counts
+ * beside each option in the status filter. Counted with every other filter
+ * applied but with the status filter itself lifted, so a count answers "how
+ * many rows would ticking this add", not "how many are showing now".
+ */
+export type StatusFacets = Partial<Record<NormalizedStatus, number>>;
+
+export type RunsFilters = RunQueryFilters & {
   range: TimeRange;
-  status?: NormalizedStatus;
-  source?: RunSource;
   cursor?: string;
   limit?: number;
   customStart?: string;

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -141,8 +141,16 @@ export type NetworkBreakdown = {
  * statuses, two networks). Values inside a dimension OR together; the
  * dimensions AND together.
  */
+/**
+ * Whether a run spent gas. "paid" is a run that put native currency on chain,
+ * whether the org's wallet or KeeperHub's gas credit covered it; "free" is a
+ * run that only read, or never reached a broadcast.
+ */
+export type GasSpend = "paid" | "free";
+
 export type RunQueryFilters = {
   statuses?: NormalizedStatus[];
+  gas?: GasSpend[];
   sources?: RunSource[];
   networks?: string[];
   /** Inclusive lower bound on run duration, in milliseconds. */

--- a/lib/atoms/analytics.ts
+++ b/lib/atoms/analytics.ts
@@ -1,10 +1,12 @@
 import { atom } from "jotai";
+import type { DurationPresetId } from "@/lib/analytics/duration-presets";
 import type {
   AnalyticsSummary,
   NetworkBreakdown,
   NormalizedStatus,
   RunSource,
   RunsResponse,
+  StatusFacets,
   TimeRange,
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
@@ -22,10 +24,18 @@ export const analyticsRunsAtom = atom<RunsResponse | null>(null);
 export const analyticsLoadingAtom = atom<boolean>(true);
 export const analyticsErrorAtom = atom<string | null>(null);
 
-export const analyticsStatusFilterAtom = atom<NormalizedStatus | undefined>(
-  undefined
-);
-export const analyticsSourceFilterAtom = atom<RunSource | undefined>(undefined);
+// Every run filter is a set: an empty array means the dimension is not
+// narrowing anything, and several values inside one dimension are a union.
+export const analyticsStatusFiltersAtom = atom<NormalizedStatus[]>([]);
+export const analyticsSourceFiltersAtom = atom<RunSource[]>([]);
+export const analyticsNetworkFiltersAtom = atom<string[]>([]);
+
+// Duration is the one dimension where overlapping choices would be confusing,
+// so it stays a single bucket.
+export const analyticsDurationFilterAtom = atom<DurationPresetId | null>(null);
+
+// Run counts per status, for the counts beside each status option.
+export const analyticsStatusFacetsAtom = atom<StatusFacets>({});
 
 export const analyticsSearchAtom = atom("");
 

--- a/lib/atoms/analytics.ts
+++ b/lib/atoms/analytics.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import type { DurationPresetId } from "@/lib/analytics/duration-presets";
 import type {
   AnalyticsSummary,
+  GasSpend,
   NetworkBreakdown,
   NormalizedStatus,
   RunSource,
@@ -29,6 +30,7 @@ export const analyticsErrorAtom = atom<string | null>(null);
 export const analyticsStatusFiltersAtom = atom<NormalizedStatus[]>([]);
 export const analyticsSourceFiltersAtom = atom<RunSource[]>([]);
 export const analyticsNetworkFiltersAtom = atom<string[]>([]);
+export const analyticsGasFiltersAtom = atom<GasSpend[]>([]);
 
 // Duration is the one dimension where overlapping choices would be confusing,
 // so it stays a single bucket.

--- a/lib/chains/sort-chains.ts
+++ b/lib/chains/sort-chains.ts
@@ -1,0 +1,19 @@
+/**
+ * One ordering for every chain list a user sees. The analytics network filter
+ * and the chain picker on a web3 node read from the same comparator, so a
+ * reader who learns where a chain sits in one finds it in the same place in the
+ * other. Alphabetical by display name, because any other order (chain id,
+ * insertion, run volume) moves a chain around as data changes.
+ */
+const COLLATOR = new Intl.Collator("en-US", { sensitivity: "base" });
+
+export function compareChainNames(a: string, b: string): number {
+  return COLLATOR.compare(a, b);
+}
+
+export function sortChainsByName<T>(
+  chains: T[],
+  name: (chain: T) => string
+): T[] {
+  return [...chains].sort((a, b) => compareChainNames(name(a), name(b)));
+}

--- a/lib/notifications/execution-digest.ts
+++ b/lib/notifications/execution-digest.ts
@@ -119,6 +119,8 @@ export type SkippedWorkflow = {
 export type OrgExecutionDigest = {
   total: number;
   success: number;
+  // Every failed run in the window, platform failures included, so the digest
+  // rates a run the same way the analytics dashboard does.
   error: number;
   // Runs the platform refused before they started, over the plan's execution
   // limit or on a gated action. They never ran, so they are reported on their
@@ -166,9 +168,9 @@ export async function getOrgExecutionDigest(
     .select({
       total: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} <> 'skipped' THEN 1 ELSE 0 END)`,
       success: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'success' THEN 1 ELSE 0 END)`,
-      error: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'error' THEN 1 ELSE 0 END)`,
+      error: sql<number>`SUM(CASE WHEN ${inArray(workflowExecutions.status, [...ERROR_STATUSES])} THEN 1 ELSE 0 END)`,
       skipped: sql<number>`SUM(CASE WHEN ${workflowExecutions.status} = 'skipped' THEN 1 ELSE 0 END)`,
-      distinctWorkflows: sql<number>`COUNT(DISTINCT ${workflowExecutions.workflowId})`,
+      distinctWorkflows: sql<number>`COUNT(DISTINCT CASE WHEN ${workflowExecutions.status} <> 'skipped' THEN ${workflowExecutions.workflowId} END)`,
       transactionCount: sql<number>`COALESCE(SUM(CASE WHEN jsonb_typeof(${workflowExecutions.transactionHashes}) = 'array' THEN jsonb_array_length(${workflowExecutions.transactionHashes}) ELSE 0 END), 0)`,
       gasUsedWei: sql<string>`COALESCE(SUM(${workflowExecutions.gasUsedWei}), 0)`,
     })

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "prom-client": "^15.1.3",
     "qrcode-generator": "1.4.4",
     "react": "19.2.4",
+    "react-day-picker": "^10.0.1",
     "react-dom": "19.2.4",
     "react-resizable-panels": "^3.0.6",
     "recharts": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         version: 5.0.169(zod@4.3.6)
       better-auth:
         specifier: ^1.6.22
-        version: 1.6.25(72oxwumzdpayeiq6rbiap6ec2y)
+        version: 1.6.25(a2aaccfca7002dd561cf3edaeba66582)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -266,6 +266,9 @@ importers:
       react:
         specifier: 19.2.4
         version: 19.2.4
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.14)(react@19.2.4)
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
@@ -794,24 +797,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.10':
     resolution: {integrity: sha512-7MH1CMW5uuxQ/s7FLST63qF8B3Hgu2HRdZ7tA1X1+mk+St4JOuIrqdhIBnnyqeyWJNI+Bww7Es5QZ0wIc1Cmkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.10':
     resolution: {integrity: sha512-kDTi3pI6PBN6CiczsWYOyP2zk0IJI08EWEQyDMQWW221rPaaEz6FvjLhnU07KMzLv8q3qSuoB93ua6inSQ55Tw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.10':
     resolution: {integrity: sha512-tZLvEEi2u9Xu1zAqRjTcpIDGVtldigVvzug2fTuPG0ME/g8/mXpRPcNgLB22bGn6FvLJpHHnqLnwliOu8xjYrg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.10':
     resolution: {integrity: sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ==}
@@ -943,6 +950,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1580,89 +1590,105 @@ packages:
     resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.2':
     resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.2':
     resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.2':
     resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.2':
     resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.2':
     resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.2':
     resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.3':
     resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.3':
     resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.3':
     resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.3':
     resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.3':
     resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.3':
     resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.3':
     resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.3':
     resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.3':
     resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
@@ -1929,6 +1955,7 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-android-arm-eabi@1.1.1':
     resolution: {integrity: sha512-kjirL3N6TnRPv5iuHw36wnucNqXAO46dzK9oPb0wj076R5Xm8PfUVA9nAFB5ZNMmfJQJVKACAPd/Z2KYMppthw==}
@@ -1971,42 +1998,49 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -2090,24 +2124,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -2462,41 +2500,49 @@ packages:
     resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
@@ -3193,131 +3239,157 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -4249,24 +4321,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.3':
     resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.3':
     resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.3':
     resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.3':
     resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
@@ -4353,24 +4429,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -7155,24 +7235,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8050,6 +8134,16 @@ packages:
 
   rc9@3.0.0:
     resolution: {integrity: sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==}
+
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -10298,6 +10392,8 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@date-fns/tz@1.5.0': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -15314,7 +15410,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.6.25(72oxwumzdpayeiq6rbiap6ec2y):
+  better-auth@1.6.25(a2aaccfca7002dd561cf3edaeba66582):
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)))
@@ -18055,6 +18151,14 @@ snapshots:
     dependencies:
       defu: 6.1.7
       destr: 2.0.5
+
+  react-day-picker@10.0.1(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.1.0
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -1,0 +1,306 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  NormalizedStatus,
+  RunQueryFilters,
+  StatusFacets,
+  UnifiedRun,
+} from "../../../lib/analytics/types";
+import {
+  organization,
+  users,
+  workflowExecutionLogs,
+  workflowExecutions,
+  workflows,
+} from "../../../lib/db/schema";
+import { ExecutionErrorType } from "../../../lib/errors/execution-error-type";
+import type { WorkflowExecutionStatus } from "../../../lib/errors/execution-status";
+
+// vitest runs in Node, not an SSR context.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally stubs @/lib/db; this suite needs the real query path,
+// because what is under test is which rows the generated SQL selects.
+vi.unmock("@/lib/db");
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+const PREFIX = "test_run_filters_";
+const ORG_ID = `${PREFIX}org`;
+const USER_ID = `${PREFIX}user`;
+const NIGHTLY_ID = `${PREFIX}wf_nightly`;
+const REBALANCE_ID = `${PREFIX}wf_rebalance`;
+
+const BASE = "8453";
+const ARBITRUM = "42161";
+
+type Seed = {
+  id: string;
+  workflowId: string;
+  status: WorkflowExecutionStatus;
+  errorType?: ExecutionErrorType;
+  durationMs?: number;
+  network?: string;
+};
+
+// One run per interesting combination, so a filter that over- or under-selects
+// shows up as a named row rather than a count.
+const SEEDS: Seed[] = [
+  {
+    id: `${PREFIX}user_err`,
+    workflowId: NIGHTLY_ID,
+    status: "error",
+    errorType: ExecutionErrorType.USER,
+    durationMs: 1000,
+    network: BASE,
+  },
+  {
+    id: `${PREFIX}external_err`,
+    workflowId: NIGHTLY_ID,
+    status: "error",
+    errorType: ExecutionErrorType.EXTERNAL,
+    durationMs: 45_000,
+    network: BASE,
+  },
+  {
+    id: `${PREFIX}system_err`,
+    workflowId: REBALANCE_ID,
+    status: "system_error",
+    errorType: ExecutionErrorType.SYSTEM,
+    durationMs: 60_000,
+    network: ARBITRUM,
+  },
+  {
+    id: `${PREFIX}ok`,
+    workflowId: REBALANCE_ID,
+    status: "success",
+    durationMs: 2000,
+    network: ARBITRUM,
+  },
+  {
+    id: `${PREFIX}skipped`,
+    workflowId: NIGHTLY_ID,
+    status: "skipped",
+  },
+  {
+    id: `${PREFIX}running`,
+    workflowId: NIGHTLY_ID,
+    status: "running",
+  },
+];
+
+describe.skipIf(SKIP)("analytics run filters", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let getUnifiedRuns: (
+    organizationId: string,
+    range: "7d",
+    options?: RunQueryFilters & { limit?: number }
+  ) => Promise<{ runs: UnifiedRun[]; total: number }>;
+  let getStatusFacets: (
+    organizationId: string,
+    range: "7d",
+    options?: RunQueryFilters
+  ) => Promise<StatusFacets>;
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  async function idsFor(filters: RunQueryFilters): Promise<string[]> {
+    const { runs } = await getUnifiedRuns(ORG_ID, "7d", {
+      ...filters,
+      limit: 50,
+    });
+    return runs.map((run) => run.id).sort();
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    db = drizzle(queryClient);
+    await cleanup();
+
+    const now = new Date();
+
+    await db.insert(organization).values({
+      id: ORG_ID,
+      name: "filters org",
+      slug: ORG_ID,
+      createdAt: now,
+    });
+    await db.insert(users).values({
+      id: USER_ID,
+      email: `${USER_ID}@keeperhub.test`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(workflows).values([
+      {
+        id: NIGHTLY_ID,
+        name: "Nightly sync",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+      {
+        id: REBALANCE_ID,
+        name: "Rebalance vault",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+    ]);
+
+    await db.insert(workflowExecutions).values(
+      SEEDS.map((seed) => ({
+        id: seed.id,
+        workflowId: seed.workflowId,
+        userId: USER_ID,
+        status: seed.status,
+        errorType: seed.errorType ?? null,
+        duration:
+          seed.durationMs === undefined ? null : String(seed.durationMs),
+        startedAt: now,
+        completedAt: seed.durationMs === undefined ? null : now,
+      }))
+    );
+
+    const logRows: Array<{
+      id: string;
+      executionId: string;
+      nodeId: string;
+      nodeName: string;
+      nodeType: string;
+      status: "success";
+      network: string;
+      startedAt: Date;
+    }> = [];
+    for (const seed of SEEDS) {
+      if (seed.network === undefined) {
+        continue;
+      }
+      logRows.push({
+        id: `${seed.id}_log`,
+        executionId: seed.id,
+        nodeId: "n1",
+        nodeName: "Step",
+        nodeType: "web3/transfer",
+        status: "success" as const,
+        network: seed.network,
+        startedAt: now,
+      });
+    }
+    await db.insert(workflowExecutionLogs).values(logRows);
+
+    ({ getUnifiedRuns, getStatusFacets } = await import(
+      "@/lib/analytics/queries"
+    ));
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  it("returns every error status when all three are selected", async () => {
+    const statuses: NormalizedStatus[] = [
+      "error",
+      "external_error",
+      "system_error",
+    ];
+    expect(await idsFor({ statuses })).toEqual(
+      [
+        `${PREFIX}user_err`,
+        `${PREFIX}external_err`,
+        `${PREFIX}system_err`,
+      ].sort()
+    );
+  });
+
+  it("keeps the error subtypes selectable on their own", async () => {
+    expect(await idsFor({ statuses: ["error"] })).toEqual([
+      `${PREFIX}user_err`,
+    ]);
+    expect(await idsFor({ statuses: ["external_error"] })).toEqual([
+      `${PREFIX}external_err`,
+    ]);
+    expect(await idsFor({ statuses: ["system_error"] })).toEqual([
+      `${PREFIX}system_err`,
+    ]);
+  });
+
+  it("ANDs across dimensions and ORs inside one", async () => {
+    expect(
+      await idsFor({
+        statuses: ["error", "external_error", "system_error"],
+        networks: [BASE],
+      })
+    ).toEqual([`${PREFIX}external_err`, `${PREFIX}user_err`].sort());
+  });
+
+  it("filters on network", async () => {
+    expect(await idsFor({ networks: [ARBITRUM] })).toEqual(
+      [`${PREFIX}system_err`, `${PREFIX}ok`].sort()
+    );
+  });
+
+  it("filters on duration, and a run still in flight has none", async () => {
+    expect(await idsFor({ durationMinMs: 30_000 })).toEqual(
+      [`${PREFIX}external_err`, `${PREFIX}system_err`].sort()
+    );
+    expect(await idsFor({ durationMaxMs: 5000 })).toEqual(
+      [`${PREFIX}ok`, `${PREFIX}user_err`].sort()
+    );
+  });
+
+  it("searches by workflow name and by run id", async () => {
+    const byName = await idsFor({ search: "nightly" });
+    expect(byName).toContain(`${PREFIX}user_err`);
+    expect(byName).not.toContain(`${PREFIX}ok`);
+
+    expect(await idsFor({ search: `${PREFIX}ok` })).toEqual([`${PREFIX}ok`]);
+  });
+
+  it("reports the total under the filters, not the unfiltered count", async () => {
+    const { total } = await getUnifiedRuns(ORG_ID, "7d", {
+      statuses: ["error", "external_error", "system_error"],
+      limit: 50,
+    });
+    expect(total).toBe(3);
+  });
+
+  it("counts each status separately for the filter's counts", async () => {
+    const facets = await getStatusFacets(ORG_ID, "7d");
+    expect(facets.error).toBe(1);
+    expect(facets.external_error).toBe(1);
+    expect(facets.system_error).toBe(1);
+    expect(facets.success).toBe(1);
+    expect(facets.skipped).toBe(1);
+    expect(facets.running).toBe(1);
+  });
+
+  it("counts under the other filters but not under the status filter", async () => {
+    const facets = await getStatusFacets(ORG_ID, "7d", {
+      networks: [ARBITRUM],
+      statuses: ["success"],
+    });
+    // Scoped to Arbitrum, and the status selection does not hide the others.
+    expect(facets.system_error).toBe(1);
+    expect(facets.success).toBe(1);
+    expect(facets.error).toBeUndefined();
+  });
+});

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -45,6 +45,8 @@ type Seed = {
   errorType?: ExecutionErrorType;
   durationMs?: number;
   network?: string;
+  /** Carries the gas-station marker a web3 step core writes on a sponsored tx. */
+  sponsored?: boolean;
 };
 
 // One run per interesting combination, so a filter that over- or under-selects
@@ -80,6 +82,14 @@ const SEEDS: Seed[] = [
     status: "success",
     durationMs: 2000,
     network: ARBITRUM,
+  },
+  {
+    id: `${PREFIX}sponsored`,
+    workflowId: REBALANCE_ID,
+    status: "success",
+    durationMs: 3000,
+    network: BASE,
+    sponsored: true,
   },
   {
     id: `${PREFIX}skipped`,
@@ -188,6 +198,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       status: "success";
       network: string;
       gasUsedWei: string | null;
+      outputRaw: { sponsored: boolean } | null;
       startedAt: Date;
     }> = [];
     for (const seed of SEEDS) {
@@ -203,6 +214,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
         status: "success" as const,
         network: seed.network,
         gasUsedWei: seed.status === "success" ? "21000" : null,
+        outputRaw: seed.sponsored ? { sponsored: true } : null,
         startedAt: now,
       });
     }
@@ -265,7 +277,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       [`${PREFIX}external_err`, `${PREFIX}system_err`].sort()
     );
     expect(await idsFor({ durationMaxMs: 5000 })).toEqual(
-      [`${PREFIX}ok`, `${PREFIX}user_err`].sort()
+      [`${PREFIX}ok`, `${PREFIX}sponsored`, `${PREFIX}user_err`].sort()
     );
   });
 
@@ -277,17 +289,24 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(await idsFor({ search: `${PREFIX}ok` })).toEqual([`${PREFIX}ok`]);
   });
 
-  it("separates runs that spent gas from those that did not", async () => {
-    // Only the seeded success rows carry gas on their step log.
-    const paid = await idsFor({ gas: ["paid"] });
-    expect(paid).toEqual([`${PREFIX}ok`]);
+  it("separates runs by who paid the gas", async () => {
+    // Only the seeded success row carries gas, and none of the rows carry a
+    // sponsorship marker, so the wallet covered all of it.
+    // The sponsored run burned gas, but the gas station covered it, so it
+    // answers to sponsored and not to wallet.
+    expect(await idsFor({ gas: ["sponsored"] })).toEqual([
+      `${PREFIX}sponsored`,
+    ]);
+    expect(await idsFor({ gas: ["wallet"] })).toEqual([`${PREFIX}ok`]);
 
     const free = await idsFor({ gas: ["free"] });
     expect(free).not.toContain(`${PREFIX}ok`);
     expect(free).toContain(`${PREFIX}user_err`);
 
-    // Both values selected is the same as neither: no narrowing at all.
-    expect(await idsFor({ gas: ["paid", "free"] })).toEqual(await idsFor({}));
+    // Every category selected is the same as none: no narrowing at all.
+    expect(await idsFor({ gas: ["sponsored", "wallet", "free"] })).toEqual(
+      await idsFor({})
+    );
   });
 
   it("reports the total under the filters, not the unfiltered count", async () => {
@@ -303,7 +322,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(facets.error).toBe(1);
     expect(facets.external_error).toBe(1);
     expect(facets.system_error).toBe(1);
-    expect(facets.success).toBe(1);
+    expect(facets.success).toBe(2);
     expect(facets.skipped).toBe(1);
     expect(facets.running).toBe(1);
   });

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -187,6 +187,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       nodeType: string;
       status: "success";
       network: string;
+      gasUsedWei: string | null;
       startedAt: Date;
     }> = [];
     for (const seed of SEEDS) {
@@ -201,6 +202,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
         nodeType: "web3/transfer",
         status: "success" as const,
         network: seed.network,
+        gasUsedWei: seed.status === "success" ? "21000" : null,
         startedAt: now,
       });
     }
@@ -273,6 +275,19 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(byName).not.toContain(`${PREFIX}ok`);
 
     expect(await idsFor({ search: `${PREFIX}ok` })).toEqual([`${PREFIX}ok`]);
+  });
+
+  it("separates runs that spent gas from those that did not", async () => {
+    // Only the seeded success rows carry gas on their step log.
+    const paid = await idsFor({ gas: ["paid"] });
+    expect(paid).toEqual([`${PREFIX}ok`]);
+
+    const free = await idsFor({ gas: ["free"] });
+    expect(free).not.toContain(`${PREFIX}ok`);
+    expect(free).toContain(`${PREFIX}user_err`);
+
+    // Both values selected is the same as neither: no narrowing at all.
+    expect(await idsFor({ gas: ["paid", "free"] })).toEqual(await idsFor({}));
   });
 
   it("reports the total under the filters, not the unfiltered count", async () => {

--- a/tests/unit/analytics-date-range-selection.test.ts
+++ b/tests/unit/analytics-date-range-selection.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  endOfDay,
+  nextRangeStep,
+  startOfDay,
+} from "@/lib/analytics/date-range-selection";
+
+const AUG_10 = new Date(2026, 7, 10, 13, 30);
+const AUG_20 = new Date(2026, 7, 20, 9, 15);
+
+describe("nextRangeStep", () => {
+  it("starts a range on the first click", () => {
+    expect(nextRangeStep(undefined, AUG_10)).toEqual({
+      kind: "start",
+      from: AUG_10,
+    });
+  });
+
+  it("closes the range on the second click", () => {
+    const step = nextRangeStep({ from: AUG_10 }, AUG_20);
+    expect(step.kind).toBe("complete");
+    if (step.kind === "complete") {
+      expect(step.from).toEqual(startOfDay(AUG_10));
+      expect(step.to).toEqual(endOfDay(AUG_20));
+    }
+  });
+
+  // The regression: handed a range that is already closed, every further click
+  // used to report a completed range, so the picker applied and dismissed on
+  // each one instead of starting over.
+  it("starts a new range rather than extending a closed one", () => {
+    expect(
+      nextRangeStep({ from: AUG_10, to: AUG_20 }, new Date(2026, 8, 1)).kind
+    ).toBe("start");
+  });
+
+  it("swaps the ends when the second click lands earlier", () => {
+    const step = nextRangeStep({ from: AUG_20 }, AUG_10);
+    expect(step.kind).toBe("complete");
+    if (step.kind === "complete") {
+      expect(step.from).toEqual(startOfDay(AUG_10));
+      expect(step.to).toEqual(endOfDay(AUG_20));
+    }
+  });
+
+  it("reads two clicks on one date as that single day", () => {
+    const step = nextRangeStep({ from: AUG_10 }, AUG_10);
+    expect(step.kind).toBe("complete");
+    if (step.kind === "complete") {
+      expect(step.from).toEqual(startOfDay(AUG_10));
+      expect(step.to).toEqual(endOfDay(AUG_10));
+    }
+  });
+
+  it("covers the whole day at both ends", () => {
+    expect(startOfDay(AUG_10).getHours()).toBe(0);
+    expect(endOfDay(AUG_10).getHours()).toBe(23);
+    expect(endOfDay(AUG_10).getMilliseconds()).toBe(999);
+  });
+});

--- a/tests/unit/analytics-run-filters-parse.test.ts
+++ b/tests/unit/analytics-run-filters-parse.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { parseRunFilters } from "@/lib/analytics/parse-run-filters";
+import { buildRunsQuery } from "@/lib/analytics/runs-query";
+
+function parse(query: string): ReturnType<typeof parseRunFilters> {
+  return parseRunFilters(new URLSearchParams(query));
+}
+
+describe("parseRunFilters", () => {
+  it("reads every value of a repeated dimension", () => {
+    expect(
+      parse("status=error&status=external_error&status=system_error").statuses
+    ).toEqual(["error", "external_error", "system_error"]);
+  });
+
+  it("keeps a single value working the way it always did", () => {
+    expect(parse("status=success").statuses).toEqual(["success"]);
+  });
+
+  it("drops unknown statuses and sources rather than narrowing on them", () => {
+    expect(parse("status=bogus&source=telepathy").statuses).toBeUndefined();
+    expect(parse("status=bogus&source=telepathy").sources).toBeUndefined();
+  });
+
+  it("de-duplicates repeated values", () => {
+    expect(parse("network=8453&network=8453").networks).toEqual(["8453"]);
+  });
+
+  it("ignores a negative or non-numeric duration bound", () => {
+    expect(parse("durationMin=-5").durationMinMs).toBeUndefined();
+    expect(parse("durationMax=soon").durationMaxMs).toBeUndefined();
+    expect(parse("durationMin=30000").durationMinMs).toBe(30_000);
+  });
+
+  it("trims search and caps its length", () => {
+    expect(parse("search=%20%20nightly%20%20").search).toBe("nightly");
+    expect(parse(`search=${"a".repeat(500)}`).search).toHaveLength(128);
+  });
+});
+
+describe("buildRunsQuery", () => {
+  it("round-trips through the parser", () => {
+    const query = buildRunsQuery({
+      range: "7d",
+      statuses: ["error", "system_error"],
+      sources: ["workflow"],
+      networks: ["8453", "42161"],
+      duration: "over30s",
+      search: "nightly",
+    });
+
+    const parsed = parse(query);
+    expect(parsed.statuses).toEqual(["error", "system_error"]);
+    expect(parsed.sources).toEqual(["workflow"]);
+    expect(parsed.networks).toEqual(["8453", "42161"]);
+    expect(parsed.durationMinMs).toBe(30_000);
+    expect(parsed.durationMaxMs).toBeUndefined();
+    expect(parsed.search).toBe("nightly");
+  });
+
+  it("omits the status dimension for the facet request", () => {
+    const query = buildRunsQuery({
+      range: "24h",
+      statuses: ["error"],
+      networks: ["8453"],
+      omitStatus: true,
+    });
+
+    expect(parse(query).statuses).toBeUndefined();
+    // Every other dimension still applies, so a count sits under them.
+    expect(parse(query).networks).toEqual(["8453"]);
+  });
+
+  it("leaves page 1 off the query so the first page has a clean URL", () => {
+    expect(buildRunsQuery({ range: "24h", page: 1 })).toBe("range=24h");
+    expect(buildRunsQuery({ range: "24h", page: 3 })).toContain("page=3");
+  });
+});

--- a/tests/unit/analytics-run-filters-parse.test.ts
+++ b/tests/unit/analytics-run-filters-parse.test.ts
@@ -32,6 +32,12 @@ describe("parseRunFilters", () => {
     expect(parse("durationMin=30000").durationMinMs).toBe(30_000);
   });
 
+  it("reads the gas dimension", () => {
+    expect(parse("gas=paid").gas).toEqual(["paid"]);
+    expect(parse("gas=paid&gas=free").gas).toEqual(["paid", "free"]);
+    expect(parse("gas=maybe").gas).toBeUndefined();
+  });
+
   it("trims search and caps its length", () => {
     expect(parse("search=%20%20nightly%20%20").search).toBe("nightly");
     expect(parse(`search=${"a".repeat(500)}`).search).toHaveLength(128);
@@ -46,10 +52,12 @@ describe("buildRunsQuery", () => {
       sources: ["workflow"],
       networks: ["8453", "42161"],
       duration: "over30s",
+      gas: ["paid"],
       search: "nightly",
     });
 
     const parsed = parse(query);
+    expect(parsed.gas).toEqual(["paid"]);
     expect(parsed.statuses).toEqual(["error", "system_error"]);
     expect(parsed.sources).toEqual(["workflow"]);
     expect(parsed.networks).toEqual(["8453", "42161"]);

--- a/tests/unit/analytics-run-filters-parse.test.ts
+++ b/tests/unit/analytics-run-filters-parse.test.ts
@@ -79,6 +79,24 @@ describe("buildRunsQuery", () => {
     expect(parse(query).networks).toEqual(["8453"]);
   });
 
+  it("carries a custom window so the picked dates reach the server", () => {
+    const query = buildRunsQuery({
+      range: "custom",
+      customStart: "2026-08-01T00:00:00.000Z",
+      customEnd: "2026-08-31T23:59:59.999Z",
+    });
+    const params = new URLSearchParams(query);
+    expect(params.get("range")).toBe("custom");
+    expect(params.get("customStart")).toBe("2026-08-01T00:00:00.000Z");
+    expect(params.get("customEnd")).toBe("2026-08-31T23:59:59.999Z");
+  });
+
+  it("omits the window on a preset range", () => {
+    const params = new URLSearchParams(buildRunsQuery({ range: "7d" }));
+    expect(params.get("customStart")).toBeNull();
+    expect(params.get("customEnd")).toBeNull();
+  });
+
   it("leaves page 1 off the query so the first page has a clean URL", () => {
     expect(buildRunsQuery({ range: "24h", page: 1 })).toBe("range=24h");
     expect(buildRunsQuery({ range: "24h", page: 3 })).toContain("page=3");

--- a/tests/unit/analytics-run-filters-parse.test.ts
+++ b/tests/unit/analytics-run-filters-parse.test.ts
@@ -33,8 +33,8 @@ describe("parseRunFilters", () => {
   });
 
   it("reads the gas dimension", () => {
-    expect(parse("gas=paid").gas).toEqual(["paid"]);
-    expect(parse("gas=paid&gas=free").gas).toEqual(["paid", "free"]);
+    expect(parse("gas=sponsored").gas).toEqual(["sponsored"]);
+    expect(parse("gas=wallet&gas=free").gas).toEqual(["wallet", "free"]);
     expect(parse("gas=maybe").gas).toBeUndefined();
   });
 
@@ -52,12 +52,12 @@ describe("buildRunsQuery", () => {
       sources: ["workflow"],
       networks: ["8453", "42161"],
       duration: "over30s",
-      gas: ["paid"],
+      gas: ["wallet"],
       search: "nightly",
     });
 
     const parsed = parse(query);
-    expect(parsed.gas).toEqual(["paid"]);
+    expect(parsed.gas).toEqual(["wallet"]);
     expect(parsed.statuses).toEqual(["error", "system_error"]);
     expect(parsed.sources).toEqual(["workflow"]);
     expect(parsed.networks).toEqual(["8453", "42161"]);

--- a/tests/unit/analytics-runs-route.test.ts
+++ b/tests/unit/analytics-runs-route.test.ts
@@ -62,7 +62,7 @@ describe("GET /api/analytics/runs status filter", () => {
     expect(getUnifiedRuns).toHaveBeenCalledWith(
       "org_from_jwt",
       expect.anything(),
-      expect.objectContaining({ status: "system_error" })
+      expect.objectContaining({ statuses: ["system_error"] })
     );
   });
 
@@ -72,7 +72,7 @@ describe("GET /api/analytics/runs status filter", () => {
     expect(getUnifiedRuns).toHaveBeenCalledWith(
       "org_from_jwt",
       expect.anything(),
-      expect.objectContaining({ status: "external_error" })
+      expect.objectContaining({ statuses: ["external_error"] })
     );
   });
 
@@ -88,18 +88,35 @@ describe("GET /api/analytics/runs status filter", () => {
       expect(getUnifiedRuns).toHaveBeenLastCalledWith(
         "org_from_jwt",
         expect.anything(),
-        expect.objectContaining({ status })
+        expect.objectContaining({ statuses: [status] })
       );
     }
   });
 
-  it("drops an unknown status to undefined", async () => {
+  it("drops an unknown status rather than narrowing on it", async () => {
     await GET(oauthRequest("bogus"));
+
+    const [, , options] = vi.mocked(getUnifiedRuns).mock.calls[0] ?? [];
+    expect(options?.statuses).toBeUndefined();
+  });
+
+  it("forwards every status of a multi-select as one union", async () => {
+    const params = new URLSearchParams();
+    params.append("status", "error");
+    params.append("status", "external_error");
+    params.append("status", "system_error");
+    await GET({
+      method: "GET",
+      headers: new Headers({ Authorization: "Bearer fake-jwt" }),
+      nextUrl: { searchParams: params },
+    } as unknown as NextRequest);
 
     expect(getUnifiedRuns).toHaveBeenCalledWith(
       "org_from_jwt",
       expect.anything(),
-      expect.objectContaining({ status: undefined })
+      expect.objectContaining({
+        statuses: ["error", "external_error", "system_error"],
+      })
     );
   });
 });
@@ -144,7 +161,7 @@ describe("GET /api/analytics/runs auth", () => {
     expect(getUnifiedRuns).toHaveBeenCalledWith(
       "org_from_jwt",
       expect.anything(),
-      expect.objectContaining({ status: "success" })
+      expect.objectContaining({ statuses: ["success"] })
     );
   });
 });

--- a/tests/unit/execution-digest-totals.test.ts
+++ b/tests/unit/execution-digest-totals.test.ts
@@ -1,0 +1,73 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const captured: Record<string, unknown>[] = [];
+
+// Chainable stand-in for the drizzle builder: every method returns itself and
+// awaiting it yields an empty result set, so the digest query runs without a DB.
+function builder(): unknown {
+  const target = (): unknown => target;
+  return new Proxy(target, {
+    get(_t, prop) {
+      if (prop === "then") {
+        return (resolve: (v: unknown[]) => unknown) => resolve([]);
+      }
+      return () => builder();
+    },
+    apply() {
+      return builder();
+    },
+  });
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (fields: Record<string, unknown>) => {
+      captured.push(fields);
+      return builder();
+    },
+    selectDistinctOn: () => builder(),
+  },
+}));
+
+vi.mock("@/lib/web3/sponsorship-feature-flag", () => ({
+  isGasSponsorshipEnabled: () => false,
+}));
+
+import { getOrgExecutionDigest } from "@/lib/notifications/execution-digest";
+
+const dialect = new PgDialect();
+
+function renderedTotals(): { sql: string; params: unknown[] } {
+  const totals = captured[0];
+  if (!totals) {
+    throw new Error("digest totals select was not captured");
+  }
+  const parts = Object.values(totals).map((expr) =>
+    dialect.sqlToQuery(expr as Parameters<PgDialect["sqlToQuery"]>[0])
+  );
+  return {
+    sql: parts.map((p) => p.sql).join(" | "),
+    params: parts.flatMap((p) => p.params),
+  };
+}
+
+describe("getOrgExecutionDigest totals", () => {
+  it("counts platform failures as failures and refused runs as neither", async () => {
+    captured.length = 0;
+    await getOrgExecutionDigest(
+      "org-1",
+      new Date("2026-06-08T00:00:00.000Z"),
+      new Date("2026-06-09T00:00:00.000Z")
+    );
+
+    const { sql, params } = renderedTotals();
+    // The failure count has to match the top-failing list, which spans both
+    // error statuses; counting only 'error' overstates the success rate.
+    expect(params).toContain("system_error");
+    // Refused runs never ran, so they stay out of the workflows-run count.
+    expect(sql).toContain("COUNT(DISTINCT CASE WHEN");
+  });
+});


### PR DESCRIPTION
The digest email counted only runs with status `error`, so `system_error` runs fell out of both sides of `success / (success + error)` and were rated as if they had never happened. External failures were already counted, since they are stored as status `error` with `error_type = "external"`.

The email also contradicted itself: `topFailing` in the same query spans both error statuses, so a digest could report "2 failed" above a list showing one workflow with 4 failures.

The failure count now uses the shared `ERROR_STATUSES` constant, the same one the analytics dashboard and the top-failing list already use. The analytics summary was already correct and is unchanged.

Refused runs no longer count towards "Workflows run": a workflow whose only runs never started did not run.

Measured against Postgres with 6 success, 1 user error, 1 external error, 2 system errors, 1 skipped and 1 running, the digest reported 75% success and "2 failed". It now reports 60% and "4 failed", matching its own top-failing list.