### PR TITLE
refactor: KEEP-1294 remove the retired conservative gas multiplier

### DIFF
--- a/app/api/gas/estimate/route.ts
+++ b/app/api/gas/estimate/route.ts
@@ -375,7 +375,6 @@ export async function POST(request: Request): Promise<NextResponse> {
       estimatedGas: result.toString(),
       chainDefaults: {
         multiplier: chainDefaults.multiplier,
-        conservative: chainDefaults.conservative,
       },
     });
   } catch (error) {

--- a/components/workflow/config/gas-limit-multiplier-field.tsx
+++ b/components/workflow/config/gas-limit-multiplier-field.tsx
@@ -171,7 +171,7 @@ export function GasLimitMultiplierField({
 
       const data = (await response.json()) as {
         estimatedGas: string;
-        chainDefaults: { multiplier: number; conservative: number };
+        chainDefaults: { multiplier: number };
       };
 
       setEstimate({ status: "success", estimatedGas: data.estimatedGas });

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -124,8 +124,10 @@ Failed steps are retried with exponential backoff. To reduce risk: test on Sepol
 
 KeeperHub calls `eth_estimateGas` and applies a multiplier per chain:
 
-- Ethereum and Polygon: 2.0x normally, 2.5x for time-sensitive triggers (events, webhooks)
-- Base and Arbitrum: 1.5x normally, 2.0x for time-sensitive triggers
+- Ethereum, Polygon, 0G, and any network without a specific default: 2.0x
+- Arbitrum, Base, Robinhood Chain, and Tempo: 1.5x (L2 estimates are more accurate)
+
+The multiplier does not depend on how the workflow was triggered.
 
 You can override the gas limit on any action node in its Advanced section. Gas pricing (base fee, priority fee) is handled automatically. See [Gas Management](/wallet-management/gas) for more.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ When a step fails, KeeperHub retries with configurable behavior. Failed runs are
 
 ### Supported Chains
 
-KeeperHub operates on Ethereum, Base, Arbitrum, Polygon, Sepolia, and additional EVM-compatible networks. Chain-specific gas defaults are applied automatically based on network conditions and trigger type. See [Gas Management](/wallet-management/gas) for details.
+KeeperHub operates on Ethereum, Base, Arbitrum, Polygon, Sepolia, and additional EVM-compatible networks. Chain-specific gas defaults are applied automatically. See [Gas Management](/wallet-management/gas) for details.
 
 Solana mainnet and devnet are supported for native SOL transfers and SPL token transfers. The same Turnkey wallet holds both an EVM and a Solana address. Contract calls, protocol plugins, and dry runs are EVM only today. See [Web3 Plugin](/plugins/web3) for the Solana actions and [Turnkey Wallets](/wallet-management/turnkey) for how the addresses are provisioned.
 

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -25,18 +25,20 @@ The multiplier exists because gas estimates are point-in-time snapshots. Between
 
 Defaults vary by chain type. L2 networks use lower multipliers because their gas estimates tend to be more accurate.
 
-| Chain | Standard Multiplier | Conservative Multiplier |
-|-------|-------------------|----------------------|
-| Ethereum | 2.0x | 2.5x |
-| Polygon | 2.0x | 2.5x |
-| Arbitrum | 1.5x | 2.0x |
-| Base | 1.5x | 2.0x |
+| Network | Multiplier |
+|---------|-----------|
+| Ethereum, Ethereum Sepolia | 2.0x |
+| Polygon, Polygon Amoy | 2.0x |
+| 0G, 0G Galileo | 2.0x |
+| Arbitrum One, Arbitrum Sepolia | 1.5x |
+| Base, Base Sepolia | 1.5x |
+| Robinhood Chain and its testnet | 1.5x |
+| Tempo, Tempo Moderato | 1.5x |
+| Any other EVM network | 2.0x (global default) |
 
-**Standard** multiplier is used for manual triggers and scheduled workflows.
+The same multiplier applies however the workflow was triggered. A manual run, a scheduled run, a webhook, and an event trigger hitting the same contract on the same network all receive the same gas limit.
 
-**Conservative** multiplier is used for time-sensitive triggers (event-based, webhook) where retry opportunity is limited and failing the transaction is more costly.
-
-These defaults are resolved in order: database chain config > hardcoded chain overrides > global default (2.0x / 2.5x).
+These defaults are resolved in order: database chain config > hardcoded chain overrides > global default (2.0x).
 
 ## Gas Limit Override
 
@@ -48,7 +50,7 @@ You can set an absolute gas limit per action node:
 
 ### Field Behavior
 
-- **When empty**: The default 2.0x multiplier is applied to the gas estimate at execution time
+- **When empty**: The chain's default multiplier (see [Default Multipliers](#default-multipliers)) is applied to the gas estimate at execution time
 - **When set**: Your absolute value is used directly as the transaction gas limit, bypassing the multiplier
 
 The field also shows a live gas estimate when enough configuration is filled in (network, contract address, function, etc.). This helps you choose an appropriate gas limit. If your value is below the current estimate, a warning is shown.
@@ -98,11 +100,11 @@ Sponsored gas is metered in USD against your plan's monthly gas credit cap (show
 
 ### What happens if I leave the gas limit empty?
 
-The default 2.0x multiplier is applied to the gas estimate at execution time. For time-sensitive triggers (event-based, webhook), a 2.5x conservative multiplier is used instead.
+The chain's default multiplier is applied to the gas estimate at execution time: 2.0x on most networks, 1.5x on the L2s listed under [Default Multipliers](#default-multipliers). The trigger type has no effect on it.
 
 ### What happens if my gas limit is too low?
 
-The transaction will revert with an "out of gas" error. You will still pay for the gas consumed up to the limit. KeeperHub's retry logic may re-attempt with the default multiplier.
+The transaction is mined but reverts with an "out of gas" error, and you still pay for the gas consumed up to the limit. KeeperHub does not retry it: the run fails and reports the revert, including the transaction hash. Raise or clear the gas limit and run the workflow again.
 
 ### What happens if my gas limit is too high?
 

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -57,7 +57,7 @@ The field also shows a live gas estimate when enough configuration is filled in 
 
 ### Example
 
-If the network estimates 100,000 gas for your transaction:
+If the network estimates 100,000 gas for your transaction and the network's default multiplier is 2.0x:
 
 | Gas Limit Setting | Result |
 |-------------------|--------|

--- a/lib/web3/gas-defaults.ts
+++ b/lib/web3/gas-defaults.ts
@@ -4,9 +4,11 @@
  * Two related concerns live here:
  *
  *  1. CHAIN_GAS_DEFAULTS / getChainGasDefaults(chainId)
- *     Display-only multipliers mirroring the hardcoded entries in
- *     gas-strategy.ts. UI code (e.g. gas-limit-multiplier-field.tsx) reads
- *     these to show users what default would apply.
+ *     Display-only gas limit multipliers. Each entry must carry the same
+ *     gasLimitMultiplier as the matching chain in getHardcodedOverrides in
+ *     gas-strategy.ts (kept in sync by hand: that module imports ethers and
+ *     the DB, so it cannot be imported here). /api/gas/estimate returns these
+ *     next to the estimate so clients can show what default would apply.
  *
  *  2. resolveGasLimitOverrides / parsePriorityFeeGwei
  *     Execution-path helpers that turn user-supplied strings into the
@@ -22,7 +24,6 @@
 
 export type ChainGasDefaults = {
   multiplier: number;
-  conservative: number;
 };
 
 /**
@@ -68,30 +69,37 @@ export function parseGasLimitConfig(
 
 const CHAIN_GAS_DEFAULTS: Record<number, ChainGasDefaults> = {
   // Ethereum mainnet
-  1: { multiplier: 2.0, conservative: 2.5 },
+  1: { multiplier: 2.0 },
   // Sepolia testnet
-  11155111: { multiplier: 2.0, conservative: 2.5 },
+  11155111: { multiplier: 2.0 },
   // Arbitrum One
-  42161: { multiplier: 1.5, conservative: 2.0 },
+  42161: { multiplier: 1.5 },
   // Arbitrum Sepolia
-  421614: { multiplier: 1.5, conservative: 2.0 },
+  421614: { multiplier: 1.5 },
   // Base
-  8453: { multiplier: 1.5, conservative: 2.0 },
+  8453: { multiplier: 1.5 },
   // Base Sepolia
-  84532: { multiplier: 1.5, conservative: 2.0 },
+  84532: { multiplier: 1.5 },
   // Polygon
-  137: { multiplier: 2.0, conservative: 2.5 },
+  137: { multiplier: 2.0 },
   // Polygon Amoy testnet
-  80002: { multiplier: 2.0, conservative: 2.5 },
+  80002: { multiplier: 2.0 },
+  // Robinhood Chain
+  4663: { multiplier: 1.5 },
+  // Robinhood Chain testnet
+  46630: { multiplier: 1.5 },
   // 0G Galileo testnet
-  16602: { multiplier: 2.0, conservative: 2.5 },
+  16602: { multiplier: 2.0 },
   // 0G Mainnet
-  16661: { multiplier: 2.0, conservative: 2.5 },
+  16661: { multiplier: 2.0 },
+  // Tempo mainnet
+  4217: { multiplier: 1.5 },
+  // Tempo Moderato testnet
+  42431: { multiplier: 1.5 },
 };
 
 const GLOBAL_DEFAULT: ChainGasDefaults = {
   multiplier: 2.0,
-  conservative: 2.5,
 };
 
 /**

--- a/lib/web3/gas-strategy.ts
+++ b/lib/web3/gas-strategy.ts
@@ -12,7 +12,7 @@
  * scheduled, webhook, event). This eliminates the manual-vs-webhook divergence
  * that surfaced in KEEP-384.
  *
- * @see docs/keeperhub/KEEP-1240/gas.md for full specification
+ * @see docs/wallet-management/gas.md for the user-facing description
  */
 
 import { eq } from "drizzle-orm";


### PR DESCRIPTION
## Summary

The trigger-type-dependent "conservative" gas limit multiplier was removed from the gas strategy on 2026-04-30 (commit 54371f58c). `lib/web3/gas-strategy.ts` states in its header that the strategy is never a function of trigger type, `getGasConfig` has no trigger parameter, and `getHardcodedOverrides` carries one `gasLimitMultiplier` per chain. The concept survived in the published docs, in `lib/web3/gas-defaults.ts`, and in the `/api/gas/estimate` response. This PR removes it everywhere it was still described or returned.

## What the code actually does

- One gas limit multiplier per chain, resolved as database `gas_config` > `getHardcodedOverrides` > 2.0 default. Values in `getHardcodedOverrides` at the base commit: 2.0 for Ethereum, Sepolia, Polygon, Polygon Amoy, 0G and 0G Galileo; 1.5 for Arbitrum One, Arbitrum Sepolia, Base, Base Sepolia, Robinhood Chain and its testnet, Tempo and Tempo Moderato.
- Trigger type is not an input anywhere in `getGasConfig` or `calculateGasLimit`.
- An out-of-gas transaction is a settled on-chain revert. `lib/web3/chain-adapter/evm.ts` turns it into an `OnChainRevertError` carrying the hash; every web3 write step sets `maxRetries = 0`; the Direct Execution retry helper (`app/api/execute/_lib/retry.ts`) only retries fee and connectivity patterns (replacement fee too low, nonce already used, underpriced, already known, timeout, ETIMEDOUT, ECONNRESET), never a revert; and the gas-escalation `executeWithRetry` in `gas-strategy.ts` has no callers. So the docs' "retry logic may re-attempt with the default multiplier" described nothing that exists.

## Changes

Docs (`docs/` is published to docs.keeperhub.com; `docs-site/content` is a symlink to it, so there is one copy):
- `docs/wallet-management/gas.md`: the Standard/Conservative table becomes one per-network multiplier table with the values above plus the 2.0x global default; the trigger-type sentences are replaced by a statement that the multiplier does not depend on the trigger; the resolution order line reads "global default (2.0x)"; the "When empty" bullet and the "leave the gas limit empty" FAQ point at the chain default instead of a flat 2.0x (the new table shows 1.5x on L2s, so a flat 2.0x on the same page would contradict it); the "too low" FAQ now says the transaction reverts out of gas, KeeperHub does not retry it, and the run fails and reports the revert.
- `docs/FAQ.md` ("How does gas estimation work?") and `docs/index.md` ("Supported Chains") repeated the trigger-type claim and are corrected in the same way.

Code:
- `lib/web3/gas-defaults.ts`: `conservative` removed from `ChainGasDefaults`, the per-chain table and `GLOBAL_DEFAULT`. The header comment no longer claims the UI reads these values (the multiplier field only reads `estimatedGas`); it now states the real constraint, that each entry must match `getHardcodedOverrides` and is kept in sync by hand because that module imports ethers and the DB. One step beyond the ticket's literal list: the table was also missing Robinhood Chain (4663, 46630) and Tempo (4217, 42431), which `getHardcodedOverrides` sets to 1.5, so the estimate API reported 2.0 for them. Those four entries are added so the file, the API and the new docs table agree. Happy to split this out if it should be its own change.
- `app/api/gas/estimate/route.ts`: the response no longer includes `chainDefaults.conservative`.
- `components/workflow/config/gas-limit-multiplier-field.tsx`: the response type drops the field.
- `lib/web3/gas-strategy.ts`: the header's `@see` pointed at `docs/keeperhub/KEEP-1240/gas.md`, which does not exist in the repository; it now points at `docs/wallet-management/gas.md`.

## Consumer check for the removed API field

Searched before removing `chainDefaults.conservative`:
- This repository (`components/`, `lib/`, `app/`, `tests/`, `docs/`, `specs/`): the only caller of `/api/gas/estimate` is `gas-limit-multiplier-field.tsx`, which types the field but never reads `chainDefaults` at all. No test asserts it. The endpoint is not documented under `docs/api/**` and has no entry in `specs/api-coverage.json`, so `check:api-docs` is unaffected.
- The `cli` repository: zero hits for `conservative`, `gas/estimate` or `chainDefaults`.

No consumer reads the field, so it is removed outright rather than kept as a deprecated alias.

Not changed, for the record: migration `drizzle/0013_chain-gas-config.sql` seeds a `gasLimitMultiplierConservative` key into the `chains.gas_config` jsonb and mentions it in the column comment. `getChainConfig` spreads the jsonb over `GasStrategyConfig`, which has no such key, so the value is inert. Migrations are immutable and cleaning the live rows would be a data change, so it is left as a follow-up: KEEP-1314 tracks a new migration to rewrite the column comment and strip the key from the existing rows.

## Verification

Run in a `node:22-slim` container against this branch (the host has no node):

- `tsx scripts/discover-plugins.ts`: ok.
- `tsc --noEmit`: 74 errors, all `Cannot find module` for packages missing from the local `node_modules` (`ioredis`, `driver.js`, `deep-diff`, `@coral-xyz/anchor`, `@solana/spl-token`) or type errors in files this PR does not touch. Baselined by stashing the diff and re-running: 74 errors, byte-identical list.
- `biome check lib/web3/gas-defaults.ts app/api/gas/estimate/route.ts lib/web3/gas-strategy.ts`: clean. (`components/workflow` is excluded from biome by `biome.jsonc`.)
- `vitest run tests/unit/gas-strategy.test.ts tests/unit/gas-estimate-batch-write.test.ts`: 55 passed.
- `vitest run tests/unit/oauth-scope-route-gate.test.ts tests/unit/write-contract-core.test.ts`: both fail at import on the same missing local packages (`bs58`, `ioredis`); identical on a clean checkout of the base branch.
- `check:api-docs`: not run, the endpoint is not part of `docs/api/**` or `specs/api-coverage.json`.
- Added lines scanned for `--`, ticket ids and non-ASCII: none in prose (the only `--` is a markdown table separator).

CI is the authority for type-check, build and the full unit suite.

