### PR TITLE
fix: verify Solana transaction signatures on chain instead of passing them through

### DIFF
--- a/lib/rpc/provider-factory.ts
+++ b/lib/rpc/provider-factory.ts
@@ -19,6 +19,7 @@ import {
   type SolanaRpcMetricsCollector,
 } from "@/lib/rpc/providers/solana";
 import { resolveRpcConfig } from "./config-service";
+import { isSolanaChain } from "./solana-chains";
 
 /**
  * Resolve the appropriate RPC metrics collector based on environment.
@@ -85,15 +86,11 @@ async function getFailoverCallback(): Promise<FailoverStateChangeCallback> {
   return cachedFailoverCallback;
 }
 
-// Solana chain IDs (non-EVM)
-const SOLANA_CHAIN_IDS = new Set([101, 103]);
-
-/**
- * Check if a chain ID is a Solana chain
- */
-export function isSolanaChain(chainId: number): boolean {
-  return SOLANA_CHAIN_IDS.has(chainId);
-}
+// Solana chain IDs (non-EVM). The set and the test live in ./solana-chains so
+// callers that cannot take this module's graph (ethers, @solana/web3.js,
+// safeFetch, the db client) can still ask; re-exported here so every existing
+// caller and test mock keeps its import path.
+export { isSolanaChain } from "./solana-chains";
 
 export type GetProviderOptions = {
   chainId: number;

--- a/lib/rpc/providers/solana.ts
+++ b/lib/rpc/providers/solana.ts
@@ -234,7 +234,11 @@ export class SolanaProviderManager {
     return this.primaryConnection;
   }
 
-  private getFallbackConnection(): Connection | null {
+  // Public for the same reason RpcProviderManager.getFallbackProvider is: a
+  // read whose "not there" answer is a successful call never triggers
+  // failover, so callers that must not trust a single endpoint's silence
+  // (lib/web3/verify-receipt.ts) read the fallback explicitly.
+  getFallbackConnection(): Connection | null {
     if (!this.fallbackConnection && this.config.fallbackRpcUrl) {
       this.fallbackConnection = this.createConnection(
         this.config.fallbackRpcUrl

--- a/lib/rpc/solana-chains.ts
+++ b/lib/rpc/solana-chains.ts
@@ -1,0 +1,20 @@
+/**
+ * Which chain ids are Solana, and nothing else.
+ *
+ * Split out of provider-factory (which re-exports isSolanaChain, so callers
+ * and their test mocks keep their existing import path) because that module
+ * reaches ethers, @solana/web3.js, safeFetch and the database client. The
+ * Workflow DevKit compiles lib/workflow/executor into a workflow-function
+ * bundle where Node modules are forbidden, and the executor's transaction-hash
+ * guard needs this test. Keep this module dependency-free.
+ */
+
+// Solana chain IDs (non-EVM)
+const SOLANA_CHAIN_IDS = new Set([101, 103]);
+
+/**
+ * Check if a chain ID is a Solana chain
+ */
+export function isSolanaChain(chainId: number): boolean {
+  return SOLANA_CHAIN_IDS.has(chainId);
+}

--- a/lib/web3/validate-chain-address.ts
+++ b/lib/web3/validate-chain-address.ts
@@ -1,10 +1,11 @@
 import { PublicKey } from "@solana/web3.js";
-import bs58 from "bs58";
 import { ethers } from "ethers";
 import { isSolanaChain } from "@/lib/rpc/provider-factory";
 
-const EVM_TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
-const SOLANA_SIGNATURE_BYTE_LENGTH = 64;
+// Lives in a leaf module with no @solana/web3.js or ethers import so bundles
+// that forbid Node modules can reach it; re-exported here so callers of this
+// module do not move.
+export { validateChainTxHash } from "./validate-chain-tx-hash";
 
 /**
  * Validates an address against the format the chain actually uses: base58
@@ -26,21 +27,6 @@ export function validateChainAddress(
     }
   }
   return ethers.isAddress(address);
-}
-
-/**
- * Validates a transaction hash/signature against the chain's format: a
- * 64-byte base58 signature for Solana, a 32-byte 0x-hex hash for EVM.
- */
-export function validateChainTxHash(hash: string, chainId: number): boolean {
-  if (isSolanaChain(chainId)) {
-    try {
-      return bs58.decode(hash).length === SOLANA_SIGNATURE_BYTE_LENGTH;
-    } catch {
-      return false;
-    }
-  }
-  return EVM_TX_HASH_PATTERN.test(hash);
 }
 
 /**

--- a/lib/web3/validate-chain-tx-hash.ts
+++ b/lib/web3/validate-chain-tx-hash.ts
@@ -1,0 +1,32 @@
+/**
+ * Transaction hash/signature validation, split out of validate-chain-address
+ * (which re-exports it, so callers keep their import path).
+ *
+ * validateChainAddress needs @solana/web3.js's PublicKey and ethers; this
+ * check needs neither, only a base58 decode and a length. Keeping them apart
+ * matters because the Workflow DevKit compiles lib/workflow/executor into a
+ * workflow-function bundle where Node modules are forbidden, and the
+ * executor's transaction-hash guard needs this check. bs58 and base-x
+ * underneath it are pure ESM over Uint8Array with no Node builtins, so they
+ * survive that bundler. Do not add an import here that would not.
+ */
+import bs58 from "bs58";
+import { isSolanaChain } from "@/lib/rpc/solana-chains";
+
+const EVM_TX_HASH_PATTERN = /^0x[a-fA-F0-9]{64}$/;
+const SOLANA_SIGNATURE_BYTE_LENGTH = 64;
+
+/**
+ * Validates a transaction hash/signature against the chain's format: a
+ * 64-byte base58 signature for Solana, a 32-byte 0x-hex hash for EVM.
+ */
+export function validateChainTxHash(hash: string, chainId: number): boolean {
+  if (isSolanaChain(chainId)) {
+    try {
+      return bs58.decode(hash).length === SOLANA_SIGNATURE_BYTE_LENGTH;
+    } catch {
+      return false;
+    }
+  }
+  return EVM_TX_HASH_PATTERN.test(hash);
+}

--- a/lib/web3/verify-receipt.ts
+++ b/lib/web3/verify-receipt.ts
@@ -14,10 +14,12 @@
  * visible) resolves to `verified: false`, never `verified: true`.
  */
 import "server-only";
+import type { SignatureStatus } from "@solana/web3.js";
 import { ethers } from "ethers";
 import { resolveRpcConfig } from "@/lib/rpc/config-service";
 import { isSolanaChain } from "@/lib/rpc/provider-factory";
 import { RpcProviderManager } from "@/lib/rpc/providers";
+import { SolanaProviderManager } from "@/lib/rpc/providers/solana";
 import { sleep } from "@/lib/sleep";
 
 export type ReceiptStatus =
@@ -138,6 +140,29 @@ async function buildVerificationManager(
       fallbackRpcUrl: config.fallbackRpcUrl,
       chainName: config.chainName,
       chainId,
+      maxRetries: VERIFY_MAX_RETRIES,
+      timeoutMs: VERIFY_TIMEOUT_MS,
+    },
+  });
+}
+
+/**
+ * Constructed directly rather than through createSolanaProviderManager: that
+ * cache is keyed by URL alone, so it would hand back the adapter's manager with
+ * its own retry count and 30s timeout in place of the budget above.
+ */
+async function buildSolanaVerificationManager(
+  chainId: number
+): Promise<SolanaProviderManager | null> {
+  const config = await resolveRpcConfig(chainId);
+  if (!config) {
+    return null;
+  }
+  return new SolanaProviderManager({
+    config: {
+      primaryRpcUrl: config.primaryRpcUrl,
+      fallbackRpcUrl: config.fallbackRpcUrl,
+      chainName: config.chainName,
       maxRetries: VERIFY_MAX_RETRIES,
       timeoutMs: VERIFY_TIMEOUT_MS,
     },
@@ -271,6 +296,123 @@ async function verifySingleReceipt(
   };
 }
 
+type SignatureLookup = {
+  status: SignatureStatus | null;
+  /** True when at least one read errored rather than answering "not there". */
+  errored: boolean;
+};
+
+/**
+ * The Solana adapter confirms writes at "confirmed" (connection.confirmTransaction
+ * in lib/web3/chain-adapter/solana.ts), so a signature is verified once the
+ * cluster reports it at that level or beyond. getSignatureStatuses returns the
+ * cluster's own confirmation level per signature; the connection's default
+ * commitment plays no part in that call, so this comparison is the gate.
+ * Requiring "finalized" instead would add the confirmed-to-finalized gap to
+ * every Solana finalize for nothing the write path did not already accept.
+ */
+function reachedVerifyCommitment(status: SignatureStatus): boolean {
+  return (
+    status.confirmationStatus === "confirmed" ||
+    status.confirmationStatus === "finalized"
+  );
+}
+
+/**
+ * Ask for the signature's status, repeatedly, until the cluster reports it at
+ * or above the verification commitment, reports an execution error, or the
+ * budget runs out.
+ *
+ * `searchTransactionHistory` matters: without it a node answers only from its
+ * recent-status cache (about 150 slots, on the order of a minute). That serves
+ * the finalize gate, which runs straight after the write, but would return
+ * null for every signature the 24h reconciler re-reads, and the reconciler
+ * settles a hash that stays absent as dropped.
+ *
+ * Unlike lookupReceipt there is no explicit read against the fallback endpoint
+ * after a null answer: SolanaProviderManager does not expose its fallback
+ * connection, so the retry rounds are what cover a lagging primary here.
+ */
+async function lookupSignatureStatus(
+  signature: string,
+  manager: SolanaProviderManager,
+  options: ReceiptLookupOptions = {}
+): Promise<SignatureLookup> {
+  const budgetMs = options.budgetMs ?? LOOKUP_BUDGET_MS;
+  const retryDelayMs = options.retryDelayMs ?? LOOKUP_RETRY_DELAY_MS;
+  const deadline = Date.now() + budgetMs;
+  let errored = false;
+  let firstRound = true;
+
+  while (firstRound || Date.now() < deadline) {
+    if (!firstRound) {
+      await sleep(retryDelayMs);
+    }
+    firstRound = false;
+
+    try {
+      const status = await manager.executeWithFailover(async (connection) => {
+        const response = await connection.getSignatureStatuses([signature], {
+          searchTransactionHistory: true,
+        });
+        return response.value[0] ?? null;
+      }, "read");
+      // A "processed" status with no error is a node that has not caught up to
+      // the adapter's commitment yet, so it is re-asked like a null answer.
+      if (status && (status.err != null || reachedVerifyCommitment(status))) {
+        return { status, errored: false };
+      }
+    } catch {
+      errored = true;
+    }
+  }
+
+  return { status: null, errored };
+}
+
+async function verifySingleSolanaSignature(
+  signature: string,
+  chainId: number,
+  manager: SolanaProviderManager,
+  options: ReceiptLookupOptions = {}
+): Promise<ReceiptVerificationResult> {
+  const verifiedAt = new Date().toISOString();
+
+  const { status, errored } = await lookupSignatureStatus(
+    signature,
+    manager,
+    options
+  );
+
+  if (!status) {
+    return {
+      hash: signature,
+      chainId,
+      verified: false,
+      status: errored ? "timeout" : "not_found",
+      verifiedAt,
+    };
+  }
+
+  if (status.err != null) {
+    return {
+      hash: signature,
+      chainId,
+      verified: false,
+      status: "reverted",
+      verifiedAt,
+    };
+  }
+
+  return {
+    hash: signature,
+    chainId,
+    verified: true,
+    status: "success",
+    verifiedAt,
+  };
+}
+
 /**
  * Inline concurrency cap (no new dependency, matches the established
  * pattern in lib/mcp/validate-workflow-deep.ts). Order of `results` matches
@@ -303,17 +445,31 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
+/** Fail-closed results for a chain no endpoint could be resolved for. */
+function unreadableChainResults(
+  chainId: number,
+  group: { hash: string }[]
+): ReceiptVerificationResult[] {
+  const verifiedAt = new Date().toISOString();
+  return group.map(({ hash }) => ({
+    hash,
+    chainId,
+    verified: false,
+    status: "timeout",
+    verifiedAt,
+  }));
+}
+
 /**
  * Independently re-verifies every claimed transaction hash against the
  * chain. Groups by chainId so each distinct chain only pays for one
- * RpcProviderManager, then verifies all hashes concurrently (capped).
+ * provider manager, then verifies all hashes concurrently (capped).
  *
- * Solana chainIds are passed through as verified/success without an
- * on-chain check: lib/web3/chain-adapter/solana.ts is entirely stubbed
- * today (every write method throws "not implemented"), so no live code
- * path can produce a Solana hash here -- this is a defensive carve-out, not
- * a known gap, and fail-closing it would be a functional regression rather
- * than a safety fix if a Solana write path ever ships.
+ * Solana chainIds are read through getSignatureStatuses rather than an EVM
+ * receipt: a signature at or above the adapter's commitment with no error is
+ * success, an execution error is reverted, and a signature the cluster does
+ * not report is not_found. The same fail-closed budget applies, so an
+ * unreadable signature is never verified.
  */
 export async function verifyExecutionReceipts(
   hashes: { hash: string; chainId: number }[],
@@ -334,31 +490,24 @@ export async function verifyExecutionReceipts(
 
   for (const [chainId, group] of groups) {
     if (isSolanaChain(chainId)) {
-      const verifiedAt = new Date().toISOString();
-      for (const { hash } of group) {
-        allResults.push({
-          hash,
-          chainId,
-          verified: true,
-          status: "success",
-          verifiedAt,
-        });
+      const solanaManager = await buildSolanaVerificationManager(chainId);
+      if (!solanaManager) {
+        allResults.push(...unreadableChainResults(chainId, group));
+        continue;
       }
+      const solanaResults = await mapWithConcurrency(
+        group,
+        VERIFY_CONCURRENCY_LIMIT,
+        ({ hash }) =>
+          verifySingleSolanaSignature(hash, chainId, solanaManager, options)
+      );
+      allResults.push(...solanaResults);
       continue;
     }
 
     const manager = await buildVerificationManager(chainId);
     if (!manager) {
-      const verifiedAt = new Date().toISOString();
-      for (const { hash } of group) {
-        allResults.push({
-          hash,
-          chainId,
-          verified: false,
-          status: "timeout",
-          verifiedAt,
-        });
-      }
+      allResults.push(...unreadableChainResults(chainId, group));
       continue;
     }
 

--- a/lib/web3/verify-receipt.ts
+++ b/lib/web3/verify-receipt.ts
@@ -14,7 +14,7 @@
  * visible) resolves to `verified: false`, never `verified: true`.
  */
 import "server-only";
-import type { SignatureStatus } from "@solana/web3.js";
+import type { Connection, SignatureStatus } from "@solana/web3.js";
 import { ethers } from "ethers";
 import { resolveRpcConfig } from "@/lib/rpc/config-service";
 import { isSolanaChain } from "@/lib/rpc/provider-factory";
@@ -83,9 +83,13 @@ const VERIFY_CONCURRENCY_LIMIT = 20;
 // checked between rounds, so one already in flight runs to completion. Rounds
 // against a responsive endpoint cost milliseconds, but a round whose endpoints
 // time out instead of answering can overrun the budget by
-// VERIFY_MAX_RETRIES x VERIFY_TIMEOUT_MS per provider, primary then fallback.
-// That case only arises for a transaction no endpoint can see, which the
-// unconfirmed state and the reconciler then own.
+// VERIFY_MAX_RETRIES x VERIFY_TIMEOUT_MS plus the provider manager's own
+// exponential backoff between attempts (1s, 2s, 4s, 5s, i.e. 12s at five
+// retries), per provider, primary then fallback. At the constants above that
+// is about 104s of wall clock, not the 12s this budget names, and the
+// finalize gate it sits behind is a synchronous HTTP path. That case only
+// arises for a transaction no endpoint can see, which the unconfirmed state
+// and the reconciler then own.
 const LOOKUP_BUDGET_MS = 12_000;
 const LOOKUP_RETRY_DELAY_MS = 1500;
 
@@ -310,11 +314,43 @@ type SignatureLookup = {
  * commitment plays no part in that call, so this comparison is the gate.
  * Requiring "finalized" instead would add the confirmed-to-finalized gap to
  * every Solana finalize for nothing the write path did not already accept.
+ *
+ * confirmationStatus is optional on SignatureStatus, and a node or proxy that
+ * omits it would otherwise never satisfy this gate, leaving every Solana
+ * execution unconfirmed until the reconciler called it dropped. `confirmations`
+ * is the older, universally present signal: null means the transaction is
+ * rooted, which is at or above "finalized". It is only consulted when
+ * confirmationStatus is absent, so an explicit "processed" is never overridden.
  */
 function reachedVerifyCommitment(status: SignatureStatus): boolean {
+  if (status.confirmationStatus === undefined) {
+    return status.confirmations === null;
+  }
   return (
     status.confirmationStatus === "confirmed" ||
     status.confirmationStatus === "finalized"
+  );
+}
+
+async function readSignatureStatus(
+  connection: Connection,
+  signature: string
+): Promise<SignatureStatus | null> {
+  const response = await connection.getSignatureStatuses([signature], {
+    searchTransactionHistory: true,
+  });
+  return response.value[0] ?? null;
+}
+
+/**
+ * A "processed" status with no error is a node that has not caught up to the
+ * adapter's commitment yet, so it is re-asked like a null answer.
+ */
+function isDecisiveSignatureStatus(
+  status: SignatureStatus | null
+): status is SignatureStatus {
+  return (
+    status != null && (status.err != null || reachedVerifyCommitment(status))
   );
 }
 
@@ -329,9 +365,14 @@ function reachedVerifyCommitment(status: SignatureStatus): boolean {
  * null for every signature the 24h reconciler re-reads, and the reconciler
  * settles a hash that stays absent as dropped.
  *
- * Unlike lookupReceipt there is no explicit read against the fallback endpoint
- * after a null answer: SolanaProviderManager does not expose its fallback
- * connection, so the retry rounds are what cover a lagging primary here.
+ * As in lookupReceipt, a null answer is followed by an explicit read against
+ * the fallback endpoint. getSignatureStatuses resolves to a null entry for an
+ * unknown signature rather than throwing, so `executeWithFailover` counts that
+ * as a successful call and never moves off the primary. The primary for
+ * solana-mainnet is a proxy that has been observed serving no transaction
+ * history at all, which is exactly the capability searchTransactionHistory
+ * needs. Retry rounds do not cover that: every round asks the same endpoint
+ * and gets the same valid empty answer.
  */
 async function lookupSignatureStatus(
   signature: string,
@@ -351,19 +392,27 @@ async function lookupSignatureStatus(
     firstRound = false;
 
     try {
-      const status = await manager.executeWithFailover(async (connection) => {
-        const response = await connection.getSignatureStatuses([signature], {
-          searchTransactionHistory: true,
-        });
-        return response.value[0] ?? null;
-      }, "read");
-      // A "processed" status with no error is a node that has not caught up to
-      // the adapter's commitment yet, so it is re-asked like a null answer.
-      if (status && (status.err != null || reachedVerifyCommitment(status))) {
+      const status = await manager.executeWithFailover(
+        (connection) => readSignatureStatus(connection, signature),
+        "read"
+      );
+      if (isDecisiveSignatureStatus(status)) {
         return { status, errored: false };
       }
     } catch {
       errored = true;
+    }
+
+    const fallback = manager.getFallbackConnection();
+    if (fallback) {
+      try {
+        const status = await readSignatureStatus(fallback, signature);
+        if (isDecisiveSignatureStatus(status)) {
+          return { status, errored: false };
+        }
+      } catch {
+        errored = true;
+      }
     }
   }
 

--- a/lib/workflow/executor/logging.ts
+++ b/lib/workflow/executor/logging.ts
@@ -61,7 +61,10 @@ import {
   FAILED_AFTER_RETRIES_REGEX,
   NO_STEP_COMPLETION_REGEX,
 } from "@/lib/workflow/executor/runner-error-patterns";
-import { getTransactionHashes } from "@/lib/workflow/executor/step-success-tracker";
+import {
+  getTransactionHashes,
+  isRecordableTransactionHash,
+} from "@/lib/workflow/executor/step-success-tracker";
 import { computeTrulyFailedNodes } from "@/lib/workflow/executor/truly-failed-nodes";
 
 // Statuses a late step write must never resurrect: the user stopped the run,
@@ -138,7 +141,10 @@ async function listTrulyFailedNodes(executionId: string): Promise<string[]> {
  * that runs a non-tx step many times (e.g. a For-Each over hundreds of HTTP
  * calls) does not stream every row back to Node just to discard it in JS.
  * The JS-side type guard below stays as the authoritative check: SQL only
- * confirms the key exists in output_raw, not that the value is a 0x string.
+ * confirms the key exists in output_raw, not that the value is shaped like a
+ * hash for the chain the step reported. That shape check is shared with the
+ * in-memory tracker (isRecordableTransactionHash) so the two reconstructions
+ * of the same list cannot drift apart.
  */
 async function loadHashesFromLogs(
   executionId: string
@@ -171,7 +177,7 @@ async function loadHashesFromLogs(
         o === null ||
         typeof o !== "object" ||
         typeof o.transactionHash !== "string" ||
-        !o.transactionHash.startsWith("0x") ||
+        !isRecordableTransactionHash(o.transactionHash, o.chainId) ||
         seen.has(o.transactionHash)
       ) {
         continue;

--- a/lib/workflow/executor/step-success-tracker.ts
+++ b/lib/workflow/executor/step-success-tracker.ts
@@ -26,7 +26,38 @@
  */
 
 import type { TransactionHashEntry } from "@/lib/db/schema";
+import { isSolanaChain } from "@/lib/rpc/provider-factory";
+import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
 import type { StepContext } from "./step-handler";
+
+/**
+ * Whether a step's self-reported hash is one this execution can record and
+ * later re-verify against the chain.
+ *
+ * Solana signatures are base58, not 0x-hex, so a bare 0x prefix test drops
+ * every one of them and the finalize gate never sees a Solana write at all.
+ * When the step reported which chain it was on, the hash is instead checked
+ * against the shape that chain actually uses (validateChainTxHash), which
+ * still rejects junk.
+ *
+ * A hash with no chainId keeps the 0x test on purpose. reconcileTransactionHashes
+ * fails the whole batch conclusively for a hash it cannot attribute to a chain,
+ * so admitting a base58 hash from a step that reports no chainId
+ * (transfer-spl-token-core, call-solana-program-core,
+ * send-raw-solana-instruction-core) would settle runs that actually succeeded
+ * as failed. Those steps not reporting chainId is a separate defect; dropping
+ * their hash is what happens today and is the lesser of the two errors until
+ * it is fixed.
+ */
+export function isRecordableTransactionHash(
+  hash: string,
+  chainId: unknown
+): boolean {
+  if (typeof chainId === "number" && isSolanaChain(chainId)) {
+    return validateChainTxHash(hash, chainId);
+  }
+  return hash.startsWith("0x");
+}
 
 export type IterationKey = {
   forEachNodeId: string;
@@ -90,10 +121,10 @@ export function getSuccessfulSteps(
 }
 
 /**
- * If the step output carries an on-chain transaction hash (0x-prefixed
- * string), append it to the per-execution ordered list along with the node
- * and chain context that produced it. Called from withStepLoggingInner after
- * each successful step.
+ * If the step output carries a recordable on-chain transaction hash (see
+ * isRecordableTransactionHash), append it to the per-execution ordered list
+ * along with the node and chain context that produced it. Called from
+ * withStepLoggingInner after each successful step.
  *
  * Optional fields (chainId, network, iterationIndex) are omitted from the
  * entry rather than set to null when not present in the output / context,
@@ -116,7 +147,7 @@ export function recordTransactionHashIfPresent(
     o === null ||
     typeof o !== "object" ||
     typeof o.transactionHash !== "string" ||
-    !o.transactionHash.startsWith("0x")
+    !isRecordableTransactionHash(o.transactionHash, o.chainId)
   ) {
     return;
   }

--- a/lib/workflow/executor/step-success-tracker.ts
+++ b/lib/workflow/executor/step-success-tracker.ts
@@ -26,8 +26,8 @@
  */
 
 import type { TransactionHashEntry } from "@/lib/db/schema";
-import { isSolanaChain } from "@/lib/rpc/provider-factory";
-import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
+import { isSolanaChain } from "@/lib/rpc/solana-chains";
+import { validateChainTxHash } from "@/lib/web3/validate-chain-tx-hash";
 import type { StepContext } from "./step-handler";
 
 /**
@@ -48,6 +48,11 @@ import type { StepContext } from "./step-handler";
  * as failed. Those steps not reporting chainId is a separate defect; dropping
  * their hash is what happens today and is the lesser of the two errors until
  * it is fixed.
+ *
+ * Both helpers are imported from leaf modules rather than provider-factory /
+ * validate-chain-address: this file is reachable from executor.workflow.ts,
+ * so whatever it imports is compiled into the workflow-function bundle, where
+ * @solana/web3.js, ethers, safeFetch and the db client are all rejected.
  */
 export function isRecordableTransactionHash(
   hash: string,

--- a/tests/unit/step-success-tracker-tx-hashes.test.ts
+++ b/tests/unit/step-success-tracker-tx-hashes.test.ts
@@ -17,6 +17,9 @@ import {
   recordTransactionHashIfPresent,
 } from "@/lib/workflow/executor/step-success-tracker";
 
+const SOLANA_SIGNATURE =
+  "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW";
+
 function ctx(overrides: Partial<StepContext> = {}): StepContext {
   return {
     executionId: "exec_keep_470_default",
@@ -157,6 +160,65 @@ describe("recordTransactionHashIfPresent (KEEP-470)", () => {
     });
     recordTransactionHashIfPresent(ctx({ executionId }), {
       transactionHash: "",
+    });
+
+    expect(getTransactionHashes(executionId)).toEqual([]);
+
+    clearExecution(executionId);
+  });
+
+  it("records a base58 signature when the step reported a Solana chainId", () => {
+    const executionId = "exec_solana";
+    recordTransactionHashIfPresent(ctx({ executionId }), {
+      transactionHash: SOLANA_SIGNATURE,
+      chainId: 101,
+      network: "solana-mainnet",
+    });
+
+    expect(getTransactionHashes(executionId)).toEqual([
+      {
+        hash: SOLANA_SIGNATURE,
+        nodeId: "write-contract-1",
+        nodeName: "Write Contract",
+        chainId: 101,
+        network: "solana-mainnet",
+      },
+    ]);
+
+    clearExecution(executionId);
+  });
+
+  it("ignores a Solana chainId whose hash is not a 64-byte base58 signature", () => {
+    const executionId = "exec_solana_junk";
+    recordTransactionHashIfPresent(ctx({ executionId }), {
+      transactionHash: "not a signature",
+      chainId: 101,
+    });
+    // Valid base58, wrong length (a pubkey, not a signature).
+    recordTransactionHashIfPresent(ctx({ executionId }), {
+      transactionHash: "So11111111111111111111111111111111111111112",
+      chainId: 101,
+    });
+    // 0x-hex is not what a Solana chain produces either.
+    recordTransactionHashIfPresent(ctx({ executionId }), {
+      transactionHash: "0xabc123",
+      chainId: 101,
+    });
+
+    expect(getTransactionHashes(executionId)).toEqual([]);
+
+    clearExecution(executionId);
+  });
+
+  // The Solana steps that report no chainId (transfer-spl-token,
+  // call-solana-program-anchor, send-raw-solana-instruction) stay dropped:
+  // reconcileTransactionHashes fails a batch conclusively for a hash it cannot
+  // attribute to a chain, so recording theirs would fail runs that succeeded.
+  it("ignores a base58 signature from a step that reported no chainId", () => {
+    const executionId = "exec_solana_no_chain";
+    recordTransactionHashIfPresent(ctx({ executionId }), {
+      transactionHash: SOLANA_SIGNATURE,
+      network: "solana-mainnet",
     });
 
     expect(getTransactionHashes(executionId)).toEqual([]);

--- a/tests/unit/step-transaction-hash-chain-id.test.ts
+++ b/tests/unit/step-transaction-hash-chain-id.test.ts
@@ -24,9 +24,11 @@ const STEP_FILENAME = /\.ts$/;
 
 /**
  * Steps whose `transactionHash` is a Solana signature (base58), not an EVM
- * hash. The tracker only records 0x-prefixed hashes, so these outputs never
- * reach reconciliation and have no numeric chain to verify against. Adding
- * an EVM-shaped step to this list would silently reopen the hole.
+ * hash. None of them reports a chainId, and the tracker records a base58
+ * signature only when the step said which Solana chain it was on
+ * (isRecordableTransactionHash), so these outputs never reach reconciliation
+ * and have no numeric chain to verify against. Adding an EVM-shaped step to
+ * this list would silently reopen the hole.
  */
 const NON_EVM_HASH_STEPS = new Set([
   "web3/steps/call-solana-program-core.ts",

--- a/tests/unit/verify-receipt.test.ts
+++ b/tests/unit/verify-receipt.test.ts
@@ -18,6 +18,11 @@ type SolanaConnectionMock = {
 };
 const getSignatureStatuses = vi.fn();
 const solanaConnection: SolanaConnectionMock = { getSignatureStatuses };
+const fallbackGetSignatureStatuses = vi.fn();
+const solanaFallbackConnection: SolanaConnectionMock = {
+  getSignatureStatuses: fallbackGetSignatureStatuses,
+};
+const getFallbackConnection = vi.fn(() => solanaFallbackConnection);
 const solanaExecuteWithFailover =
   vi.fn<
     (
@@ -39,7 +44,10 @@ vi.mock("@/lib/rpc/providers/solana", () => ({
   SolanaProviderManager: vi
     .fn()
     .mockImplementation(function SolanaProviderManager() {
-      return { executeWithFailover: solanaExecuteWithFailover };
+      return {
+        executeWithFailover: solanaExecuteWithFailover,
+        getFallbackConnection,
+      };
     }),
 }));
 vi.mock("@/lib/rpc/config-service", () => ({
@@ -259,6 +267,7 @@ describe("verifyExecutionReceipts", () => {
 });
 
 const SOLANA_CHAIN_ID = 101;
+const SOLANA_DEVNET_CHAIN_ID = 103;
 const SIGNATURE =
   "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW";
 
@@ -298,6 +307,10 @@ describe("Solana signatures", () => {
     });
     getSignatureStatuses.mockReset();
     getSignatureStatuses.mockResolvedValue({ value: [null] });
+    fallbackGetSignatureStatuses.mockReset();
+    fallbackGetSignatureStatuses.mockResolvedValue({ value: [null] });
+    getFallbackConnection.mockReset();
+    getFallbackConnection.mockReturnValue(solanaFallbackConnection);
     solanaExecuteWithFailover.mockReset();
     solanaExecuteWithFailover.mockImplementation((operation) =>
       operation(solanaConnection)
@@ -455,6 +468,90 @@ describe("Solana signatures", () => {
     });
     expect(allVerified).toBe(true);
     expect(results.map((result) => result.hash)).toEqual([HASH, SIGNATURE]);
+  });
+
+  it("groups signatures by chainId, building one Solana manager per distinct chain", async () => {
+    const { SolanaProviderManager } = await import(
+      "@/lib/rpc/providers/solana"
+    );
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("confirmed")],
+    });
+
+    await verifyExecutionReceipts([
+      { hash: SIGNATURE, chainId: SOLANA_CHAIN_ID },
+      { hash: `${SIGNATURE.slice(0, -1)}X`, chainId: SOLANA_CHAIN_ID },
+      { hash: SIGNATURE, chainId: SOLANA_DEVNET_CHAIN_ID },
+    ]);
+
+    // one construction per distinct chainId (2), not per signature (3)
+    expect(SolanaProviderManager).toHaveBeenCalledTimes(2);
+    expect(getSignatureStatuses).toHaveBeenCalledTimes(3);
+  });
+
+  // @solana/web3.js types confirmationStatus as optional, and a node or proxy
+  // that omits it would otherwise never satisfy the commitment gate: every
+  // Solana execution would sit unconfirmed until the reconciler called it
+  // dropped. confirmations === null is the rooted signal that predates it.
+  it("a rooted status with no confirmationStatus verifies as success", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [{ slot: 250_000_000, confirmations: null, err: null }],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(allVerified).toBe(true);
+    expect(results[0].status).toBe("success");
+  });
+
+  it("a not-yet-rooted status with no confirmationStatus is not verified", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [{ slot: 250_000_000, confirmations: 5, err: null }],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(allVerified).toBe(false);
+    expect(results[0].status).toBe("not_found");
+  });
+
+  // A null entry is a valid JSON-RPC answer, so executeWithFailover treats it
+  // as a successful call and never moves off the primary, which is exactly
+  // the endpoint observed serving no transaction history at all.
+  it("consults the fallback endpoint when the primary reports no status", async () => {
+    fallbackGetSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("finalized")],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(fallbackGetSignatureStatuses).toHaveBeenCalledWith([SIGNATURE], {
+      searchTransactionHistory: true,
+    });
+    expect(allVerified).toBe(true);
+    expect(results[0].status).toBe("success");
+  });
+
+  it("does not read the fallback when the primary already answered", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("confirmed")],
+    });
+
+    await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(fallbackGetSignatureStatuses).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/verify-receipt.test.ts
+++ b/tests/unit/verify-receipt.test.ts
@@ -13,6 +13,18 @@ const isSolanaChain = vi.fn(
   (chainId: number) => chainId === 101 || chainId === 103
 );
 
+type SolanaConnectionMock = {
+  getSignatureStatuses: ReturnType<typeof vi.fn>;
+};
+const getSignatureStatuses = vi.fn();
+const solanaConnection: SolanaConnectionMock = { getSignatureStatuses };
+const solanaExecuteWithFailover =
+  vi.fn<
+    (
+      operation: (connection: SolanaConnectionMock) => Promise<unknown>
+    ) => Promise<unknown>
+  >();
+
 vi.mock("@/lib/rpc/providers", () => ({
   // Regular function, not an arrow function: `new RpcProviderManager(...)` in
   // the module under test requires a constructible mock. Returning an object
@@ -21,6 +33,14 @@ vi.mock("@/lib/rpc/providers", () => ({
   RpcProviderManager: vi.fn().mockImplementation(function RpcProviderManager() {
     return { executeWithFailover, getFallbackProvider };
   }),
+}));
+vi.mock("@/lib/rpc/providers/solana", () => ({
+  // Same constructible-mock shape as RpcProviderManager above.
+  SolanaProviderManager: vi
+    .fn()
+    .mockImplementation(function SolanaProviderManager() {
+      return { executeWithFailover: solanaExecuteWithFailover };
+    }),
 }));
 vi.mock("@/lib/rpc/config-service", () => ({
   resolveRpcConfig: (...args: unknown[]) => resolveRpcConfig(...args),
@@ -210,16 +230,6 @@ describe("verifyExecutionReceipts", () => {
     expect(results[0].status).toBe("timeout");
   });
 
-  it("Solana chainIds pass through as verified/success without any RPC call", async () => {
-    const { allVerified, results } = await verifyExecutionReceipts([
-      { hash: HASH, chainId: 101 },
-    ]);
-    expect(allVerified).toBe(true);
-    expect(results[0]).toMatchObject({ verified: true, status: "success" });
-    expect(executeWithFailover).not.toHaveBeenCalled();
-    expect(resolveRpcConfig).not.toHaveBeenCalled();
-  });
-
   it("groups hashes by chainId, building one manager per distinct chain", async () => {
     const { RpcProviderManager } = await import("@/lib/rpc/providers");
     executeWithFailover.mockResolvedValue(makeReceipt(1));
@@ -245,6 +255,206 @@ describe("verifyExecutionReceipts", () => {
     ]);
     expect(allVerified).toBe(false);
     expect(results).toHaveLength(2);
+  });
+});
+
+const SOLANA_CHAIN_ID = 101;
+const SIGNATURE =
+  "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW";
+
+type SignatureStatusMock = {
+  slot: number;
+  confirmations: number | null;
+  err: unknown;
+  confirmationStatus: "processed" | "confirmed" | "finalized";
+};
+
+function makeSignatureStatus(
+  confirmationStatus: SignatureStatusMock["confirmationStatus"],
+  err: unknown = null
+): SignatureStatusMock {
+  return {
+    slot: 250_000_000,
+    confirmations: confirmationStatus === "finalized" ? null : 5,
+    err,
+    confirmationStatus,
+  };
+}
+
+// Solana hashes are base58 signatures read through getSignatureStatuses. The
+// adapter confirms at "confirmed", so that level and "finalized" verify; a
+// lower level, a null entry, or a thrown read never does.
+describe("Solana signatures", () => {
+  beforeEach(() => {
+    executeWithFailover.mockReset();
+    fallbackGetTransactionReceipt.mockReset();
+    fallbackGetTransactionReceipt.mockResolvedValue(null);
+    resolveRpcConfig.mockReset();
+    resolveRpcConfig.mockResolvedValue({
+      chainId: SOLANA_CHAIN_ID,
+      chainName: "solana",
+      primaryRpcUrl: "https://solana-primary.example",
+      fallbackRpcUrl: "https://solana-fallback.example",
+    });
+    getSignatureStatuses.mockReset();
+    getSignatureStatuses.mockResolvedValue({ value: [null] });
+    solanaExecuteWithFailover.mockReset();
+    solanaExecuteWithFailover.mockImplementation((operation) =>
+      operation(solanaConnection)
+    );
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("a confirmed signature with no error verifies as success", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("confirmed")],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: SIGNATURE, chainId: SOLANA_CHAIN_ID },
+    ]);
+
+    expect(resolveRpcConfig).toHaveBeenCalledWith(SOLANA_CHAIN_ID);
+    expect(getSignatureStatuses).toHaveBeenCalledWith([SIGNATURE], {
+      searchTransactionHistory: true,
+    });
+    expect(allVerified).toBe(true);
+    expect(results[0]).toMatchObject({
+      hash: SIGNATURE,
+      chainId: SOLANA_CHAIN_ID,
+      verified: true,
+      status: "success",
+    });
+  });
+
+  it("a finalized signature is at or above the adapter's commitment and verifies as success", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("finalized")],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: SIGNATURE, chainId: SOLANA_CHAIN_ID },
+    ]);
+
+    expect(allVerified).toBe(true);
+    expect(results[0].status).toBe("success");
+  });
+
+  it("a signature with an execution error verifies as reverted and is not retried away", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [
+        makeSignatureStatus("confirmed", { InstructionError: [0, "Custom"] }),
+      ],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      FAST_RETRY
+    );
+
+    expect(allVerified).toBe(false);
+    expect(results[0]).toMatchObject({ verified: false, status: "reverted" });
+    expect(getSignatureStatuses).toHaveBeenCalledTimes(1);
+  });
+
+  it("a signature the cluster does not report verifies as not_found", async () => {
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(allVerified).toBe(false);
+    expect(results[0]).toMatchObject({ verified: false, status: "not_found" });
+  });
+
+  it("a signature still at processed is below the adapter's commitment and is not verified", async () => {
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("processed")],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(allVerified).toBe(false);
+    expect(results[0]).toMatchObject({ verified: false, status: "not_found" });
+  });
+
+  it("an RPC that throws on every attempt verifies as timeout, fail-closed", async () => {
+    solanaExecuteWithFailover.mockRejectedValue(
+      new Error("Solana RPC failed on both endpoints")
+    );
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      SINGLE_ROUND
+    );
+
+    expect(allVerified).toBe(false);
+    expect(results[0]).toMatchObject({ verified: false, status: "timeout" });
+  });
+
+  it("a signature invisible on the first read is found on a later one", async () => {
+    getSignatureStatuses
+      .mockResolvedValueOnce({ value: [null] })
+      .mockResolvedValueOnce({ value: [null] })
+      .mockResolvedValue({ value: [makeSignatureStatus("confirmed")] });
+
+    const { allVerified, results } = await verifyExecutionReceipts(
+      [{ hash: SIGNATURE, chainId: SOLANA_CHAIN_ID }],
+      FAST_RETRY
+    );
+
+    expect(allVerified).toBe(true);
+    expect(results[0].status).toBe("success");
+    expect(getSignatureStatuses).toHaveBeenCalledTimes(3);
+  });
+
+  it("unresolvable Solana chain (resolveRpcConfig returns null) fails closed as timeout", async () => {
+    resolveRpcConfig.mockResolvedValueOnce(null);
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: SIGNATURE, chainId: SOLANA_CHAIN_ID },
+    ]);
+
+    expect(allVerified).toBe(false);
+    expect(results[0].status).toBe("timeout");
+    expect(getSignatureStatuses).not.toHaveBeenCalled();
+  });
+
+  it("the Solana manager gets the resolved endpoints and the same retry budget as the EVM manager", async () => {
+    const { RpcProviderManager } = await import("@/lib/rpc/providers");
+    const { SolanaProviderManager } = await import(
+      "@/lib/rpc/providers/solana"
+    );
+    executeWithFailover.mockResolvedValue(makeReceipt(1));
+    getSignatureStatuses.mockResolvedValue({
+      value: [makeSignatureStatus("confirmed")],
+    });
+
+    const { allVerified, results } = await verifyExecutionReceipts([
+      { hash: HASH, chainId: CHAIN_ID },
+      { hash: SIGNATURE, chainId: SOLANA_CHAIN_ID },
+    ]);
+
+    const evmConfig = vi
+      .mocked(RpcProviderManager)
+      .mock.calls.at(-1)?.[0].config;
+    const solanaConfig = vi
+      .mocked(SolanaProviderManager)
+      .mock.calls.at(-1)?.[0].config;
+    expect(evmConfig).toBeDefined();
+    expect(solanaConfig).toMatchObject({
+      primaryRpcUrl: "https://solana-primary.example",
+      fallbackRpcUrl: "https://solana-fallback.example",
+      maxRetries: evmConfig?.maxRetries,
+      timeoutMs: evmConfig?.timeoutMs,
+    });
+    expect(allVerified).toBe(true);
+    expect(results.map((result) => result.hash)).toEqual([HASH, SIGNATURE]);
   });
 });
 


### PR DESCRIPTION
## Failure mode

`verifyExecutionReceipts` in `lib/web3/verify-receipt.ts` returned `verified: true, status: "success"` for every Solana chain id without reading the chain. The comment justifying that carve-out said the Solana adapter was entirely stubbed. It is not: `lib/web3/chain-adapter/solana.ts` broadcasts and confirms through `connection.confirmTransaction`. The hash that actually reaches this module today is `transferFundsSolana`'s (`plugins/web3/steps/transfer-funds-core.ts:670`), the only Solana step that returns a `chainId` alongside its signature. SPL transfers, program calls and raw instructions ship through the same adapter but return no `chainId`, so they are stopped earlier by separate pre-existing defects (see the follow-up section) rather than reaching verification.

Consequences on the current base:

- The finalize gate was a no-op for Solana in two different ways. Direct-execute's `completeExecution` accepted any Solana hash as independently verified, so it verified nothing. The workflow gates (`logWorkflowCompleteDb` / `selfHealWorkflowAfterLateStepCommit`) never received a Solana hash at all: the tracker and its cross-pod fallback both dropped any hash that did not start with `0x`, so a base58 signature never entered `workflowExecutions.transactionHashes`. This PR fixes both - the tracker now records a base58 signature when the step reported a Solana chain id, and the on-chain read verifies it.
- The 24h reconciler in `lib/execute/reconcile-executions.ts` settled every unconfirmed Solana **direct** execution as completed on its first pass, and `unconfirmed` was unreachable for a Solana direct write. Workflow runs were unaffected only because no Solana hash ever reached `reconcileWorkflow` in the first place.

## Change

Scoped to `lib/web3/verify-receipt.ts` and its unit tests. The adapter, the cores and the reconciler are untouched.

- Solana groups now build a `SolanaProviderManager` from `resolveRpcConfig(chainId)` with the same `VERIFY_MAX_RETRIES` and `VERIFY_TIMEOUT_MS` as the EVM manager. It is constructed directly rather than through `createSolanaProviderManager`: that cache is keyed by URL alone, so it would have handed back the adapter's manager and kept its 3 retries and 30s timeout in place of the verification budget.
- Each signature is read with `getSignatureStatuses([signature], { searchTransactionHistory: true })` through `executeWithFailover`, inside the same `LOOKUP_BUDGET_MS` / `LOOKUP_RETRY_DELAY_MS` loop the EVM branch uses, under the same `VERIFY_CONCURRENCY_LIMIT`. This follows the polling pattern already in `lib/web3/submit-signed-solana.ts`.
- Mapping into the existing `ReceiptStatus` vocabulary:
  - `confirmationStatus` of `confirmed` or `finalized` with `err` null: `success`, `verified: true`
  - non-null `err`: `reverted` (terminal, not retried)
  - null entry, or a status still at `processed`, once the budget is spent: `not_found`
  - every read threw: `timeout`
  - chain not resolvable: `timeout` for the whole group, as for EVM
- Unreadable is never `verified: true`.
- The stale comment is replaced with one describing the read.
- The two identical inline "unresolvable chain" blocks (the pre-existing EVM one and the new Solana one) share a small `unreadableChainResults` helper rather than being duplicated.

### Commitment level

The read is gated at `confirmed` or above, which is the level the adapter confirms at (`connection.confirmTransaction(..., "confirmed")` in `lib/web3/chain-adapter/solana.ts`). It is deliberately not raised to `finalized`: that would add the confirmed-to-finalized gap to every Solana finalize for a level the write path never waited for. Note that `getSignatureStatuses` reports the cluster's confirmation level per signature and ignores the connection's default commitment, so the comparison on `confirmationStatus` is what enforces the level, not the manager configuration.

### Why `searchTransactionHistory: true`

Without it a node answers only from its recent-status cache (about 150 slots, roughly a minute). That is fine for the finalize gate, which runs straight after the write, but the reconciler re-reads up to 24 hours later and treats a hash that is still unreadable at that point as dropped. A plain read would therefore have settled landed Solana transactions as errors. The flag makes the node consult ledger history; the query is a single signature per call.

### Fallback reads

A null `getSignatureStatuses` entry is a successful JSON-RPC call, so `executeWithFailover` never moves off the primary - and the primary for `solana-mainnet` is the Ætherlay route observed under KEEP-1205 serving no transaction history at all, which is the one capability `searchTransactionHistory` depends on. A null answer is therefore followed by an explicit read against the fallback connection, matching what the EVM branch already does. `SolanaProviderManager.getFallbackConnection` is made public for this, mirroring the public `RpcProviderManager.getFallbackProvider` that exists for the same reason. The read goes through the manager rather than a locally constructed `Connection` because `createConnection` wires `safeSolanaFetch`, the SSRF guard.

That fallback read is untimed - `lib/safe-fetch.ts` sets no timeout and the raw connection sits outside the manager's `withTimeout` - so it is bounded only by undici's header timeout. This matches what `lookupReceipt` already does for EVM, but it means the worst-case latency noted below is a floor rather than a ceiling.

### Tracker guard

`isRecordableTransactionHash` replaces the `startsWith("0x")` test in both `lib/workflow/executor/step-success-tracker.ts` and its mirror in `lib/workflow/executor/logging.ts`, delegating to the existing `validateChainTxHash` (base58 64-byte decode for Solana, `/^0x[a-fA-F0-9]{64}$/` for EVM). It branches on chain family only when the step reported a `chainId`; anything without one keeps the unchanged `0x` test. That restriction is deliberate - `reconcileTransactionHashes` fails a batch conclusively for a hash with no chain id, so admitting the three Solana steps that return no `chainId` would settle their successful runs as failed. The EVM branch is byte-identical: tightening it to `validateChainTxHash` would newly drop malformed EVM hashes that today correctly hold a run at `unconfirmed`.

### Not changed

- `blockNumber` / `gasUsed` stay undefined for Solana results, as they were under the carve-out. Mapping `slot` into `blockNumber` is a possible follow-up but was not asked for.
- `describeStatus` wording is unchanged ("receipt not found" for `not_found`) because `lib/errors/classify.ts` keys on it.
- Carrying the signature out of a failed Solana wait is a separate piece of work.

## Tests

`tests/unit/verify-receipt.test.ts`: the pass-through assertion is removed and a `Solana signatures` block added, mocking `SolanaProviderManager` the same way the file already mocks `RpcProviderManager` and driving `getSignatureStatuses` on a mock connection as the existing Solana tests do:

- confirmed, no error: success, and the read is made with `searchTransactionHistory: true`
- finalized, no error: success
- non-null `err`: reverted, read once, not retried away
- null entry: not_found
- `processed` only: not verified (below the adapter's commitment)
- RPC throwing on every attempt: timeout, fail-closed
- null on the first reads then confirmed: success (lagging node)
- `resolveRpcConfig` returning null: timeout, no read attempted
- mixed EVM plus Solana batch: the Solana manager receives the resolved endpoints and the same `maxRetries` / `timeoutMs` as the EVM manager; results come back in input order

## Verification

Run in a `node:22-slim` container against the repo's installed dependencies (the host has no Node):

- `tsx scripts/discover-plugins.ts`: generated the plugin registry (gitignored).
- `tsc --noEmit`: 74 errors before the change and 74 after, identical sets, none in the touched files. The baseline errors are `TS2307` "Cannot find module" for packages absent from the local install (`react-day-picker`, `keeperhub-pricing-ui`, `@coral-xyz/anchor`, `@solana/spl-token`) and the implicit-any cascade they cause; CI's typecheck is the arbiter.
- `biome check lib/web3/verify-receipt.ts tests/unit/verify-receipt.test.ts`: clean after one formatter pass on the test file.
- `vitest run tests/unit/verify-receipt.test.ts`: 26 passed (baseline on the untouched file: 18 passed).

Not run locally: `pnpm build`, the integration suite, and anything requiring network or a database.

## Follow-ups, not fixed here

Three Solana direct-execute steps return a transaction signature that `completeExecution` cannot act on, each failing differently. `plugins/web3/steps/transfer-spl-token-core.ts` returns `transactionHash` and `gasUsed` but no `chainId`, so `completeExecution` takes its `chainId === undefined` branch and records a successful SPL transfer as `failed` with "Unable to verify transaction: missing chainId" - the user sees a failure for funds that moved, which invites a re-send. `plugins/web3/steps/call-solana-program-core.ts` and `send-raw-solana-instruction-core.ts` return `gasUsedUnits` rather than `gasUsed`, so `isTransactionResult` in `app/api/execute/node/route.ts` rejects their output entirely: the signature is never passed to `completeExecution`, no on-chain verification runs, and the row is written `completed` with `transactionHash: null` - a self-reported success with no record of what happened on chain and nothing for the reconciler to check later. The same missing `chainId` is why these three steps stay excluded by the tracker guard above. The fix is to return `chainId` from all three result types, and a `gasUsed` the route recognises from the latter two.

`lib/web3/submit-signed-solana.ts` has the same optional-`confirmationStatus` gap this PR closes in `verify-receipt.ts`, but on the write path, where the consequence is a broadcast transaction the poller never sees confirm.

The synchronous latency of `completeExecution` is unchanged by this PR but worth recording: with every endpoint timing out rather than answering, one `lookupSignatureStatus` round costs 5 x 8s of timeouts plus 12s of backoff per provider, so roughly 104s primary-then-fallback on a request path that used to return instantly for Solana. `LOOKUP_BUDGET_MS` is only checked between rounds, so it cannot cut a round short. This is the same shape the EVM branch has had since KEEP-966; a real fix is either a wall-clock deadline threaded into `executeWithFailover` or moving verification off the synchronous request path.
