### PR TITLE
test(analytics): select the run source through its filter popover

### DIFF
--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -30,6 +30,7 @@ export function FilterPopover({
   onSelectAll,
   children,
 }: FilterPopoverProps): ReactNode {
+  const slug = label.toLowerCase().replace(/\s+/g, "-");
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -38,6 +39,7 @@ export function FilterPopover({
             "h-8 gap-1.5 px-2.5 text-xs",
             selectedCount > 0 && "border-primary/40"
           )}
+          data-testid={`filter-${slug}`}
           size="sm"
           variant="outline"
         >
@@ -50,7 +52,11 @@ export function FilterPopover({
           <ChevronDown className="size-3.5 text-muted-foreground" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-64 p-0">
+      <PopoverContent
+        align="start"
+        className="w-64 p-0"
+        data-testid={`filter-${slug}-panel`}
+      >
         <div className="max-h-80 overflow-y-auto p-1.5">{children}</div>
         <div className="flex items-center justify-between border-t px-2 py-1.5">
           <span className="text-[11px] text-muted-foreground">

--- a/tests/e2e/playwright/analytics-gas.test.ts
+++ b/tests/e2e/playwright/analytics-gas.test.ts
@@ -56,10 +56,18 @@ test.describe("Analytics Gas Tracking", () => {
     );
 
     // Filter by workflow source
-    const workflowFilter = page.locator(
-      'nav[aria-label="Source"] button:has-text("Workflow")'
+    const filteredRuns = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/analytics/runs?") &&
+        response.url().includes("source=workflow")
     );
-    await workflowFilter.click();
+    await page.getByTestId("filter-source").click();
+    await page
+      .getByTestId("filter-source-panel")
+      .getByRole("button", { name: "Workflow" })
+      .click();
+    await filteredRuns;
+    await page.keyboard.press("Escape");
 
     // Wait for table to reload after filter
     await expect(page.getByTestId("runs-table")).toHaveAttribute(


### PR DESCRIPTION
## Problem

The staging pipeline failed on `analytics-gas.test.ts:42` -- `workflow runs table loads with data` timed out for 60s waiting on `nav[aria-label="Source"] button:has-text("Workflow")`.

That selector no longer resolves. The run filters were reworked into popovers, so the inline `nav` of source buttons the test clicked is gone: the source dimension is now a trigger button that opens a panel of checkboxes.

## Change

- `FilterPopover` exposes a stable test id on its trigger (`filter-<label>`) and on its panel (`filter-<label>-panel`), so tests address a filter dimension by name instead of by its chrome. Every dimension (Status, Network, Duration, Gas, Source) gets one.
- The test opens the source popover and ticks `Workflow` inside it.
- After the click it waits for the `/api/analytics/runs` response carrying `source=workflow`. Without that wait, `data-ready` still reads `true` from the previous load and the row assertions run against the unfiltered listing -- confirmed locally, where the rows read `Direct` right after the click.

## Verification

Ran the interaction against a local dev server with the analytics seed data: the request goes out as `/api/analytics/runs?range=7d&source=workflow` and the table narrows from 50 rows to the 30 seeded workflow runs.

`pnpm check` and `pnpm type-check` are clean.