### PR TITLE
fix(editor): stop auto-layout from stacking nodes on top of each other

### DIFF
--- a/components/workflow/nodes/action-node.tsx
+++ b/components/workflow/nodes/action-node.tsx
@@ -16,10 +16,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { memo, useState } from "react";
-import {
-  Node,
-  type SourceHandleConfig,
-} from "@/components/ai-elements/node";
+import { Node } from "@/components/ai-elements/node";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { NodeLabel } from "@/components/workflow/nodes/node-label";
 import {
@@ -27,6 +24,10 @@ import {
   integrationsLoadedAtom,
 } from "@/lib/integrations-store";
 import { cn } from "@/lib/utils";
+import {
+  CONDITION_SOURCE_HANDLES,
+  FOR_EACH_SOURCE_HANDLES,
+} from "@/lib/workflow/source-handles";
 import {
   executionLogsAtom,
   pendingIntegrationNodesAtom,
@@ -71,16 +72,6 @@ const getModelDisplayName = (modelId: string): string => {
   };
   return modelNames[modelId] || modelId;
 };
-
-const FOR_EACH_SOURCE_HANDLES: SourceHandleConfig[] = [
-  { id: "done", label: "done", topPercent: 30 },
-  { id: "loop", label: "loop", topPercent: 70 },
-];
-
-const CONDITION_SOURCE_HANDLES: SourceHandleConfig[] = [
-  { id: "true", label: "true", topPercent: 30 },
-  { id: "false", label: "false", topPercent: 70 },
-];
 
 // System action labels (non-plugin actions)
 const SYSTEM_ACTION_LABELS: Record<string, string> = {

--- a/lib/workflow/editor/auto-layout.ts
+++ b/lib/workflow/editor/auto-layout.ts
@@ -1,3 +1,5 @@
+import { sourceHandleRank } from "@/lib/workflow/source-handles";
+
 // Local structural types instead of importing @xyflow/react, so this pure
 // layout helper can also run server-side (e.g. seeding onboarding workflow
 // fixtures). Real @xyflow/react Node/Edge are structural supersets, so editor
@@ -25,24 +27,20 @@ const ROW_STEP = NODE_HEIGHT + V_GAP;
 // under their parents; more passes stop changing the picture.
 const REFINE_PASSES = 2;
 
-/** Order outgoing edges: true/loop first, normal next, false/done last. */
+// An edge with no named handle sits between the upper and the lower handle.
+const UNNAMED_RANK = 0.5;
+
+/**
+ * Order outgoing edges the way their handles sit on the node: the upper handle
+ * (true, done) first, then edges with no named handle, then the lower one
+ * (false, loop). Sorting is stable, so edges sharing a handle keep their order.
+ */
 function sortEdges(edges: Edge[]): Edge[] {
-  const top: Edge[] = [];
-  const normal: Edge[] = [];
-  const bottom: Edge[] = [];
-
-  for (const edge of edges) {
-    const handle = edge.sourceHandle;
-    if (handle === "true" || handle === "loop") {
-      top.push(edge);
-    } else if (handle === "false" || handle === "done") {
-      bottom.push(edge);
-    } else {
-      normal.push(edge);
-    }
-  }
-
-  return [...top, ...normal, ...bottom];
+  return [...edges].sort(
+    (a, b) =>
+      (sourceHandleRank(a.sourceHandle) ?? UNNAMED_RANK) -
+      (sourceHandleRank(b.sourceHandle) ?? UNNAMED_RANK)
+  );
 }
 
 /** Walk the trigger first, then unreferenced nodes, then anything left on a cycle. */
@@ -130,12 +128,15 @@ type Graph = {
   children: Map<string, string[]>;
   parents: Map<string, string[]>;
   inDegree: Map<string, number>;
+  /** Where the edge leaves its source, keyed "source->target". */
+  edgeRank: Map<string, number>;
 };
 
 function buildGraph(realNodes: Node[], forwardEdges: Edge[]): Graph {
   const children = new Map<string, string[]>();
   const parents = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
+  const edgeRank = new Map<string, number>();
 
   for (const node of realNodes) {
     children.set(node.id, []);
@@ -158,10 +159,14 @@ function buildGraph(realNodes: Node[], forwardEdges: Edge[]): Graph {
       children.get(node.id)?.push(edge.target);
       parents.get(edge.target)?.push(node.id);
       inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+      edgeRank.set(
+        `${node.id}->${edge.target}`,
+        sourceHandleRank(edge.sourceHandle) ?? UNNAMED_RANK
+      );
     }
   }
 
-  return { children, parents, inDegree };
+  return { children, parents, inDegree, edgeRank };
 }
 
 function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
@@ -221,9 +226,77 @@ function assignColumns(roots: string[], graph: Graph): Map<string, number> {
 }
 
 /**
- * Vertical order of each column, taken from a depth-first walk of the graph so
- * that a branch and everything below it stay together, true/loop above
- * false/done.
+ * The branch turns taken to reach a node, one entry per step: which root it
+ * came from, then where each edge left its source. Comparing two of these
+ * decides which node belongs higher in a column, so a true branch stays above
+ * a false branch even where the two meet nodes placed from another path.
+ *
+ * A node is reached through the parent that fixed its column, which is the one
+ * furthest right; nodes on a cycle with no path from a root sort last.
+ */
+function branchPaths(
+  realNodes: Node[],
+  roots: string[],
+  graph: Graph,
+  columns: Map<string, number>
+): Map<string, number[]> {
+  const paths = new Map<string, number[]>();
+  for (const [index, root] of roots.entries()) {
+    paths.set(root, [index]);
+  }
+
+  const byColumn: string[][] = [];
+  for (const node of realNodes) {
+    const col = columns.get(node.id) ?? 0;
+    byColumn[col] = byColumn[col] ?? [];
+    byColumn[col].push(node.id);
+  }
+
+  for (const ids of byColumn) {
+    for (const id of ids ?? []) {
+      if (paths.has(id)) {
+        continue;
+      }
+      let from: string | undefined;
+      let fromColumn = Number.NEGATIVE_INFINITY;
+      for (const parent of graph.parents.get(id) ?? []) {
+        const col = columns.get(parent) ?? 0;
+        if (paths.has(parent) && col > fromColumn) {
+          from = parent;
+          fromColumn = col;
+        }
+      }
+      const parentPath = from === undefined ? undefined : paths.get(from);
+      if (parentPath) {
+        paths.set(id, [
+          ...parentPath,
+          graph.edgeRank.get(`${from}->${id}`) ?? UNNAMED_RANK,
+        ]);
+      }
+    }
+  }
+
+  for (const node of realNodes) {
+    if (!paths.has(node.id)) {
+      paths.set(node.id, [Number.POSITIVE_INFINITY]);
+    }
+  }
+
+  return paths;
+}
+
+function comparePaths(a: number[], b: number[]): number {
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    if (a[i] !== b[i]) {
+      return a[i] - b[i];
+    }
+  }
+  return a.length - b.length;
+}
+
+/**
+ * Vertical order of each column: upper branches first, and within a branch the
+ * order the nodes were declared.
  */
 function orderColumns(
   realNodes: Node[],
@@ -231,39 +304,22 @@ function orderColumns(
   graph: Graph,
   columns: Map<string, number>
 ): string[][] {
+  const paths = branchPaths(realNodes, roots, graph, columns);
   const order: string[][] = [];
-  const seen = new Set<string>();
+  const seq = new Map<string, number>();
 
-  const push = (nodeId: string): void => {
-    const col = columns.get(nodeId) ?? 0;
-    const list = order[col];
-    if (list) {
-      list.push(nodeId);
-    } else {
-      order[col] = [nodeId];
-    }
-  };
-
-  const visit = (nodeId: string): void => {
-    if (seen.has(nodeId)) {
-      return;
-    }
-    seen.add(nodeId);
-    push(nodeId);
-    for (const child of graph.children.get(nodeId) ?? []) {
-      visit(child);
-    }
-  };
-
-  for (const root of roots) {
-    visit(root);
-  }
-  for (const node of realNodes) {
-    visit(node.id);
+  for (const [index, node] of realNodes.entries()) {
+    const col = columns.get(node.id) ?? 0;
+    order[col] = order[col] ?? [];
+    order[col].push(node.id);
+    seq.set(node.id, index);
   }
 
   for (let col = 0; col < order.length; col++) {
-    order[col] ??= [];
+    order[col] = (order[col] ?? []).sort((a, b) => {
+      const byPath = comparePaths(paths.get(a) ?? [], paths.get(b) ?? []);
+      return byPath === 0 ? (seq.get(a) ?? 0) - (seq.get(b) ?? 0) : byPath;
+    });
   }
 
   return order;
@@ -372,7 +428,7 @@ function refineRows(
  *
  * - Columns via longest-path topological sort (handles convergence)
  * - Rows via a layered sweep that keeps every column free of overlap
- * - Edge ordering: true/loop on top, false/done on bottom
+ * - Branches follow their handles: true/done above, false/loop below
  * - Loop bodies lay out to the right of their For Each node; only the edges
  *   that close a cycle are ignored
  */

--- a/lib/workflow/editor/auto-layout.ts
+++ b/lib/workflow/editor/auto-layout.ts
@@ -18,35 +18,158 @@ const NODE_HEIGHT = 192;
 const H_GAP = 60;
 const V_GAP = 40;
 
-function buildGraph(
-  realNodes: Node[],
-  forwardEdges: Edge[]
-): { outEdges: Map<string, Edge[]>; inDegree: Map<string, number> } {
-  const outEdges = new Map<string, Edge[]>();
+const COLUMN_STEP = NODE_WIDTH + H_GAP;
+const ROW_STEP = NODE_HEIGHT + V_GAP;
+
+// Two sweeps are enough to pull parents onto their children and children back
+// under their parents; more passes stop changing the picture.
+const REFINE_PASSES = 2;
+
+/** Order outgoing edges: true/loop first, normal next, false/done last. */
+function sortEdges(edges: Edge[]): Edge[] {
+  const top: Edge[] = [];
+  const normal: Edge[] = [];
+  const bottom: Edge[] = [];
+
+  for (const edge of edges) {
+    const handle = edge.sourceHandle;
+    if (handle === "true" || handle === "loop") {
+      top.push(edge);
+    } else if (handle === "false" || handle === "done") {
+      bottom.push(edge);
+    } else {
+      normal.push(edge);
+    }
+  }
+
+  return [...top, ...normal, ...bottom];
+}
+
+/** Walk the trigger first, then unreferenced nodes, then anything left on a cycle. */
+function walkOrder(realNodes: Node[], targets: Set<string>): string[] {
+  const start: string[] = [];
+  const trigger = realNodes.find((n) => n.type === "trigger");
+  if (trigger) {
+    start.push(trigger.id);
+  }
+  for (const node of realNodes) {
+    if (!(targets.has(node.id) || start.includes(node.id))) {
+      start.push(node.id);
+    }
+  }
+  for (const node of realNodes) {
+    if (!start.includes(node.id)) {
+      start.push(node.id);
+    }
+  }
+  return start;
+}
+
+/**
+ * Drop self edges, duplicates and back edges so the rest of the layout works on
+ * a DAG. A back edge points at a node still open on the DFS stack, which is the
+ * edge that closes a loop back onto its own body.
+ */
+function forwardEdgesOf(realNodes: Node[], edges: Edge[]): Edge[] {
+  const realIds = new Set(realNodes.map((n) => n.id));
+  const candidates: Edge[] = [];
+  const seen = new Set<string>();
+  const targets = new Set<string>();
+
+  for (const edge of edges) {
+    const key = `${edge.source}->${edge.target}`;
+    if (
+      edge.source === edge.target ||
+      !(realIds.has(edge.source) && realIds.has(edge.target)) ||
+      seen.has(key)
+    ) {
+      continue;
+    }
+    seen.add(key);
+    candidates.push(edge);
+    targets.add(edge.target);
+  }
+
+  const bySource = new Map<string, Edge[]>();
+  for (const edge of candidates) {
+    const list = bySource.get(edge.source);
+    if (list) {
+      list.push(edge);
+    } else {
+      bySource.set(edge.source, [edge]);
+    }
+  }
+
+  const backEdges = new Set<string>();
+  const open = new Set<string>();
+  const done = new Set<string>();
+
+  const visit = (nodeId: string): void => {
+    open.add(nodeId);
+    for (const edge of sortEdges(bySource.get(nodeId) ?? [])) {
+      if (open.has(edge.target)) {
+        backEdges.add(`${edge.source}->${edge.target}`);
+      } else if (!done.has(edge.target)) {
+        visit(edge.target);
+      }
+    }
+    open.delete(nodeId);
+    done.add(nodeId);
+  };
+
+  for (const nodeId of walkOrder(realNodes, targets)) {
+    if (!done.has(nodeId)) {
+      visit(nodeId);
+    }
+  }
+
+  return candidates.filter((e) => !backEdges.has(`${e.source}->${e.target}`));
+}
+
+type Graph = {
+  children: Map<string, string[]>;
+  parents: Map<string, string[]>;
+  inDegree: Map<string, number>;
+};
+
+function buildGraph(realNodes: Node[], forwardEdges: Edge[]): Graph {
+  const children = new Map<string, string[]>();
+  const parents = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
 
   for (const node of realNodes) {
-    outEdges.set(node.id, []);
+    children.set(node.id, []);
+    parents.set(node.id, []);
     inDegree.set(node.id, 0);
   }
 
+  const bySource = new Map<string, Edge[]>();
   for (const edge of forwardEdges) {
-    const out = outEdges.get(edge.source);
-    if (out) {
-      out.push(edge);
+    const list = bySource.get(edge.source);
+    if (list) {
+      list.push(edge);
+    } else {
+      bySource.set(edge.source, [edge]);
     }
-    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
   }
 
-  return { outEdges, inDegree };
+  for (const node of realNodes) {
+    for (const edge of sortEdges(bySource.get(node.id) ?? [])) {
+      children.get(node.id)?.push(edge.target);
+      parents.get(edge.target)?.push(node.id);
+      inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
+    }
+  }
+
+  return { children, parents, inDegree };
 }
 
 function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
   const roots: string[] = [];
-  const triggerNode = realNodes.find((n) => n.type === "trigger");
+  const trigger = realNodes.find((n) => n.type === "trigger");
 
-  if (triggerNode && inDegree.get(triggerNode.id) === 0) {
-    roots.push(triggerNode.id);
+  if (trigger && inDegree.get(trigger.id) === 0) {
+    roots.push(trigger.id);
   }
 
   for (const node of realNodes) {
@@ -59,39 +182,27 @@ function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
 }
 
 /**
- * Assign columns using longest-path from roots (topological order).
+ * Assign columns using longest-path from roots (topological order), so a node
+ * always sits to the right of every node that feeds it.
  */
-function assignColumns(
-  roots: string[],
-  outEdges: Map<string, Edge[]>,
-  inDegree: Map<string, number>
-): Map<string, number> {
+function assignColumns(roots: string[], graph: Graph): Map<string, number> {
   const column = new Map<string, number>();
-  const remaining = new Map<string, number>();
+  const remaining = new Map(graph.inDegree);
+  const queue = [...roots];
 
-  for (const [id, deg] of inDegree) {
-    remaining.set(id, deg);
-  }
-
-  const queue: string[] = [];
   for (const root of roots) {
     column.set(root, 0);
-    queue.push(root);
   }
 
   let head = 0;
   while (head < queue.length) {
     const current = queue[head++];
-    const currentCol = column.get(current) ?? 0;
+    const nextCol = (column.get(current) ?? 0) + 1;
 
-    for (const edge of outEdges.get(current) ?? []) {
-      const child = edge.target;
-      const newCol = currentCol + 1;
-      const existing = column.get(child);
-      if (existing === undefined || newCol > existing) {
-        column.set(child, newCol);
+    for (const child of graph.children.get(current) ?? []) {
+      if (nextCol > (column.get(child) ?? Number.NEGATIVE_INFINITY)) {
+        column.set(child, nextCol);
       }
-
       const rem = (remaining.get(child) ?? 1) - 1;
       remaining.set(child, rem);
       if (rem <= 0) {
@@ -100,388 +211,158 @@ function assignColumns(
     }
   }
 
+  for (const node of graph.children.keys()) {
+    if (!column.has(node)) {
+      column.set(node, 0);
+    }
+  }
+
   return column;
 }
 
 /**
- * Sort outgoing edges: true/loop first, normal middle, false/done last.
+ * Vertical order of each column, taken from a depth-first walk of the graph so
+ * that a branch and everything below it stay together, true/loop above
+ * false/done.
  */
-function sortedChildren(
-  nodeId: string,
-  outEdges: Map<string, Edge[]>
-): string[] {
-  const edges = outEdges.get(nodeId) ?? [];
-  const top: string[] = [];
-  const normal: string[] = [];
-  const bottom: string[] = [];
+function orderColumns(
+  realNodes: Node[],
+  roots: string[],
+  graph: Graph,
+  columns: Map<string, number>
+): string[][] {
+  const order: string[][] = [];
   const seen = new Set<string>();
 
-  for (const edge of edges) {
-    // Skip duplicate edges (same source->target)
-    if (seen.has(edge.target)) {
-      continue;
-    }
-    seen.add(edge.target);
-
-    const handle = edge.sourceHandle;
-    if (handle === "true" || handle === "loop") {
-      top.push(edge.target);
-    } else if (handle === "false" || handle === "done") {
-      bottom.push(edge.target);
+  const push = (nodeId: string): void => {
+    const col = columns.get(nodeId) ?? 0;
+    const list = order[col];
+    if (list) {
+      list.push(nodeId);
     } else {
-      normal.push(edge.target);
+      order[col] = [nodeId];
     }
-  }
-
-  return [...top, ...normal, ...bottom];
-}
-
-const STEP_Y = NODE_HEIGHT + V_GAP;
-
-/**
- * Compute how many vertical rows a node's subtree needs.
- * - Leaf: 1
- * - Linear (1 child): propagates child's spread (so downstream branches
- *   are accounted for at all ancestor levels, preventing overlap)
- * - Branching (N children): sum of owned children's spreads
- *   (convergence children that were already visited contribute 0)
- * - Already-visited (convergence): 0 (don't double-count)
- */
-function computeSpread(
-  nodeId: string,
-  outEdges: Map<string, Edge[]>,
-  visited: Set<string>,
-  spreadMap: Map<string, number>
-): number {
-  if (visited.has(nodeId)) {
-    return 0;
-  }
-  visited.add(nodeId);
-
-  const children = sortedChildren(nodeId, outEdges);
-
-  if (children.length === 0) {
-    spreadMap.set(nodeId, 1);
-    return 1;
-  }
-
-  if (children.length === 1) {
-    const childSpread = computeSpread(
-      children[0],
-      outEdges,
-      visited,
-      spreadMap
-    );
-    const spread = Math.max(1, childSpread);
-    spreadMap.set(nodeId, spread);
-    return spread;
-  }
-
-  // Branching: sum only owned children (convergence children contribute 0)
-  let total = 0;
-  for (const child of children) {
-    total += computeSpread(child, outEdges, visited, spreadMap);
-  }
-  const spread = Math.max(total, 1);
-  spreadMap.set(nodeId, spread);
-  return spread;
-}
-
-type PlacementCtx = {
-  positions: Map<string, { x: number; y: number }>;
-  placed: Set<string>;
-  columns: Map<string, number>;
-  outEdges: Map<string, Edge[]>;
-  spreadMap: Map<string, number>;
-};
-
-/**
- * Place a list of nodes vertically, centered around centerY,
- * using each node's subtree spread to allocate space.
- */
-function spreadNodes(
-  nodeIds: string[],
-  centerY: number,
-  ctx: PlacementCtx
-): void {
-  const spreads: number[] = [];
-  let totalSpread = 0;
-  for (const id of nodeIds) {
-    const s = ctx.spreadMap.get(id) ?? 1;
-    spreads.push(s);
-    totalSpread += s;
-  }
-
-  let y = centerY - ((totalSpread - 1) * STEP_Y) / 2;
-  for (let i = 0; i < nodeIds.length; i++) {
-    const id = nodeIds[i];
-    const s = spreads[i];
-    const nodeCenterY = y + ((s - 1) * STEP_Y) / 2;
-    const col = ctx.columns.get(id) ?? 0;
-    ctx.positions.set(id, { x: col * (NODE_WIDTH + H_GAP), y: nodeCenterY });
-    ctx.placed.add(id);
-    y += s * STEP_Y;
-  }
-}
-
-/**
- * Check if a node has branch handles (true/false/done/loop) on its edges.
- * Used to determine phantom centering behavior.
- */
-function hasBranchHandles(
-  nodeId: string,
-  outEdges: Map<string, Edge[]>
-): boolean {
-  for (const edge of outEdges.get(nodeId) ?? []) {
-    const h = edge.sourceHandle;
-    if (h === "true" || h === "false" || h === "done" || h === "loop") {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Compute immediate spread for a child: 1 for linear, full spread for branching.
- */
-function childPlacementSpread(
-  childId: string,
-  outEdges: Map<string, Edge[]>,
-  spreadMap: Map<string, number>
-): number {
-  const edgeCount = (outEdges.get(childId) ?? []).length;
-  return edgeCount > 1 ? (spreadMap.get(childId) ?? 1) : 1;
-}
-
-/**
- * Place children of a single parent node.
- * - 1 effective child: linear, shares parent Y
- * - 2+ effective children: centered around parent Y.
- *   For branch nodes (true/false handles): ALL children used for centering
- *   (phantoms for already-placed) so true goes above, false below.
- *   For normal nodes: only unplaced children centered around parent.
- */
-function placeChildrenOf(parentId: string, ctx: PlacementCtx): void {
-  const parentPos = ctx.positions.get(parentId);
-  if (!parentPos) {
-    return;
-  }
-
-  const allChildren = sortedChildren(parentId, ctx.outEdges);
-  const unplaced = allChildren.filter((c) => !ctx.placed.has(c));
-
-  if (unplaced.length === 0) {
-    return;
-  }
-
-  // Branch nodes (true/false handles): use ALL children for centering (phantoms)
-  // Normal nodes: only center unplaced children
-  const isBranch = hasBranchHandles(parentId, ctx.outEdges);
-  const childrenToCenter = isBranch ? allChildren : unplaced;
-
-  // Single effective child: linear, share parent Y
-  if (childrenToCenter.length <= 1) {
-    const child = unplaced[0];
-    const col = ctx.columns.get(child) ?? 0;
-    ctx.positions.set(child, {
-      x: col * (NODE_WIDTH + H_GAP),
-      y: parentPos.y,
-    });
-    ctx.placed.add(child);
-    return;
-  }
-
-  // 2+ children: centered around parent Y.
-  // Linear children get spread=1 for even spacing.
-  // Branching children get their full subtree spread.
-  const spreads: number[] = [];
-  let totalSpread = 0;
-  for (const id of childrenToCenter) {
-    const s = childPlacementSpread(id, ctx.outEdges, ctx.spreadMap);
-    spreads.push(s);
-    totalSpread += s;
-  }
-
-  let y = parentPos.y - ((totalSpread - 1) * STEP_Y) / 2;
-  for (let i = 0; i < childrenToCenter.length; i++) {
-    const child = childrenToCenter[i];
-    const s = spreads[i];
-    const centerY = y + ((s - 1) * STEP_Y) / 2;
-    if (!ctx.placed.has(child)) {
-      const col = ctx.columns.get(child) ?? 0;
-      ctx.positions.set(child, {
-        x: col * (NODE_WIDTH + H_GAP),
-        y: centerY,
-      });
-      ctx.placed.add(child);
-    }
-    y += s * STEP_Y;
-  }
-}
-
-/**
- * Place nodes level by level (column by column), left to right.
- * Each parent spreads its children vertically based on their subtree spread.
- */
-function placeLevelByLevel(
-  roots: string[],
-  columns: Map<string, number>,
-  outEdges: Map<string, Edge[]>,
-  spreadMap: Map<string, number>
-): Map<string, { x: number; y: number }> {
-  const ctx: PlacementCtx = {
-    positions: new Map(),
-    placed: new Set(),
-    columns,
-    outEdges,
-    spreadMap,
   };
 
-  let maxCol = 0;
-  for (const col of columns.values()) {
-    if (col > maxCol) {
-      maxCol = col;
+  const visit = (nodeId: string): void => {
+    if (seen.has(nodeId)) {
+      return;
     }
+    seen.add(nodeId);
+    push(nodeId);
+    for (const child of graph.children.get(nodeId) ?? []) {
+      visit(child);
+    }
+  };
+
+  for (const root of roots) {
+    visit(root);
+  }
+  for (const node of realNodes) {
+    visit(node.id);
   }
 
-  // Place roots centered around y=0
-  spreadNodes(roots, 0, ctx);
-
-  // Process columns left to right
-  for (let col = 0; col <= maxCol; col++) {
-    for (const [nodeId, nodeCol] of columns) {
-      if (nodeCol === col && ctx.placed.has(nodeId)) {
-        placeChildrenOf(nodeId, ctx);
-      }
-    }
+  for (let col = 0; col < order.length; col++) {
+    order[col] ??= [];
   }
 
-  return ctx.positions;
+  return order;
 }
 
-/**
- * Build parent map from forward edges.
- */
-function buildParentMap(forwardEdges: Edge[]): Map<string, string[]> {
-  const parents = new Map<string, string[]>();
-  for (const edge of forwardEdges) {
-    const p = parents.get(edge.target);
-    if (p) {
-      if (!p.includes(edge.source)) {
-        p.push(edge.source);
-      }
-    } else {
-      parents.set(edge.target, [edge.source]);
-    }
-  }
-  return parents;
-}
-
-/**
- * Check if all parents of a node are in the same column (siblings).
- */
-function areParentsSiblings(
-  nodeParents: string[],
-  columns: Map<string, number>
-): boolean {
-  const firstCol = columns.get(nodeParents[0]);
-  for (const p of nodeParents) {
-    if (columns.get(p) !== firstCol) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/**
- * Compute the average Y position of a list of parent nodes.
- * Returns undefined if no parents have positions.
- */
-function averageParentY(
-  nodeParents: string[],
-  positions: Map<string, { x: number; y: number }>
+/** Average row of the neighbours that already have one. */
+function averageRow(
+  neighbours: string[],
+  rows: Map<string, number>
 ): number | undefined {
-  let sumY = 0;
+  let sum = 0;
   let count = 0;
-  for (const parentId of nodeParents) {
-    const parentPos = positions.get(parentId);
-    if (parentPos) {
-      sumY += parentPos.y;
+  for (const id of neighbours) {
+    const row = rows.get(id);
+    if (row !== undefined) {
+      sum += row;
       count++;
     }
   }
-  return count > 0 ? sumY / count : undefined;
+  return count > 0 ? sum / count : undefined;
 }
 
 /**
- * Center convergence nodes between their parents, but ONLY when all parents
- * are in the same column (siblings). Shifts uniquely-owned descendants
- * (inDegree=1) to avoid cascading through shared subtrees.
+ * Write one column's rows, keeping every node at least a full node height
+ * apart. Packing can only push nodes down, so the column is shifted back up by
+ * the average displacement and stays centred on where its nodes wanted to be.
  */
-function centerSiblingConvergence(
-  positions: Map<string, { x: number; y: number }>,
-  forwardEdges: Edge[],
-  inDegree: Map<string, number>,
-  columns: Map<string, number>,
-  outEdges: Map<string, Edge[]>
+function packColumn(
+  ids: string[],
+  targets: number[],
+  rows: Map<string, number>
 ): void {
-  const parents = buildParentMap(forwardEdges);
+  const packed: number[] = [];
+  let drift = 0;
 
-  for (const [nodeId, degree] of inDegree) {
-    if (degree <= 1) {
-      continue;
-    }
+  for (let i = 0; i < ids.length; i++) {
+    const min = packed[i - 1] + ROW_STEP;
+    const row = i === 0 ? targets[i] : Math.max(targets[i], min);
+    packed.push(row);
+    drift += row - targets[i];
+  }
 
-    const nodeParents = parents.get(nodeId);
-    const pos = positions.get(nodeId);
-    if (!(nodeParents && pos)) {
-      continue;
-    }
-
-    if (!areParentsSiblings(nodeParents, columns)) {
-      continue;
-    }
-
-    const targetY = averageParentY(nodeParents, positions);
-    if (targetY === undefined) {
-      continue;
-    }
-
-    const deltaY = targetY - pos.y;
-    if (Math.abs(deltaY) < 1) {
-      continue;
-    }
-
-    shiftOwned(nodeId, deltaY, positions, outEdges, inDegree, new Set());
+  const shift = ids.length > 0 ? drift / ids.length : 0;
+  for (let i = 0; i < ids.length; i++) {
+    rows.set(ids[i], packed[i] - shift);
   }
 }
 
 /**
- * Shift a node and its descendants that have inDegree=1 (uniquely owned).
- * Stops at convergence nodes to avoid cascading into shared subtrees.
+ * First pass: sweep left to right, hanging each node off its parents. Every
+ * parent lives in a lower column, so it always has a row by the time its
+ * children are placed.
  */
-function shiftOwned(
-  nodeId: string,
-  deltaY: number,
-  positions: Map<string, { x: number; y: number }>,
-  outEdges: Map<string, Edge[]>,
-  inDegree: Map<string, number>,
-  visited: Set<string>
+function seedRows(order: string[][], graph: Graph): Map<string, number> {
+  const rows = new Map<string, number>();
+
+  for (const ids of order) {
+    const targets: number[] = [];
+    let previous: number | undefined;
+    for (const id of ids) {
+      const fromParents = averageRow(graph.parents.get(id) ?? [], rows);
+      const target =
+        fromParents ?? (previous === undefined ? 0 : previous + ROW_STEP);
+      targets.push(target);
+      previous = target;
+    }
+    packColumn(ids, targets, rows);
+  }
+
+  return rows;
+}
+
+/**
+ * Later passes: pull each node onto the average of its children (right to
+ * left), then back onto the average of its parents (left to right). This is
+ * what centres a branch node between its branches and a join node between the
+ * paths that feed it.
+ */
+function refineRows(
+  order: string[][],
+  graph: Graph,
+  rows: Map<string, number>
 ): void {
-  if (visited.has(nodeId)) {
-    return;
-  }
-  visited.add(nodeId);
+  const sweep = (
+    columnIds: string[],
+    neighboursOf: (id: string) => string[]
+  ): void => {
+    const targets = columnIds.map(
+      (id) => averageRow(neighboursOf(id), rows) ?? rows.get(id) ?? 0
+    );
+    packColumn(columnIds, targets, rows);
+  };
 
-  const pos = positions.get(nodeId);
-  if (pos) {
-    positions.set(nodeId, { x: pos.x, y: pos.y + deltaY });
-  }
-
-  for (const edge of outEdges.get(nodeId) ?? []) {
-    const childDegree = inDegree.get(edge.target) ?? 0;
-    if (childDegree <= 1) {
-      shiftOwned(edge.target, deltaY, positions, outEdges, inDegree, visited);
+  for (let pass = 0; pass < REFINE_PASSES; pass++) {
+    for (let col = order.length - 1; col >= 0; col--) {
+      sweep(order[col], (id) => graph.children.get(id) ?? []);
+    }
+    for (const ids of order) {
+      sweep(ids, (id) => graph.parents.get(id) ?? []);
     }
   }
 }
@@ -490,76 +371,38 @@ function shiftOwned(
  * Compute a clean left-to-right DAG layout for workflow nodes.
  *
  * - Columns via longest-path topological sort (handles convergence)
- * - Rows via level-by-level forward sweep with subtree-spread sizing
+ * - Rows via a layered sweep that keeps every column free of overlap
  * - Edge ordering: true/loop on top, false/done on bottom
- * - Sibling convergence nodes centered between their parents
+ * - Loop bodies lay out to the right of their For Each node; only the edges
+ *   that close a cycle are ignored
  */
 export function computeAutoLayout(
   nodes: Node[],
   edges: Edge[]
 ): Map<string, { x: number; y: number }> {
   const realNodes = nodes.filter((n) => n.type !== "add");
-  const realNodeIds = new Set(realNodes.map((n) => n.id));
-
-  const forwardEdges = edges.filter(
-    (e) =>
-      realNodeIds.has(e.source) &&
-      realNodeIds.has(e.target) &&
-      e.sourceHandle !== "loop"
-  );
-
+  const forwardEdges = forwardEdgesOf(realNodes, edges);
   const graph = buildGraph(realNodes, forwardEdges);
   const roots = findRoots(realNodes, graph.inDegree);
-  const columns = assignColumns(roots, graph.outEdges, graph.inDegree);
+  const columns = assignColumns(roots, graph);
+  const order = orderColumns(realNodes, roots, graph, columns);
 
-  // Phase 1: Compute subtree spreads (bottom-up)
-  const spreadVisited = new Set<string>();
-  const spreadMap = new Map<string, number>();
-  for (const root of roots) {
-    computeSpread(root, graph.outEdges, spreadVisited, spreadMap);
+  const rows = seedRows(order, graph);
+  refineRows(order, graph, rows);
+
+  let topRow = Number.POSITIVE_INFINITY;
+  for (const row of rows.values()) {
+    topRow = Math.min(topRow, row);
   }
-  // Ensure disconnected nodes have spread computed
+  const offset = Number.isFinite(topRow) ? topRow : 0;
+
+  const positions = new Map<string, { x: number; y: number }>();
   for (const node of realNodes) {
-    if (!spreadMap.has(node.id)) {
-      computeSpread(node.id, graph.outEdges, spreadVisited, spreadMap);
-    }
+    positions.set(node.id, {
+      x: (columns.get(node.id) ?? 0) * COLUMN_STEP,
+      y: Math.round((rows.get(node.id) ?? 0) - offset),
+    });
   }
-
-  // Phase 2: Place nodes level by level
-  const positions = placeLevelByLevel(
-    roots,
-    columns,
-    graph.outEdges,
-    spreadMap
-  );
-
-  // Place any unplaced nodes (disconnected)
-  let maxY = 0;
-  for (const pos of positions.values()) {
-    if (pos.y > maxY) {
-      maxY = pos.y;
-    }
-  }
-  let nextUnplacedY = maxY + STEP_Y;
-  for (const node of realNodes) {
-    if (!positions.has(node.id)) {
-      const col = columns.get(node.id) ?? 0;
-      positions.set(node.id, {
-        x: col * (NODE_WIDTH + H_GAP),
-        y: nextUnplacedY,
-      });
-      nextUnplacedY += STEP_Y;
-    }
-  }
-
-  // Phase 3: Center convergence nodes whose parents are siblings (same column)
-  centerSiblingConvergence(
-    positions,
-    forwardEdges,
-    graph.inDegree,
-    columns,
-    graph.outEdges
-  );
 
   return positions;
 }

--- a/lib/workflow/editor/auto-layout.ts
+++ b/lib/workflow/editor/auto-layout.ts
@@ -23,10 +23,6 @@ const V_GAP = 40;
 const COLUMN_STEP = NODE_WIDTH + H_GAP;
 const ROW_STEP = NODE_HEIGHT + V_GAP;
 
-// Two sweeps are enough to pull parents onto their children and children back
-// under their parents; more passes stop changing the picture.
-const REFINE_PASSES = 2;
-
 // An edge with no named handle sits between the upper and the lower handle.
 const UNNAMED_RANK = 0.5;
 
@@ -128,15 +124,15 @@ type Graph = {
   children: Map<string, string[]>;
   parents: Map<string, string[]>;
   inDegree: Map<string, number>;
-  /** Where the edge leaves its source, keyed "source->target". */
-  edgeRank: Map<string, number>;
+  /** Edges that leave a named handle, keyed "source->target". */
+  branchEdges: Set<string>;
 };
 
 function buildGraph(realNodes: Node[], forwardEdges: Edge[]): Graph {
   const children = new Map<string, string[]>();
   const parents = new Map<string, string[]>();
   const inDegree = new Map<string, number>();
-  const edgeRank = new Map<string, number>();
+  const branchEdges = new Set<string>();
 
   for (const node of realNodes) {
     children.set(node.id, []);
@@ -159,14 +155,13 @@ function buildGraph(realNodes: Node[], forwardEdges: Edge[]): Graph {
       children.get(node.id)?.push(edge.target);
       parents.get(edge.target)?.push(node.id);
       inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1);
-      edgeRank.set(
-        `${node.id}->${edge.target}`,
-        sourceHandleRank(edge.sourceHandle) ?? UNNAMED_RANK
-      );
+      if (sourceHandleRank(edge.sourceHandle) !== undefined) {
+        branchEdges.add(`${node.id}->${edge.target}`);
+      }
     }
   }
 
-  return { children, parents, inDegree, edgeRank };
+  return { children, parents, inDegree, branchEdges };
 }
 
 function findRoots(realNodes: Node[], inDegree: Map<string, number>): string[] {
@@ -226,24 +221,21 @@ function assignColumns(roots: string[], graph: Graph): Map<string, number> {
 }
 
 /**
- * The branch turns taken to reach a node, one entry per step: which root it
- * came from, then where each edge left its source. Comparing two of these
- * decides which node belongs higher in a column, so a true branch stays above
- * a false branch even where the two meet nodes placed from another path.
- *
- * A node is reached through the parent that fixed its column, which is the one
- * furthest right; nodes on a cycle with no path from a root sort last.
+ * Pick one parent per node, so the graph reduces to a tree that can be given
+ * tidy bands. A branch owns its target: a node reached from a named handle
+ * hangs off that node, even when another path also leads into it, which is what
+ * keeps a true target above the false target it later merges with. Failing
+ * that, a node hangs off the parent furthest to the right. The remaining edges
+ * are drawn but do not decide where anything sits.
  */
-function branchPaths(
+function spanningTree(
   realNodes: Node[],
   roots: string[],
   graph: Graph,
   columns: Map<string, number>
-): Map<string, number[]> {
-  const paths = new Map<string, number[]>();
-  for (const [index, root] of roots.entries()) {
-    paths.set(root, [index]);
-  }
+): { roots: string[]; children: Map<string, string[]> } {
+  const treeParent = new Map<string, string>();
+  const attached = new Set(roots);
 
   const byColumn: string[][] = [];
   for (const node of realNodes) {
@@ -252,182 +244,95 @@ function branchPaths(
     byColumn[col].push(node.id);
   }
 
-  for (const ids of byColumn) {
+  const treeRoots = [...roots];
+
+  for (const [col, ids] of byColumn.entries()) {
     for (const id of ids ?? []) {
-      if (paths.has(id)) {
+      if (attached.has(id)) {
         continue;
       }
       let from: string | undefined;
       let fromColumn = Number.NEGATIVE_INFINITY;
+      let fromBranch = false;
       for (const parent of graph.parents.get(id) ?? []) {
-        const col = columns.get(parent) ?? 0;
-        if (paths.has(parent) && col > fromColumn) {
+        const parentColumn = columns.get(parent) ?? 0;
+        if (!attached.has(parent) || parentColumn >= col) {
+          continue;
+        }
+        const isBranch = graph.branchEdges.has(`${parent}->${id}`);
+        const better =
+          isBranch === fromBranch ? parentColumn > fromColumn : isBranch;
+        if (better) {
           from = parent;
-          fromColumn = col;
+          fromColumn = parentColumn;
+          fromBranch = isBranch;
         }
       }
-      const parentPath = from === undefined ? undefined : paths.get(from);
-      if (parentPath) {
-        paths.set(id, [
-          ...parentPath,
-          graph.edgeRank.get(`${from}->${id}`) ?? UNNAMED_RANK,
-        ]);
+      attached.add(id);
+      if (from === undefined) {
+        treeRoots.push(id);
+      } else {
+        treeParent.set(id, from);
       }
     }
   }
 
+  // Children keep the order their edges leave the node: upper handle first.
+  const children = new Map<string, string[]>();
   for (const node of realNodes) {
-    if (!paths.has(node.id)) {
-      paths.set(node.id, [Number.POSITIVE_INFINITY]);
-    }
+    const kept = (graph.children.get(node.id) ?? []).filter(
+      (child) => treeParent.get(child) === node.id
+    );
+    children.set(node.id, kept);
   }
 
-  return paths;
-}
-
-function comparePaths(a: number[], b: number[]): number {
-  for (let i = 0; i < Math.min(a.length, b.length); i++) {
-    if (a[i] !== b[i]) {
-      return a[i] - b[i];
-    }
-  }
-  return a.length - b.length;
+  return { roots: treeRoots, children };
 }
 
 /**
- * Vertical order of each column: upper branches first, and within a branch the
- * order the nodes were declared.
+ * Give every subtree its own band of rows. A node with no branches of its own
+ * takes one row; a node that branches spans the bands of its branches and sits
+ * in the middle of them. Bands never overlap, so two branches never interleave
+ * and their edges have no reason to cross.
  */
-function orderColumns(
-  realNodes: Node[],
-  roots: string[],
-  graph: Graph,
-  columns: Map<string, number>
-): string[][] {
-  const paths = branchPaths(realNodes, roots, graph, columns);
-  const order: string[][] = [];
-  const seq = new Map<string, number>();
-
-  for (const [index, node] of realNodes.entries()) {
-    const col = columns.get(node.id) ?? 0;
-    order[col] = order[col] ?? [];
-    order[col].push(node.id);
-    seq.set(node.id, index);
-  }
-
-  for (let col = 0; col < order.length; col++) {
-    order[col] = (order[col] ?? []).sort((a, b) => {
-      const byPath = comparePaths(paths.get(a) ?? [], paths.get(b) ?? []);
-      return byPath === 0 ? (seq.get(a) ?? 0) - (seq.get(b) ?? 0) : byPath;
-    });
-  }
-
-  return order;
-}
-
-/** Average row of the neighbours that already have one. */
-function averageRow(
-  neighbours: string[],
-  rows: Map<string, number>
-): number | undefined {
-  let sum = 0;
-  let count = 0;
-  for (const id of neighbours) {
-    const row = rows.get(id);
-    if (row !== undefined) {
-      sum += row;
-      count++;
-    }
-  }
-  return count > 0 ? sum / count : undefined;
-}
-
-/**
- * Write one column's rows, keeping every node at least a full node height
- * apart. Packing can only push nodes down, so the column is shifted back up by
- * the average displacement and stays centred on where its nodes wanted to be.
- */
-function packColumn(
-  ids: string[],
-  targets: number[],
-  rows: Map<string, number>
-): void {
-  const packed: number[] = [];
-  let drift = 0;
-
-  for (let i = 0; i < ids.length; i++) {
-    const min = packed[i - 1] + ROW_STEP;
-    const row = i === 0 ? targets[i] : Math.max(targets[i], min);
-    packed.push(row);
-    drift += row - targets[i];
-  }
-
-  const shift = ids.length > 0 ? drift / ids.length : 0;
-  for (let i = 0; i < ids.length; i++) {
-    rows.set(ids[i], packed[i] - shift);
-  }
-}
-
-/**
- * First pass: sweep left to right, hanging each node off its parents. Every
- * parent lives in a lower column, so it always has a row by the time its
- * children are placed.
- */
-function seedRows(order: string[][], graph: Graph): Map<string, number> {
+function assignRows(
+  treeRoots: string[],
+  children: Map<string, string[]>
+): Map<string, number> {
   const rows = new Map<string, number>();
+  let nextRow = 0;
 
-  for (const ids of order) {
-    const targets: number[] = [];
-    let previous: number | undefined;
-    for (const id of ids) {
-      const fromParents = averageRow(graph.parents.get(id) ?? [], rows);
-      const target =
-        fromParents ?? (previous === undefined ? 0 : previous + ROW_STEP);
-      targets.push(target);
-      previous = target;
+  const place = (id: string): { first: number; last: number } => {
+    const kids = children.get(id) ?? [];
+    if (kids.length === 0) {
+      const row = nextRow++;
+      rows.set(id, row * ROW_STEP);
+      return { first: row, last: row };
     }
-    packColumn(ids, targets, rows);
+
+    let first = Number.POSITIVE_INFINITY;
+    let last = Number.NEGATIVE_INFINITY;
+    for (const kid of kids) {
+      const band = place(kid);
+      first = Math.min(first, band.first);
+      last = Math.max(last, band.last);
+    }
+    rows.set(id, ((first + last) / 2) * ROW_STEP);
+    return { first, last };
+  };
+
+  for (const root of treeRoots) {
+    place(root);
   }
 
   return rows;
 }
 
 /**
- * Later passes: pull each node onto the average of its children (right to
- * left), then back onto the average of its parents (left to right). This is
- * what centres a branch node between its branches and a join node between the
- * paths that feed it.
- */
-function refineRows(
-  order: string[][],
-  graph: Graph,
-  rows: Map<string, number>
-): void {
-  const sweep = (
-    columnIds: string[],
-    neighboursOf: (id: string) => string[]
-  ): void => {
-    const targets = columnIds.map(
-      (id) => averageRow(neighboursOf(id), rows) ?? rows.get(id) ?? 0
-    );
-    packColumn(columnIds, targets, rows);
-  };
-
-  for (let pass = 0; pass < REFINE_PASSES; pass++) {
-    for (let col = order.length - 1; col >= 0; col--) {
-      sweep(order[col], (id) => graph.children.get(id) ?? []);
-    }
-    for (const ids of order) {
-      sweep(ids, (id) => graph.parents.get(id) ?? []);
-    }
-  }
-}
-
-/**
  * Compute a clean left-to-right DAG layout for workflow nodes.
  *
  * - Columns via longest-path topological sort (handles convergence)
- * - Rows via a layered sweep that keeps every column free of overlap
+ * - Rows via tidy bands: each branch owns a range of rows nothing else uses
  * - Branches follow their handles: true/done above, false/loop below
  * - Loop bodies lay out to the right of their For Each node; only the edges
  *   that close a cycle are ignored
@@ -441,10 +346,8 @@ export function computeAutoLayout(
   const graph = buildGraph(realNodes, forwardEdges);
   const roots = findRoots(realNodes, graph.inDegree);
   const columns = assignColumns(roots, graph);
-  const order = orderColumns(realNodes, roots, graph, columns);
-
-  const rows = seedRows(order, graph);
-  refineRows(order, graph, rows);
+  const tree = spanningTree(realNodes, roots, graph, columns);
+  const rows = assignRows(tree.roots, tree.children);
 
   let topRow = Number.POSITIVE_INFINITY;
   for (const row of rows.values()) {

--- a/lib/workflow/source-handles.ts
+++ b/lib/workflow/source-handles.ts
@@ -1,0 +1,34 @@
+/**
+ * Named source handles, listed in the order they render down the right edge of
+ * a node. Auto-layout reads the same order, so a branch always lays out on the
+ * side its handle sits on.
+ */
+export type SourceHandle = {
+  id: string;
+  label: string;
+  topPercent: number;
+};
+
+export const FOR_EACH_SOURCE_HANDLES: SourceHandle[] = [
+  { id: "done", label: "done", topPercent: 30 },
+  { id: "loop", label: "loop", topPercent: 70 },
+];
+
+export const CONDITION_SOURCE_HANDLES: SourceHandle[] = [
+  { id: "true", label: "true", topPercent: 30 },
+  { id: "false", label: "false", topPercent: 70 },
+];
+
+const rank = new Map<string, number>();
+for (const handles of [FOR_EACH_SOURCE_HANDLES, CONDITION_SOURCE_HANDLES]) {
+  for (const [index, handle] of handles.entries()) {
+    rank.set(handle.id, index);
+  }
+}
+
+/** How far down a node its handle sits, 0 for the upper one, 1 for the lower. */
+export function sourceHandleRank(
+  handle: string | null | undefined
+): number | undefined {
+  return handle === null || handle === undefined ? undefined : rank.get(handle);
+}

--- a/tests/unit/auto-layout.test.ts
+++ b/tests/unit/auto-layout.test.ts
@@ -68,6 +68,44 @@ function rowOf(
   return positions.get(id)?.y ?? 0;
 }
 
+/** Pairs of edges whose endpoints swap vertical order while their spans overlap. */
+function crossings(
+  positions: Map<string, { x: number; y: number }>,
+  edges: TestEdge[]
+): string[] {
+  const found: string[] = [];
+  for (let i = 0; i < edges.length; i++) {
+    for (let j = i + 1; j < edges.length; j++) {
+      const a = edges[i];
+      const b = edges[j];
+      const as = positions.get(a.source);
+      const at = positions.get(a.target);
+      const bs = positions.get(b.source);
+      const bt = positions.get(b.target);
+      if (!(as && at && bs && bt)) {
+        continue;
+      }
+      const overlap =
+        Math.min(at.x, bt.x) > Math.max(as.x, bs.x) ||
+        (as.x === bs.x && at.x === bt.x);
+      if (!overlap) {
+        continue;
+      }
+      if ((as.y - bs.y) * (at.y - bt.y) < 0) {
+        found.push(`${a.source}->${a.target} x ${b.source}->${b.target}`);
+      }
+    }
+  }
+  return found;
+}
+
+function rowsOf(
+  positions: Map<string, { x: number; y: number }>,
+  ids: string[]
+): number[] {
+  return ids.map((id) => positions.get(id)?.y ?? 0);
+}
+
 describe("computeAutoLayout", () => {
   it("keeps a loop body clear of the branch that runs beside it", () => {
     const { nodes, edges } = graph(
@@ -208,6 +246,85 @@ describe("computeAutoLayout", () => {
 
       expect(rowOf(positions, "only")).toBe(rowOf(positions, "branch"));
     }
+  });
+
+  it("gives each branch its own band of rows", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "split", "up1", "up2", "up3", "down1", "down2", "down3"],
+      [
+        ["trigger", "split"],
+        ["split", "up1", "true"],
+        ["up1", "up2"],
+        ["up2", "up3"],
+        ["split", "down1", "false"],
+        ["down1", "down2"],
+        ["down2", "down3"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    const upper = rowsOf(positions, ["up1", "up2", "up3"]);
+    const lower = rowsOf(positions, ["down1", "down2", "down3"]);
+    expect(Math.max(...upper)).toBeLessThan(Math.min(...lower));
+    expect(crossings(positions, edges)).toEqual([]);
+  });
+
+  it("does not run a branching node's rows through a neighbouring branch", () => {
+    const { nodes, edges } = graph(
+      [
+        "trigger",
+        "split",
+        "first",
+        "firstYes",
+        "firstNo",
+        "second",
+        "secondOnly",
+        "third",
+        "thirdYes",
+        "thirdNo",
+      ],
+      [
+        ["trigger", "split"],
+        ["split", "first", "true"],
+        ["first", "firstYes", "true"],
+        ["first", "firstNo", "false"],
+        ["split", "second"],
+        ["second", "secondOnly", "true"],
+        ["split", "third", "false"],
+        ["third", "thirdYes", "true"],
+        ["third", "thirdNo", "false"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(crossings(positions, edges)).toEqual([]);
+    expect(overlaps(positions)).toEqual([]);
+    const firstBand = rowsOf(positions, ["first", "firstYes", "firstNo"]);
+    const secondBand = rowsOf(positions, ["second", "secondOnly"]);
+    const thirdBand = rowsOf(positions, ["third", "thirdYes", "thirdNo"]);
+    expect(Math.max(...firstBand)).toBeLessThan(Math.min(...secondBand));
+    expect(Math.max(...secondBand)).toBeLessThan(Math.min(...thirdBand));
+  });
+
+  it("keeps both sides apart when the branches merge again", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "exists", "cast", "alert"],
+      [
+        ["trigger", "exists"],
+        ["exists", "cast", "true"],
+        ["exists", "alert", "false"],
+        ["alert", "cast"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(rowOf(positions, "cast")).toBeLessThan(rowOf(positions, "exists"));
+    expect(rowOf(positions, "alert")).toBeGreaterThan(
+      rowOf(positions, "exists")
+    );
   });
 
   it("lays out a loop whose body feeds back into the loop node", () => {

--- a/tests/unit/auto-layout.test.ts
+++ b/tests/unit/auto-layout.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import { computeAutoLayout } from "@/lib/workflow/editor/auto-layout";
+
+type TestNode = {
+  id: string;
+  type?: string;
+  position: { x: number; y: number };
+};
+type TestEdge = {
+  source: string;
+  target: string;
+  sourceHandle?: string | null;
+};
+
+const NODE_HEIGHT = 192;
+const COLUMN_STEP = 252;
+
+function graph(
+  ids: string[],
+  links: [string, string, string?][]
+): { nodes: TestNode[]; edges: TestEdge[] } {
+  return {
+    nodes: ids.map((id, index) => ({
+      id,
+      type: index === 0 ? "trigger" : "action",
+      position: { x: 0, y: 0 },
+    })),
+    edges: links.map(([source, target, sourceHandle]) => ({
+      source,
+      target,
+      sourceHandle: sourceHandle ?? null,
+    })),
+  };
+}
+
+function overlaps(positions: Map<string, { x: number; y: number }>): string[] {
+  const byColumn = new Map<number, { id: string; y: number }[]>();
+  for (const [id, position] of positions) {
+    const column = Math.round(position.x / COLUMN_STEP);
+    const list = byColumn.get(column) ?? [];
+    list.push({ id, y: position.y });
+    byColumn.set(column, list);
+  }
+
+  const found: string[] = [];
+  for (const list of byColumn.values()) {
+    list.sort((a, b) => a.y - b.y);
+    for (let i = 1; i < list.length; i++) {
+      if (list[i].y - list[i - 1].y < NODE_HEIGHT) {
+        found.push(`${list[i - 1].id}/${list[i].id}`);
+      }
+    }
+  }
+  return found;
+}
+
+function columnOf(
+  positions: Map<string, { x: number; y: number }>,
+  id: string
+): number {
+  return Math.round((positions.get(id)?.x ?? 0) / COLUMN_STEP);
+}
+
+function rowOf(
+  positions: Map<string, { x: number; y: number }>,
+  id: string
+): number {
+  return positions.get(id)?.y ?? 0;
+}
+
+describe("computeAutoLayout", () => {
+  it("keeps a loop body clear of the branch that runs beside it", () => {
+    const { nodes, edges } = graph(
+      [
+        "trigger",
+        "chainlog",
+        "hole",
+        "dirt",
+        "buildGlobal",
+        "pushGlobal",
+        "registry",
+        "buildList",
+        "loop",
+        "clipper",
+        "liquidatable",
+        "chop",
+        "price",
+        "buildMetrics",
+        "pushMetrics",
+        "collect",
+      ],
+      [
+        ["trigger", "chainlog"],
+        ["chainlog", "hole"],
+        ["hole", "dirt"],
+        ["dirt", "buildGlobal"],
+        ["buildGlobal", "pushGlobal"],
+        ["chainlog", "registry"],
+        ["registry", "buildList"],
+        ["buildList", "loop"],
+        ["loop", "clipper", "loop"],
+        ["clipper", "liquidatable"],
+        ["liquidatable", "chop", "true"],
+        ["chop", "price"],
+        ["price", "buildMetrics"],
+        ["buildMetrics", "pushMetrics"],
+        ["pushMetrics", "collect"],
+        ["liquidatable", "collect", "false"],
+        ["loop", "collect", "done"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(overlaps(positions)).toEqual([]);
+    expect(columnOf(positions, "clipper")).toBeGreaterThan(
+      columnOf(positions, "loop")
+    );
+    expect(columnOf(positions, "collect")).toBeGreaterThan(
+      columnOf(positions, "pushMetrics")
+    );
+  });
+
+  it("gives every column at least one node height of clearance", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "fan", "a", "b", "c", "d", "join"],
+      [
+        ["trigger", "fan"],
+        ["fan", "a"],
+        ["fan", "b"],
+        ["fan", "c"],
+        ["fan", "d"],
+        ["a", "join"],
+        ["b", "join"],
+        ["c", "join"],
+        ["d", "join"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(overlaps(positions)).toEqual([]);
+  });
+
+  it("keeps a linear chain on one row, one column per step", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "a", "b", "c"],
+      [
+        ["trigger", "a"],
+        ["a", "b"],
+        ["b", "c"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    for (const id of ["a", "b", "c"]) {
+      expect(rowOf(positions, id)).toBe(rowOf(positions, "trigger"));
+    }
+    expect(columnOf(positions, "c")).toBe(3);
+  });
+
+  it("puts the true branch above the false branch, centred on the condition", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "condition", "yes", "no"],
+      [
+        ["trigger", "condition"],
+        ["condition", "yes", "true"],
+        ["condition", "no", "false"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(rowOf(positions, "yes")).toBeLessThan(rowOf(positions, "no"));
+    const middle = (rowOf(positions, "yes") + rowOf(positions, "no")) / 2;
+    expect(Math.abs(middle - rowOf(positions, "condition"))).toBeLessThan(1);
+  });
+
+  it("lays out a loop whose body feeds back into the loop node", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "loop", "body", "collect"],
+      [
+        ["trigger", "loop"],
+        ["loop", "body", "loop"],
+        ["body", "loop"],
+        ["loop", "collect", "done"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(positions.size).toBe(4);
+    expect(overlaps(positions)).toEqual([]);
+    expect(columnOf(positions, "body")).toBeGreaterThan(
+      columnOf(positions, "loop")
+    );
+  });
+
+  it("places disconnected nodes without stacking them on the flow", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "a", "orphan1", "orphan2"],
+      [["trigger", "a"]]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(positions.size).toBe(4);
+    expect(overlaps(positions)).toEqual([]);
+  });
+
+  it("ignores the placeholder add nodes", () => {
+    const nodes: TestNode[] = [
+      { id: "trigger", type: "trigger", position: { x: 0, y: 0 } },
+      { id: "a", type: "action", position: { x: 0, y: 0 } },
+      { id: "add-1", type: "add", position: { x: 0, y: 0 } },
+    ];
+    const edges: TestEdge[] = [
+      { source: "trigger", target: "a" },
+      { source: "a", target: "add-1" },
+    ];
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(positions.has("add-1")).toBe(false);
+    expect(positions.size).toBe(2);
+  });
+});

--- a/tests/unit/auto-layout.test.ts
+++ b/tests/unit/auto-layout.test.ts
@@ -177,6 +177,39 @@ describe("computeAutoLayout", () => {
     expect(Math.abs(middle - rowOf(positions, "condition"))).toBeLessThan(1);
   });
 
+  it("puts the done branch above the loop body, the way the handles sit", () => {
+    const { nodes, edges } = graph(
+      ["trigger", "each", "body", "collect"],
+      [
+        ["trigger", "each"],
+        ["each", "body", "loop"],
+        ["each", "collect", "done"],
+      ]
+    );
+
+    const positions = computeAutoLayout(nodes, edges);
+
+    expect(rowOf(positions, "collect")).toBeLessThan(rowOf(positions, "body"));
+    const middle = (rowOf(positions, "collect") + rowOf(positions, "body")) / 2;
+    expect(Math.abs(middle - rowOf(positions, "each"))).toBeLessThan(1);
+  });
+
+  it("keeps a lone branch on its parent's row whichever handle it leaves from", () => {
+    for (const handle of ["true", "false", "loop", "done"]) {
+      const { nodes, edges } = graph(
+        ["trigger", "branch", "only"],
+        [
+          ["trigger", "branch"],
+          ["branch", "only", handle],
+        ]
+      );
+
+      const positions = computeAutoLayout(nodes, edges);
+
+      expect(rowOf(positions, "only")).toBe(rowOf(positions, "branch"));
+    }
+  });
+
   it("lays out a loop whose body feeds back into the loop node", () => {
     const { nodes, edges } = graph(
       ["trigger", "loop", "body", "collect"],


### PR DESCRIPTION
## Problem

Auto-layout put nodes on top of each other, pushed loop bodies to the far left of the canvas, sent branches to the wrong side of the node they leave from, and let branches cross each other.

- **Overlap.** Children were placed one parent at a time, with no knowledge of what already sat in a column, and centring produced half-row offsets (116px) while a node is 192px tall.
- **Loop bodies.** Edges on the `loop` handle were dropped from the graph before layout. That left the body head with in-degree 0, so it was treated as a root and given column 0, far to the left of the For Each that owns it, with its edges running backwards across the canvas.
- **Branch sides.** A For Each renders `done` at 30% and `loop` at 70%, so the body leaves the lower handle, but the layout ranked `loop` as an upper branch alongside `true`. The body climbed to the top row while the `done` edge dived to the bottom, crossing right after the node.
- **Crossing branches.** Rows were packed column by column, each node pulled towards the average of its neighbours. Nothing reserved space for a branch, so one branch's nodes drifted into rows another branch was using.
- **A branch losing its side.** Where a branch's target was also reachable through the other branch, the target inherited the row of whichever path reached it last, which is how a `true` target ended up level with the node it came from while `false` went down.

## Change

- Columns come from a longest-path topological sort, as before.
- The graph then reduces to a tree, one parent per node, and every subtree gets a contiguous band of rows nothing else uses. A node with no branches of its own takes one row; a node that branches spans the bands below it and sits in the middle of them. Bands cannot overlap, so two branches never interleave and their edges have no reason to cross.
- A branch owns its target: a node reached from a named handle hangs off that handle even when another path also leads into it. A node with both handles connected therefore always has one target above it and one below, and only takes the middle row when the other handle has nothing on it.
- `loop` edges are ordinary forward edges again, so a For Each body lays out to the right of its loop node. Only edges that actually close a cycle are dropped, detected as DFS back edges, which also covers a user wiring a node back into an ancestor.
- The handle list moves to `lib/workflow/source-handles.ts`, so the node component and the layout share one definition of which handle sits where: `true` and `done` above, `false` and `loop` below.

## Checks

- New unit tests: the workflow shape from the report, wide fan-out and fan-in, linear chains, `true` above `false`, `done` above the loop body, branches keeping their own band, no crossings where a branching node sits beside a single-branch one, both sides staying apart when the branches merge again, a lone branch keeping its parent's row, a loop whose body feeds back into its loop node, disconnected nodes and `add` placeholders.
- 1200 generated graphs across three shapes (trees, graphs with joins, graphs with cycles): every node placed, no column overlap, output stable across runs. Zero edge crossings on all 400 tree-shaped graphs, against 179 before this change. The upper handle's target is never below the lower handle's target.
- Onboarding seed fixtures still lay out free of overlap.
- Full unit suite, lint and type-check pass.