### PR TITLE
fix: fail Safe and transaction-manager writes when the mined receipt has status 0

### DIFF
--- a/lib/safe/execute-as-safe.ts
+++ b/lib/safe/execute-as-safe.ts
@@ -8,6 +8,7 @@ import { buildExecTransactionWithRoleCalldata } from "@/lib/safe/zodiac-roles";
 import type { TransactionReceipt } from "@/lib/web3/chain-adapter/types";
 import { getGasStrategy } from "@/lib/web3/gas-strategy";
 import { getNonceManager, type NonceSession } from "@/lib/web3/nonce-manager";
+import { OnChainRevertError } from "@/lib/web3/onchain-revert";
 import {
   NonceConflictError,
   submitSignedTransactionWithFailover,
@@ -67,6 +68,23 @@ function finishOnError(
     err instanceof NonceConflictError ? "nonce-conflict" : "failure"
   );
   throw err;
+}
+
+/**
+ * A mined receipt with status 0 is a reverted transaction. Both Safe routes
+ * are built so that an inner-call failure reverts the whole outer transaction
+ * (execTransaction with safeTxGas=0 and gasPrice=0, execTransactionWithRole
+ * with shouldRevert=true), and `waitForTransaction`, unlike `tx.wait()`,
+ * resolves that receipt instead of throwing, so the status has to be read here.
+ */
+function throwIfReverted(receipt: ethers.TransactionReceipt): void {
+  if (receipt.status === 0) {
+    throw new OnChainRevertError({
+      message: `Transaction ${receipt.hash} reverted on-chain (status 0, block ${receipt.blockNumber})`,
+      transactionHash: receipt.hash,
+      blockNumber: receipt.blockNumber,
+    });
+  }
 }
 
 export async function executeContractCallAsSafe(
@@ -155,6 +173,7 @@ export async function executeContractCallAsSafe(
     if (!receipt) {
       throw new Error("Safe-routed transaction sent but receipt unavailable");
     }
+    throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
@@ -283,6 +302,7 @@ export async function executeContractCallAsRole(
     if (!receipt) {
       throw new Error("Role-routed transaction sent but receipt unavailable");
     }
+    throwIfReverted(receipt);
     await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
@@ -389,6 +409,7 @@ export async function executeNativeTransferAsRole(
         "Role-routed native transfer sent but receipt unavailable"
       );
     }
+    throwIfReverted(receipt);
     await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");
     return {
@@ -496,6 +517,7 @@ export async function executeNativeTransferAsSafe(
         "Safe-routed native transfer sent but receipt unavailable"
       );
     }
+    throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);
     finishMetrics("success");

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -26,6 +26,7 @@ import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
 import { getGasStrategy } from "./gas-strategy";
 import { getNonceManager, type NonceSession } from "./nonce-manager";
+import { OnChainRevertError } from "./onchain-revert";
 import {
   type BroadcastResult,
   submitSignedTransactionWithFailover,
@@ -163,6 +164,21 @@ async function confirmAndBuildResult(
 // ---------------------------------------------------------------------------
 
 /**
+ * `waitForTransaction` resolves a mined receipt whatever its status, so a
+ * reverted transaction (status 0) has to become a failure here or the caller
+ * reads it as `success: true`.
+ */
+function throwIfReverted(receipt: ethers.TransactionReceipt | null): void {
+  if (receipt?.status === 0) {
+    throw new OnChainRevertError({
+      message: `Transaction ${receipt.hash} reverted on-chain (status 0, block ${receipt.blockNumber})`,
+      transactionHash: receipt.hash,
+      blockNumber: receipt.blockNumber,
+    });
+  }
+}
+
+/**
  * Execute a single transaction with nonce management and gas strategy.
  */
 export async function executeTransaction(
@@ -234,6 +250,7 @@ export async function executeTransaction(
         (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
         "read"
       ));
+    throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);
 
@@ -336,6 +353,7 @@ export async function executeContractTransaction(
         (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
         "read"
       ));
+    throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);
 

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -139,6 +139,7 @@ async function confirmAndBuildResult(
   if (!receipt) {
     throw new Error("Transaction sent but receipt not available");
   }
+  throwIfReverted(receipt);
 
   await nonceManager.confirmTransaction(broadcast.hash);
 
@@ -250,6 +251,9 @@ export async function executeTransaction(
         (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
         "read"
       ));
+    if (!receipt) {
+      throw new Error("Transaction sent but receipt not available");
+    }
     throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);
@@ -353,6 +357,9 @@ export async function executeContractTransaction(
         (rpcProvider) => rpcProvider.waitForTransaction(broadcast.hash),
         "read"
       ));
+    if (!receipt) {
+      throw new Error("Contract transaction sent but receipt not available");
+    }
     throwIfReverted(receipt);
 
     await nonceManager.confirmTransaction(broadcast.hash);

--- a/plugins/robinhood/steps/trade-stock-token-core.ts
+++ b/plugins/robinhood/steps/trade-stock-token-core.ts
@@ -16,6 +16,7 @@ import {
   preflightGasBalance,
   resolveFundingHolder,
 } from "@/lib/web3/gas-preflight";
+import { broadcastTransactionHash } from "@/lib/web3/onchain-revert";
 import { resolveOrganizationContext } from "@/lib/web3/resolve-org-context";
 import {
   convertAmountForWrite,
@@ -96,7 +97,15 @@ export type TradeStockTokenResult =
       poolFee: number;
       poolTickSpacing: number;
     }
-  | { success: false; error: string };
+  | {
+      success: false;
+      error: string;
+      // Set only when a transaction reached the chain and failed there, so the
+      // finalizer can persist a receipt for the failure. Absent on
+      // pre-broadcast failures, where no transaction exists.
+      transactionHash?: string;
+      chainId?: number;
+    };
 
 /** Refusals that are the caller's to fix, phrased so they can fix them. */
 function refuse(error: string): TradeStockTokenResult {
@@ -457,6 +466,12 @@ export async function tradeStockTokenCore(
       error,
       { plugin_name: "robinhood", action_name: "trade-stock-token" }
     );
-    return refuse(getErrorMessage(error));
+    return {
+      success: false,
+      error: getErrorMessage(error),
+      ...(broadcastTransactionHash(error)
+        ? { transactionHash: broadcastTransactionHash(error), chainId }
+        : {}),
+    };
   }
 }

--- a/tests/unit/execute-as-safe.test.ts
+++ b/tests/unit/execute-as-safe.test.ts
@@ -1,0 +1,261 @@
+import type { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks - must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  finishMetrics: vi.fn(),
+  recordTransaction: vi.fn(),
+  confirmTransaction: vi.fn(),
+  submitSigned: vi.fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/safe", () => ({
+  startSafeTxMetrics: () => mocks.finishMetrics,
+}));
+
+vi.mock("@/lib/safe/allowance-module", () => ({
+  buildExecTransactionCalldata: () => "0xouter",
+}));
+
+vi.mock("@/lib/safe/zodiac-roles", () => ({
+  buildExecTransactionWithRoleCalldata: () => "0xouter",
+}));
+
+vi.mock("@/lib/web3/nonce-manager", () => ({
+  getNonceManager: () => ({
+    getNextNonce: () => 42,
+    recordTransaction: mocks.recordTransaction,
+    confirmTransaction: mocks.confirmTransaction,
+  }),
+}));
+
+vi.mock("@/lib/web3/gas-strategy", () => ({
+  getGasStrategy: () => ({
+    getGasConfig: async () => ({
+      gasLimit: BigInt(100_000),
+      maxFeePerGas: BigInt(20_000_000_000),
+      maxPriorityFeePerGas: BigInt(1_000_000_000),
+    }),
+  }),
+}));
+
+vi.mock("@/lib/web3/submit-signed", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/web3/submit-signed")
+  >("@/lib/web3/submit-signed");
+  return {
+    ...actual,
+    submitSignedTransactionWithFailover: mocks.submitSigned,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER mocks
+// ---------------------------------------------------------------------------
+
+import {
+  type ExecuteAsSafeOptions,
+  executeContractCallAsRole,
+  executeContractCallAsSafe,
+  executeNativeTransferAsRole,
+  executeNativeTransferAsSafe,
+} from "@/lib/safe/execute-as-safe";
+import type { NonceSession } from "@/lib/web3/nonce-manager";
+import {
+  broadcastTransactionHash,
+  isOnChainRevertError,
+} from "@/lib/web3/onchain-revert";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SAFE = "0x1111111111111111111111111111111111111111";
+const OWNER = "0x2222222222222222222222222222222222222222";
+const TARGET = "0x3333333333333333333333333333333333333333";
+const RECIPIENT = "0x4444444444444444444444444444444444444444";
+const MODIFIER = "0x5555555555555555555555555555555555555555";
+const ROLE_KEY = `0x${"ab".repeat(32)}`;
+const TX_HASH = "0xf00d";
+const BLOCK = 500;
+const ERC20_ABI = [
+  "function transfer(address to, uint256 amount) returns (bool)",
+];
+
+const signer = { provider: {} } as unknown as ethers.Signer;
+
+const session: NonceSession = {
+  walletAddress: OWNER,
+  chainId: 1,
+  executionId: "exec-1",
+  currentNonce: 42,
+  startedAt: new Date(),
+};
+
+function makeReceipt(status: number): ethers.TransactionReceipt {
+  return {
+    hash: TX_HASH,
+    status,
+    gasUsed: BigInt(90_000),
+    gasPrice: BigInt(1_000_000_000),
+    blockNumber: BLOCK,
+  } as unknown as ethers.TransactionReceipt;
+}
+
+function makeRpcManager(receipt: ethers.TransactionReceipt | null): {
+  options: ExecuteAsSafeOptions;
+  waitForTransaction: ReturnType<typeof vi.fn>;
+} {
+  const waitForTransaction = vi.fn().mockResolvedValue(receipt);
+  const provider = {
+    estimateGas: vi.fn().mockResolvedValue(BigInt(50_000)),
+    waitForTransaction,
+  } as unknown as ethers.JsonRpcProvider;
+  const rpcManager = {
+    executeWithFailover: (
+      op: (p: ethers.JsonRpcProvider) => Promise<unknown>
+    ) => op(provider),
+  } as unknown as ExecuteAsSafeOptions["rpcManager"];
+  return {
+    options: { chainId: 1, workflowId: "wf-1", rpcManager },
+    waitForTransaction,
+  };
+}
+
+type Invoke = (options: ExecuteAsSafeOptions) => Promise<unknown>;
+
+const cases: [string, Invoke][] = [
+  [
+    "executeContractCallAsSafe",
+    (options) =>
+      executeContractCallAsSafe(
+        signer,
+        {
+          safeAddress: SAFE,
+          ownerAddress: OWNER,
+          contractAddress: TARGET,
+          abi: ERC20_ABI,
+          functionKey: "transfer",
+          args: [RECIPIENT, BigInt(1)],
+        },
+        session,
+        options
+      ),
+  ],
+  [
+    "executeContractCallAsRole",
+    (options) =>
+      executeContractCallAsRole(
+        signer,
+        {
+          safeAddress: SAFE,
+          delegateAddress: OWNER,
+          rolesModifierAddress: MODIFIER,
+          roleKey: ROLE_KEY,
+          contractAddress: TARGET,
+          abi: ERC20_ABI,
+          functionKey: "transfer",
+          args: [RECIPIENT, BigInt(1)],
+        },
+        session,
+        options
+      ),
+  ],
+  [
+    "executeNativeTransferAsRole",
+    (options) =>
+      executeNativeTransferAsRole(
+        signer,
+        {
+          safeAddress: SAFE,
+          delegateAddress: OWNER,
+          rolesModifierAddress: MODIFIER,
+          roleKey: ROLE_KEY,
+          to: RECIPIENT,
+          amount: BigInt(1),
+        },
+        session,
+        options
+      ),
+  ],
+  [
+    "executeNativeTransferAsSafe",
+    (options) =>
+      executeNativeTransferAsSafe(
+        signer,
+        {
+          safeAddress: SAFE,
+          ownerAddress: OWNER,
+          to: RECIPIENT,
+          amount: BigInt(1),
+        },
+        session,
+        options
+      ),
+  ],
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe.each(cases)("%s", (_name, invoke) => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.submitSigned.mockResolvedValue({
+      hash: TX_HASH,
+      response: { hash: TX_HASH },
+    });
+  });
+
+  it("fails with OnChainRevertError when the mined receipt has status 0", async () => {
+    const { options } = makeRpcManager(makeReceipt(0));
+
+    const error: unknown = await invoke(options).catch((e: unknown) => e);
+
+    expect(isOnChainRevertError(error)).toBe(true);
+    expect(broadcastTransactionHash(error)).toBe(TX_HASH);
+    expect((error as { blockNumber?: number }).blockNumber).toBe(BLOCK);
+    expect((error as Error).message).toContain(
+      `reverted on-chain (status 0, block ${BLOCK})`
+    );
+    expect(mocks.recordTransaction).toHaveBeenCalledOnce();
+    expect(mocks.confirmTransaction).not.toHaveBeenCalled();
+    expect(mocks.finishMetrics).toHaveBeenCalledWith("failure");
+  });
+
+  it("treats a status-0 receipt found during broadcast reconciliation as a revert", async () => {
+    mocks.submitSigned.mockResolvedValue({
+      hash: TX_HASH,
+      response: { hash: TX_HASH },
+      preExistingReceipt: makeReceipt(0),
+    });
+    const { options, waitForTransaction } = makeRpcManager(makeReceipt(1));
+
+    const error: unknown = await invoke(options).catch((e: unknown) => e);
+
+    expect(isOnChainRevertError(error)).toBe(true);
+    expect(waitForTransaction).not.toHaveBeenCalled();
+    expect(mocks.confirmTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns the receipt and confirms the nonce for a status-1 receipt", async () => {
+    const { options } = makeRpcManager(makeReceipt(1));
+
+    const receipt = await invoke(options);
+
+    expect(receipt).toEqual({
+      hash: TX_HASH,
+      gasUsed: BigInt(90_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+      blockNumber: BLOCK,
+    });
+    expect(mocks.confirmTransaction).toHaveBeenCalledWith(TX_HASH);
+    expect(mocks.finishMetrics).toHaveBeenCalledWith("success");
+  });
+});

--- a/tests/unit/robinhood-trade-stock-token.test.ts
+++ b/tests/unit/robinhood-trade-stock-token.test.ts
@@ -98,6 +98,8 @@ vi.mock("@/lib/web3/gas-defaults", () => ({
   }),
 }));
 
+import { executeContractCallAsRole } from "@/lib/safe/execute-as-safe";
+import { OnChainRevertError } from "@/lib/web3/onchain-revert";
 import { tradeStockTokenCore } from "@/plugins/robinhood/steps/trade-stock-token-core";
 
 const AAPL = "0xaF3D76f1834A1d425780943C99Ea8A608f8a93f9";
@@ -267,6 +269,34 @@ describe("a clean trade", () => {
     const r = await tradeStockTokenCore(baseInput({ poolFee: "not-a-number" }));
     expect(r.success).toBe(false);
     expect(mockOnChain).not.toHaveBeenCalled();
+  });
+});
+
+describe("a reverted trade", () => {
+  it("carries the broadcast hash and chainId out of a Safe-role revert", async () => {
+    mockSignerMode.mockReturnValue({
+      kind: "safe-role",
+      safeAddress: "0x2222222222222222222222222222222222222222",
+      delegateAddress: "0x3333333333333333333333333333333333333333",
+      rolesModifierAddress: "0x4444444444444444444444444444444444444444",
+      roleKey: "0xrole",
+    } as never);
+    vi.mocked(executeContractCallAsRole).mockRejectedValue(
+      new OnChainRevertError({
+        message:
+          "Transaction 0xreverted reverted on-chain (status 0, block 500)",
+        transactionHash: "0xreverted",
+        blockNumber: 500,
+      })
+    );
+
+    const r = await tradeStockTokenCore(baseInput());
+
+    expect(r).toMatchObject({
+      success: false,
+      transactionHash: "0xreverted",
+      chainId: 4663,
+    });
   });
 });
 

--- a/tests/unit/write-failover.test.ts
+++ b/tests/unit/write-failover.test.ts
@@ -81,23 +81,31 @@ vi.mock("@/lib/web3/submit-signed", async () => {
 // Import module under test AFTER mocks
 // ---------------------------------------------------------------------------
 
+import { logUserError } from "@/lib/logging";
+import { getGasStrategy } from "@/lib/web3/gas-strategy";
 import type { NonceSession } from "@/lib/web3/nonce-manager";
 import { NonceConflictError } from "@/lib/web3/submit-signed";
 import {
+  executeContractTransaction,
+  executeTransaction,
   type SubmitAndConfirmOptions,
   submitAndConfirm,
   submitContractCallAndConfirm,
+  type TransactionContext,
 } from "@/lib/web3/transaction-manager";
+import { initializeWalletSigner } from "@/lib/web3/wallet-helpers";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeMockReceipt(hash: string): ethers.TransactionReceipt {
+function makeMockReceipt(hash: string, status = 1): ethers.TransactionReceipt {
   return {
     hash,
+    status,
     gasUsed: BigInt(21_000),
     gasPrice: BigInt(10_000_000_000),
+    blockNumber: 500,
   } as unknown as ethers.TransactionReceipt;
 }
 
@@ -124,6 +132,7 @@ function makeRpcManager(waitReceipt?: ethers.TransactionReceipt | null) {
         _opType: string
       ) => {
         const provider = {
+          estimateGas: vi.fn().mockResolvedValue(BigInt(50_000)),
           waitForTransaction: vi
             .fn()
             .mockImplementation((hash: string) =>
@@ -152,6 +161,45 @@ function makeOptions(
     maxFeePerGas: BigInt(20_000_000_000),
     ...overrides,
   };
+}
+
+function makeContext(
+  rpcManager: TransactionContext["rpcManager"]
+): TransactionContext {
+  return {
+    organizationId: "org-1",
+    executionId: "exec-1",
+    workflowId: "wf-1",
+    chainId: 1,
+    rpcUrl: "https://rpc.example",
+    rpcManager,
+  };
+}
+
+function makeContract(): ethers.Contract {
+  return {
+    runner: { provider: {}, signTransaction: vi.fn() },
+    connect: () => ({
+      getFunction: () => ({
+        estimateGas: vi.fn().mockResolvedValue(BigInt(50_000)),
+      }),
+    }),
+    interface: { encodeFunctionData: vi.fn().mockReturnValue("0xencodeddata") },
+    getAddress: vi.fn().mockResolvedValue("0xcontract"),
+  } as unknown as ethers.Contract;
+}
+
+function stubSignerAndGas(): void {
+  vi.mocked(initializeWalletSigner).mockResolvedValue({
+    provider: {},
+  } as never);
+  vi.mocked(getGasStrategy).mockReturnValue({
+    getGasConfig: vi.fn().mockResolvedValue({
+      gasLimit: BigInt(100_000),
+      maxFeePerGas: BigInt(20_000_000_000),
+      maxPriorityFeePerGas: BigInt(1_000_000_000),
+    }),
+  } as never);
 }
 
 // ---------------------------------------------------------------------------
@@ -317,5 +365,128 @@ describe("submitContractCallAndConfirm", () => {
         makeOptions()
       )
     ).rejects.toBeInstanceOf(NonceConflictError);
+  });
+});
+
+describe("executeTransaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSignerAndGas();
+  });
+
+  it("returns success: false and leaves the nonce unconfirmed when the mined receipt has status 0", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xreverted",
+      response: makeMockTxResponse("0xreverted"),
+    });
+    const rpcManager = makeRpcManager(makeMockReceipt("0xreverted", 0));
+
+    const result = await executeTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      () => ({ to: "0xrecipient", value: BigInt(0) }),
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Transaction 0xreverted reverted on-chain (status 0, block 500)"
+    );
+    expect(result.nonce).toBe(42);
+    expect(mockRecordTransaction).toHaveBeenCalledOnce();
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+    expect(logUserError).toHaveBeenCalledOnce();
+  });
+
+  it("treats a status-0 preExistingReceipt from broadcast reconciliation as a revert", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xreverted",
+      response: makeMockTxResponse("0xreverted"),
+      preExistingReceipt: makeMockReceipt("0xreverted", 0),
+    });
+    const rpcManager = makeRpcManager();
+
+    const result = await executeTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      () => ({ to: "0xrecipient", value: BigInt(0) }),
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("reverted on-chain (status 0");
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns success: true with the receipt for a status-1 receipt", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xmined",
+      response: makeMockTxResponse("0xmined"),
+    });
+    const rpcManager = makeRpcManager(makeMockReceipt("0xmined", 1));
+
+    const result = await executeTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      () => ({ to: "0xrecipient", value: BigInt(0) }),
+      makeSession()
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBe("0xmined");
+    expect(result.receipt?.status).toBe(1);
+    expect(mockConfirmTransaction).toHaveBeenCalledWith("0xmined");
+  });
+});
+
+describe("executeContractTransaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubSignerAndGas();
+  });
+
+  it("returns success: false and leaves the nonce unconfirmed when the mined receipt has status 0", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xreverted",
+      response: makeMockTxResponse("0xreverted"),
+    });
+    const rpcManager = makeRpcManager(makeMockReceipt("0xreverted", 0));
+
+    const result = await executeContractTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      makeContract(),
+      "transfer",
+      ["0xrecipient", BigInt(1000)],
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Transaction 0xreverted reverted on-chain (status 0, block 500)"
+    );
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+    expect(logUserError).toHaveBeenCalledOnce();
+  });
+
+  it("returns success: true for a status-1 receipt", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xmined",
+      response: makeMockTxResponse("0xmined"),
+    });
+    const rpcManager = makeRpcManager(makeMockReceipt("0xmined", 1));
+
+    const result = await executeContractTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      makeContract(),
+      "transfer",
+      ["0xrecipient", BigInt(1000)],
+      makeSession()
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.txHash).toBe("0xmined");
+    expect(mockConfirmTransaction).toHaveBeenCalledWith("0xmined");
   });
 });

--- a/tests/unit/write-failover.test.ts
+++ b/tests/unit/write-failover.test.ts
@@ -298,6 +298,27 @@ describe("submitAndConfirm", () => {
       )
     ).rejects.toThrow("receipt not available");
   });
+
+  it("throws and leaves the nonce unconfirmed when the mined receipt has status 0", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xreverted",
+      response: makeMockTxResponse("0xreverted"),
+    });
+    const options = makeOptions(undefined);
+    options.rpcManager = makeRpcManager(makeMockReceipt("0xreverted", 0));
+
+    await expect(
+      submitAndConfirm(
+        {} as never,
+        { to: "0xrecipient", value: BigInt(0), nonce: 42 },
+        options
+      )
+    ).rejects.toThrow(
+      "Transaction 0xreverted reverted on-chain (status 0, block 500)"
+    );
+
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+  });
 });
 
 describe("submitContractCallAndConfirm", () => {
@@ -437,6 +458,25 @@ describe("executeTransaction", () => {
     expect(result.receipt?.status).toBe(1);
     expect(mockConfirmTransaction).toHaveBeenCalledWith("0xmined");
   });
+
+  it("returns success: false rather than a receiptless success when the receipt is null", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xunread",
+      response: makeMockTxResponse("0xunread"),
+    });
+    const rpcManager = makeRpcManager(null);
+
+    const result = await executeTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      () => ({ to: "0xrecipient", value: BigInt(0) }),
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Transaction sent but receipt not available");
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+  });
 });
 
 describe("executeContractTransaction", () => {
@@ -488,5 +528,50 @@ describe("executeContractTransaction", () => {
     expect(result.success).toBe(true);
     expect(result.txHash).toBe("0xmined");
     expect(mockConfirmTransaction).toHaveBeenCalledWith("0xmined");
+  });
+
+  it("treats a status-0 preExistingReceipt from broadcast reconciliation as a revert", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xreverted",
+      response: makeMockTxResponse("0xreverted"),
+      preExistingReceipt: makeMockReceipt("0xreverted", 0),
+    });
+    const rpcManager = makeRpcManager();
+
+    const result = await executeContractTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      makeContract(),
+      "transfer",
+      ["0xrecipient", BigInt(1000)],
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("reverted on-chain (status 0");
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns success: false rather than a receiptless success when the receipt is null", async () => {
+    mockSubmitSigned.mockResolvedValue({
+      hash: "0xunread",
+      response: makeMockTxResponse("0xunread"),
+    });
+    const rpcManager = makeRpcManager(null);
+
+    const result = await executeContractTransaction(
+      makeContext(rpcManager),
+      "0xABCD",
+      makeContract(),
+      "transfer",
+      ["0xrecipient", BigInt(1000)],
+      makeSession()
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      "Contract transaction sent but receipt not available"
+    );
+    expect(mockConfirmTransaction).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Failure mode

A Safe-routed write (`execTransaction`) is built with `safeTxGas=0` and `gasPrice=0`, and a role-routed write (`execTransactionWithRole`) is sent with `shouldRevert=true`. In both cases an inner-call failure reverts the whole outer transaction, so the receipt comes back mined with `status: 0`.

The four executors in `lib/safe/execute-as-safe.ts` and the `executeTransaction` / `executeContractTransaction` helpers in `lib/web3/transaction-manager.ts` wait for that receipt with `provider.waitForTransaction`, which, unlike `tx.wait()`, resolves a status-0 receipt instead of throwing. None of them read `receipt.status`, so a reverted Safe write was returned to its caller as a successful write: downstream workflow steps ran on a false success, and the roles orchestrator would persist a role configuration as installed after its configuration transaction reverted. The finalize-time verifier (`lib/web3/verify-receipt.ts`) does catch the status-0 receipt and demote the run, but only after the rest of the workflow has executed.

## Change

- `lib/safe/execute-as-safe.ts`: a module-private `throwIfReverted(receipt)` throws `OnChainRevertError` (hash and block number attached, same message format as `confirmTransaction` in `lib/web3/chain-adapter/evm.ts`) when `receipt.status === 0`. It runs at all four sites after the existing null-receipt check and before `nonceManager.confirmTransaction`, so the error passes through `finishOnError` and the `safe.tx.*` metric records `failure`. The plugin steps that call these executors read `broadcastTransactionHash(error)` in their catch and attach the hash and chain id to the failed step output; `plugins/robinhood/steps/trade-stock-token-core.ts` was the one that did not, and this PR brings it in line. `app/api/user/wallet/withdraw/route.ts` also calls two of these executors and rethrows without recovering the hash - it is an API route rather than a workflow step, so no finalizer reads its output, and it is left alone here.
- `lib/web3/transaction-manager.ts`: the same check (accepting a nullable receipt) runs in `executeTransaction` and `executeContractTransaction` before `confirmTransaction`. The existing catch turns the throw into `{ success: false, error, nonce }`, which every `executeTransaction` caller - `lib/safe/deployment.ts:233` and five sites in `lib/safe/roles-orchestrator.ts` - already handles by throwing `result.error` and returning `success: false` from its own catch, before any DB write. `executeContractTransaction` has no production callers at all; it is guarded for consistency, not for a live path.
- `lib/web3/transaction-manager.ts`: `confirmAndBuildResult` gets the same status-0 guard. It has no production callers today - `submitAndConfirm` and `submitContractCallAndConfirm` appear only in tests - but both are exported and tested, so the guard is there for consistency rather than for a live path.
- `lib/web3/transaction-manager.ts`: `executeTransaction` and `executeContractTransaction` had no null-receipt handling to leave unchanged - they returned `success: true` with `receipt: undefined` - so this PR adds the same throw the other sites already had. The path is not reachable through the real provider (`waitForTransaction` is called without a timeout argument, and `executeWithFailover` rejects on timeout rather than resolving null), but it is the same false-success class the PR exists to close.
- `plugins/robinhood/steps/trade-stock-token-core.ts`: the failure branch of `TradeStockTokenResult` now carries `transactionHash` and `chainId`, and the catch attaches them with the same inline-spread pattern used by `transfer-funds-core.ts`, `approve-token-core.ts` and `transfer-token-core.ts`. `chainId` is load-bearing: `reconcileTransactionHashes` fails a batch conclusively for a hash it cannot attribute to a chain.
- Not changed: the null-receipt handling in `lib/safe/execute-as-safe.ts`; and `validateReceiptStatus` in `deployment.ts`, which is now only reachable with a status-1 receipt and is left as a second check.

## Tests

- New `tests/unit/execute-as-safe.test.ts`, table-driven over all four executors: a status-0 receipt from `waitForTransaction` rejects with `OnChainRevertError` carrying the hash and block, leaves the nonce unconfirmed, and records a `failure` metric; a status-0 `preExistingReceipt` from broadcast reconciliation is treated the same; a status-1 receipt still returns the receipt shape and confirms the nonce.
- `tests/unit/write-failover.test.ts`: `executeTransaction` and `executeContractTransaction` return `success: false` with the revert message and leave the nonce unconfirmed on status 0 (including the `preExistingReceipt` path); status 1 still returns `success: true`.
- `tests/unit/robinhood-trade-stock-token.test.ts`: a SAFE_ROLE trade whose `executeContractCallAsRole` rejects with an `OnChainRevertError` returns `success: false` carrying both `transactionHash` and `chainId`.
- `tests/unit/write-failover.test.ts` also covers the `submitAndConfirm` status-0 path, the null-receipt path for both `executeTransaction` and `executeContractTransaction`, and the `preExistingReceipt` status-0 case for `executeContractTransaction` that was previously only covered for `executeTransaction`.
- Negative control (measured against the original two-file change, before the additions above): with the two source files stashed, exactly the 11 status-0 tests fail and the other 12 pass.

## Verification

Run locally in a `node:22-slim` container against the repo's `node_modules`:

- `tsx scripts/discover-plugins.ts`: ok
- `tsc` (no emit, the `pnpm type-check` equivalent): 74 errors before and after the change, identical sets, all pre-existing `Cannot find module '@coral-xyz/anchor'` / `'@solana/spl-token'` in Solana test files (a local install artifact); none in the touched files
- `biome check` on the four touched files: clean
- `vitest run tests/unit/execute-as-safe.test.ts tests/unit/write-failover.test.ts`: 23 passed
- `vitest run` on `onchain-revert`, `evm-chain-adapter-post-broadcast`, `safe-roles-orchestrator`: 31 passed; `write-contract-core` and `transfer-token-core` fail at import with `Cannot find package 'ioredis'` from `lib/redis.ts`, identically on the unchanged base

## Decisions

- The status check runs before `nonceManager.confirmTransaction`, matching the EVM adapter. The pending row is reconciled by the next session's `validateAndReconcile`, which marks any mined pending row confirmed.
- In `executeTransaction` / `executeContractTransaction` the existing catch flattens the error to `result.error` (message only). None of the current callers consume a structured hash on the failure path, so the `TransactionResult` shape was left alone.

## Follow-up, not fixed here

`installRolesWithInitialConfig` runs two transactions with no persistence between them. Before this change, a reverted configuration transaction was returned as a success and the role was persisted `active`. After it, the call throws with the Roles modifier proxy from transaction 1 already deployed and nothing in the DB - and the install can never succeed again for that `(organizationId, chainId)`: `defaultSaltNonce` is `keccak256` over `("kh-zodiac-roles", organizationId, chainId)` with a fixed initializer, so the CREATE2 address is fixed, and per EIP-684 a `CREATE2` to an address that already has code fails. Reconcile does not rescue it - `probeRolesModifierOnChain` and `reconcileSafeRoleFromChain` both discover the modifier only by reading the Safe's enabled-module list, and `enableModule` was in the reverted transaction's MultiSend, so the orphaned proxy is invisible to them. There is also a second-order case: an out-of-band `enableModule(orphanProxy)` from the Safe UI would make reconcile report `installed` and write `status: "active"` for a proxy that never received `assignRoles`, `setDefaultRole`, or any scope.

This is strictly better than the pre-change behaviour, which persisted `active` after the revert with no manual step at all, so it is not a blocker for this PR. The fix is to persist the proxy address between the two transactions, or to include a retry counter in the salt.
