### PR TITLE
fix: schedule the execution reconciler and move cron routes to internal-service HMAC

### DIFF
--- a/app/api/cron/audit-retention/route.ts
+++ b/app/api/cron/audit-retention/route.ts
@@ -4,12 +4,17 @@
  * permits deleting rows past that window, so this job is the sole path that
  * can remove audit data and it can only ever remove already-expired rows.
  *
- * Deployment: invoked by an external scheduler (Kubernetes CronJob), e.g.
- * daily. Authorized via `Authorization: Bearer $CRON_SECRET`, mirroring the
- * other cron routes. Fails closed when CRON_SECRET is unset; no NODE_ENV
- * bypass.
+ * Deployment: intended for a Kubernetes CronJob (e.g. daily) that runs
+ * `deploy/scripts/reaper.sh` against this path, the same way the other cron
+ * routes are scheduled. No CronJob is defined for it yet: scheduling a
+ * retention deletion is a product decision that has not been taken.
+ * Authorized via the internal-service HMAC scheme (`X-KH-Caller`,
+ * `X-KH-Timestamp`, `X-KH-Signature` signed with
+ * `INTERNAL_SERVICE_HMAC_SECRET`) through `authenticateInternalService`. Fails
+ * closed when the signature does not verify; there is no NODE_ENV bypass.
  */
 
+import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import {
   AUDIT_RETENTION_DAYS,
@@ -18,17 +23,13 @@ import {
 
 export const dynamic = "force-dynamic";
 
-function isAuthorized(request: Request): boolean {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) {
-    return false;
-  }
-  return request.headers.get("authorization") === `Bearer ${expected}`;
-}
-
 export async function GET(request: Request): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return Response.json({ error: "unauthorized" }, { status: 401 });
+  const auth = await authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return Response.json(
+      { error: auth.error ?? "Unauthorized" },
+      { status: auth.status }
+    );
   }
 
   try {

--- a/app/api/cron/execution-reconciler/route.ts
+++ b/app/api/cron/execution-reconciler/route.ts
@@ -1,30 +1,34 @@
 /**
- * Settles direct executions stuck in `unconfirmed`: a transaction was
- * broadcast, but the chain had not answered by the time the request had to.
- * Re-reads each receipt and moves the row to completed or failed once the
- * outcome is known.
+ * Settles executions stuck in `unconfirmed`: a transaction was broadcast, but
+ * the chain had not answered by the time the request had to. Covers both
+ * direct executions and workflow runs. Re-reads each receipt and moves the row
+ * to completed or failed once the outcome is known, or to failed once a
+ * transaction has been absent from every endpoint for long enough that it can
+ * only have been dropped.
  *
- * Deployment: invoked by an external scheduler (Kubernetes CronJob), on the
- * order of every minute. Authorized via `Authorization: Bearer $CRON_SECRET`,
- * mirroring the other cron routes. Fails closed when CRON_SECRET is unset.
+ * Deployment: invoked by the `execution-reconciler` Kubernetes CronJob (the
+ * job of that name in `deploy/keeperhub-stack/{prod,staging}/values.yaml`,
+ * which runs `deploy/scripts/reaper.sh` against this path) every two minutes.
+ * Authorized via the internal-service HMAC scheme (`X-KH-Caller`,
+ * `X-KH-Timestamp`, `X-KH-Signature` signed with
+ * `INTERNAL_SERVICE_HMAC_SECRET`) through `authenticateInternalService`, the
+ * same mechanism the reaper CronJob uses. Fails closed when the signature does
+ * not verify; there is no NODE_ENV bypass.
  */
 
 import { reconcileUnconfirmedExecutions } from "@/lib/execute/reconcile-executions";
+import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 
 export const dynamic = "force-dynamic";
 
-function isAuthorized(request: Request): boolean {
-  const expected = process.env.CRON_SECRET;
-  if (!expected) {
-    return false;
-  }
-  return request.headers.get("authorization") === `Bearer ${expected}`;
-}
-
 export async function GET(request: Request): Promise<Response> {
-  if (!isAuthorized(request)) {
-    return Response.json({ error: "unauthorized" }, { status: 401 });
+  const auth = await authenticateInternalService(request);
+  if (!auth.authenticated) {
+    return Response.json(
+      { error: auth.error ?? "Unauthorized" },
+      { status: auth.status }
+    );
   }
 
   try {

--- a/app/api/execute/_lib/execution-service.ts
+++ b/app/api/execute/_lib/execution-service.ts
@@ -132,8 +132,10 @@ export async function completeExecution(
       estimatedCostUsd: result.estimatedCostUsd ?? null,
       // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
       output: (result.output ?? {}) as any,
-      // An unconfirmed execution has not completed, and the reconciler uses a
-      // null completedAt to find rows that still need settling.
+      // An unconfirmed execution has not completed, so it carries no
+      // completedAt. The reconciler finds rows that still need settling by
+      // status = 'unconfirmed' (lib/execute/reconcile-executions.ts), not by a
+      // null completedAt.
       completedAt: isTerminal ? new Date() : null,
     })
     .where(eq(directExecutions.id, executionId));
@@ -216,8 +218,9 @@ export async function failExecution(
         ? {}
         : // biome-ignore lint/suspicious/noExplicitAny: jsonb column accepts arbitrary serializable data
           { output: { sponsored: params.sponsored } as any }),
-      // The reconciler finds rows still needing settlement by their null
-      // completedAt, so an unconfirmed row must not carry one.
+      // The reconciler finds rows still needing settlement by
+      // status = 'unconfirmed' (lib/execute/reconcile-executions.ts); an
+      // unconfirmed row carries no completedAt because it has not finished.
       completedAt: status === "failed" ? new Date() : null,
     })
     .where(eq(directExecutions.id, executionId));

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -676,7 +676,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-prod
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/2 * * * *" # every 2 minutes; the reconciler only re-reads rows older than 30s
+        schedule: "1-59/2 * * * *" # every 2 minutes, offset by 1 minute per this file's convention; the reconciler only re-reads rows older than 30s
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -671,6 +671,33 @@ app:
         failedJobsHistoryLimit: 3
         restartPolicy: OnFailure
         backoffLimit: 2
+      - name: execution-reconciler
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-prod
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "*/2 * * * *" # every 2 minutes; the reconciler only re-reads rows older than 30s
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/cron/execution-reconciler"
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-prod/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
       - name: execution-digest
         image:
           repository: ${ECR_REGISTRY}/keeperhub-prod

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -610,6 +610,33 @@ app:
         failedJobsHistoryLimit: 3
         restartPolicy: OnFailure
         backoffLimit: 2
+      - name: execution-reconciler
+        image:
+          repository: ${ECR_REGISTRY}/keeperhub-staging
+          tag: app-${IMAGE_TAG}
+          imagePullPolicy: Always
+        schedule: "*/2 * * * *" # every 2 minutes; the reconciler only re-reads rows older than 30s
+        command: ["/bin/sh"]
+        args:
+          - "/app/deploy/scripts/reaper.sh"
+          - "http://keeperhub-common:3000/api/cron/execution-reconciler"
+        env:
+          INTERNAL_SERVICE_HMAC_SECRET:
+            type: parameterStore
+            name: internal-service-hmac-secret
+            parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
+            cpu: "10m"
+        concurrencyPolicy: Forbid
+        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        restartPolicy: OnFailure
+        backoffLimit: 2
       - name: execution-digest
         image:
           repository: ${ECR_REGISTRY}/keeperhub-staging

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -615,7 +615,7 @@ app:
           repository: ${ECR_REGISTRY}/keeperhub-staging
           tag: app-${IMAGE_TAG}
           imagePullPolicy: Always
-        schedule: "*/2 * * * *" # every 2 minutes; the reconciler only re-reads rows older than 30s
+        schedule: "1-59/2 * * * *" # every 2 minutes, offset by 1 minute per this file's convention; the reconciler only re-reads rows older than 30s
         command: ["/bin/sh"]
         args:
           - "/app/deploy/scripts/reaper.sh"

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -485,6 +485,33 @@ cronjob:
       failedJobsHistoryLimit: 3
       restartPolicy: OnFailure
       backoffLimit: 2
+    - name: execution-reconciler
+      image:
+        repository: ${ECR_REGISTRY}/keeperhub-staging
+        tag: app-${IMAGE_TAG}
+        imagePullPolicy: Always
+      schedule: "* * * * *" # every minute (faster than prod for PR validation)
+      command: ["/bin/sh"]
+      args:
+        - "/app/deploy/scripts/reaper.sh"
+        - "http://keeperhub-pr-${PR_NUMBER}-common:3000/api/cron/execution-reconciler"
+      env:
+        INTERNAL_SERVICE_HMAC_SECRET:
+          type: parameterStore
+          name: internal-service-hmac-secret
+          parameter_name: /eks/techops-staging/keeperhub/internal-service-hmac-secret
+      resources:
+        requests:
+          memory: "32Mi"
+          cpu: "10m"
+        limits:
+          memory: "32Mi"
+          cpu: "10m"
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 3
+      restartPolicy: OnFailure
+      backoffLimit: 2
     - name: tempo-broadcast-due
       image:
         repository: ${ECR_REGISTRY}/keeperhub-staging

--- a/lib/execute/reconcile-executions.ts
+++ b/lib/execute/reconcile-executions.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, isNotNull, lt } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, lt } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   type DirectExecution,
@@ -37,10 +37,15 @@ import {
 const DROPPED_AFTER_MS = 24 * 60 * 60 * 1000;
 // Give the write path's own retries room to finish before re-reading.
 const MIN_AGE_MS = 30 * 1000;
-// Every eligible row is read in one narrow query, so a backlog of rows that
-// stay unreadable cannot hide the rows behind them. This cap only bounds memory;
+// Upper bound on the rows one run reads newest-first. It bounds memory only;
 // the work a run does is bounded by the time budget below.
 const DEFAULT_MAX_ROWS = 2000;
+// Once the eligible set exceeds DEFAULT_MAX_ROWS the newest-first read can
+// never reach its tail, and the tail is exactly the set old enough to reach the
+// 24h dropped verdict and leave. So every run also reads a small oldest-first
+// slice and examines it before the newest-first sweep, which drains that tail
+// at a bounded rate however large the backlog grows.
+const OLDEST_SLICE_ROWS = 100;
 // Wall-clock budget for one run. The CronJob fires every two minutes with
 // concurrencyPolicy Forbid, and a receipt lookup against an endpoint that times
 // out instead of answering can take tens of seconds, so without a budget one
@@ -52,6 +57,8 @@ export type ReconcileSummary = {
   examined: number;
   completed: number;
   failed: number;
+  // Rows this run did not move to a terminal state: still open, or settled by
+  // another writer before this run's guarded update reached them.
   stillUnconfirmed: number;
   // Eligible rows the run did not reach before its time budget ran out.
   deferred: number;
@@ -122,14 +129,16 @@ function toReceiptEntries(
 }
 
 // Every write below is guarded on the row still being unconfirmed, so a run
-// never overwrites a verdict something else reached first.
+// never overwrites a verdict something else reached first. Reports whether this
+// call performed the transition, so a run that lost the race does not tally a
+// settle it did not make - the same reason settleWorkflow reads `returning`.
 async function settle(
   executionId: string,
   status: "completed" | "failed",
   receipts: DirectExecutionReceiptEntry[],
   error: string | null
-): Promise<void> {
-  await db
+): Promise<boolean> {
+  const updated = await db
     .update(directExecutions)
     .set({ status, error, receipts, completedAt: new Date() })
     .where(
@@ -137,7 +146,19 @@ async function settle(
         eq(directExecutions.id, executionId),
         eq(directExecutions.status, "unconfirmed")
       )
-    );
+    )
+    .returning({ id: directExecutions.id });
+  return updated.length > 0;
+}
+
+// A settle that matched no row means another writer reached a verdict first;
+// this run neither completed nor failed the row, so it reports the outcome it
+// did reach.
+function settledOutcome(
+  settled: boolean,
+  verdict: "completed" | "failed"
+): SettleOutcome {
+  return settled ? verdict : "unconfirmed";
 }
 
 async function reconcileOne(
@@ -147,13 +168,13 @@ async function reconcileOne(
   const chainId = resolveChainId(execution);
   const hash = execution.transactionHash;
   if (!hash || chainId === null) {
-    await settle(
+    const settled = await settle(
       execution.id,
       "failed",
       execution.receipts,
       "Unable to verify transaction: chain could not be resolved"
     );
-    return "failed";
+    return settledOutcome(settled, "failed");
   }
 
   const { allVerified, results } = await verifyExecutionReceipts([
@@ -162,8 +183,8 @@ async function reconcileOne(
   const receipts = toReceiptEntries(results);
 
   if (allVerified) {
-    await settle(execution.id, "completed", receipts, null);
-    return "completed";
+    const settled = await settle(execution.id, "completed", receipts, null);
+    return settledOutcome(settled, "completed");
   }
 
   const conclusive = results.every(
@@ -171,18 +192,18 @@ async function reconcileOne(
       result.status === "reverted" || result.status === "safe_inner_failure"
   );
   if (conclusive) {
-    await settle(
+    const settled = await settle(
       execution.id,
       "failed",
       receipts,
       describeVerificationFailure(results)
     );
-    return "failed";
+    return settledOutcome(settled, "failed");
   }
 
   const age = now.getTime() - execution.createdAt.getTime();
   if (age >= DROPPED_AFTER_MS) {
-    await settle(
+    const settled = await settle(
       execution.id,
       "failed",
       receipts,
@@ -190,7 +211,7 @@ async function reconcileOne(
         DROPPED_AFTER_MS / 3_600_000
       )}h`
     );
-    return "failed";
+    return settledOutcome(settled, "failed");
   }
 
   await db
@@ -338,11 +359,25 @@ async function drain<T extends { id: string }>(
 }
 
 /**
- * Rows are read newest first. A row that has sat unconfirmed for hours has
- * already been re-read many times and is the least likely to change, while a
- * row broadcast a minute ago usually settles on its first re-read. So when the
- * budget does run out it is the stale rows that wait, and the one verdict that
- * is delayed is "dropped after 24h", which is the safe direction to be late in.
+ * Put the oldest slice at the front of the newest-first read, dropping the rows
+ * both reads returned. When the eligible set fits under the row cap the two
+ * reads cover the same rows and this only reorders them.
+ */
+function tailFirst<T extends { id: string }>(oldest: T[], newest: T[]): T[] {
+  const inSlice = new Set(oldest.map((row) => row.id));
+  return [...oldest, ...newest.filter((row) => !inSlice.has(row.id))];
+}
+
+/**
+ * Rows are read newest first, then examined behind a small oldest-first slice.
+ *
+ * A row that has sat unconfirmed for hours has already been re-read many times
+ * and is the least likely to change, while a row broadcast a minute ago usually
+ * settles on its first re-read, so the bulk of a run's budget goes to the fresh
+ * end. But a newest-first read alone never reaches the tail of a set larger
+ * than `maxRows`, and under inflow at or above the drain rate that tail is
+ * exactly the set old enough to reach the 24h dropped verdict and leave. The
+ * slice keeps that tail draining at up to OLDEST_SLICE_ROWS rows per run.
  *
  * Direct rows get at most half the budget so a slow direct backlog cannot
  * starve workflow rows; whatever they leave unused rolls over.
@@ -354,52 +389,69 @@ export async function reconcileUnconfirmedExecutions(
 ): Promise<ReconcileReport> {
   const cutoff = new Date(now.getTime() - MIN_AGE_MS);
   const startedAt = Date.now();
+  const sliceRows = Math.min(OLDEST_SLICE_ROWS, maxRows);
 
-  const pending = await db
-    .select({
-      id: directExecutions.id,
-      transactionHash: directExecutions.transactionHash,
-      network: directExecutions.network,
-      receipts: directExecutions.receipts,
-      createdAt: directExecutions.createdAt,
-    })
-    .from(directExecutions)
-    .where(
-      and(
-        eq(directExecutions.status, "unconfirmed"),
-        isNotNull(directExecutions.transactionHash),
-        lt(directExecutions.createdAt, cutoff)
-      )
-    )
-    .orderBy(desc(directExecutions.createdAt))
-    .limit(maxRows);
+  const directColumns = {
+    id: directExecutions.id,
+    transactionHash: directExecutions.transactionHash,
+    network: directExecutions.network,
+    receipts: directExecutions.receipts,
+    createdAt: directExecutions.createdAt,
+  };
+  const directEligible = and(
+    eq(directExecutions.status, "unconfirmed"),
+    isNotNull(directExecutions.transactionHash),
+    lt(directExecutions.createdAt, cutoff)
+  );
+  const [newestDirect, oldestDirect] = await Promise.all([
+    db
+      .select(directColumns)
+      .from(directExecutions)
+      .where(directEligible)
+      .orderBy(desc(directExecutions.createdAt))
+      .limit(maxRows),
+    db
+      .select(directColumns)
+      .from(directExecutions)
+      .where(directEligible)
+      .orderBy(asc(directExecutions.createdAt))
+      .limit(sliceRows),
+  ]);
 
   const direct = await drain(
-    pending,
+    tailFirst(oldestDirect, newestDirect),
     startedAt + timeBudgetMs / 2,
     (execution) => reconcileOne(execution, now),
     "[Reconciler] Failed to re-verify an unconfirmed execution; leaving it open"
   );
 
-  const pendingWorkflows = await db
-    .select({
-      id: workflowExecutions.id,
-      workflowId: workflowExecutions.workflowId,
-      transactionHashes: workflowExecutions.transactionHashes,
-      startedAt: workflowExecutions.startedAt,
-    })
-    .from(workflowExecutions)
-    .where(
-      and(
-        eq(workflowExecutions.status, "unconfirmed"),
-        lt(workflowExecutions.startedAt, cutoff)
-      )
-    )
-    .orderBy(desc(workflowExecutions.startedAt))
-    .limit(maxRows);
+  const workflowColumns = {
+    id: workflowExecutions.id,
+    workflowId: workflowExecutions.workflowId,
+    transactionHashes: workflowExecutions.transactionHashes,
+    startedAt: workflowExecutions.startedAt,
+  };
+  const workflowEligible = and(
+    eq(workflowExecutions.status, "unconfirmed"),
+    lt(workflowExecutions.startedAt, cutoff)
+  );
+  const [newestWorkflows, oldestWorkflows] = await Promise.all([
+    db
+      .select(workflowColumns)
+      .from(workflowExecutions)
+      .where(workflowEligible)
+      .orderBy(desc(workflowExecutions.startedAt))
+      .limit(maxRows),
+    db
+      .select(workflowColumns)
+      .from(workflowExecutions)
+      .where(workflowEligible)
+      .orderBy(asc(workflowExecutions.startedAt))
+      .limit(sliceRows),
+  ]);
 
   const workflows = await drain(
-    pendingWorkflows,
+    tailFirst(oldestWorkflows, newestWorkflows),
     startedAt + timeBudgetMs,
     (execution) => reconcileWorkflow(execution, now),
     "[Reconciler] Failed to re-verify an unconfirmed workflow run; leaving it open"

--- a/lib/execute/reconcile-executions.ts
+++ b/lib/execute/reconcile-executions.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, asc, eq, isNotNull, lt } from "drizzle-orm";
+import { and, desc, eq, isNotNull, lt } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   type DirectExecution,
@@ -9,7 +9,7 @@ import {
   type TransactionHashEntry,
   workflowExecutions,
 } from "@/lib/db/schema";
-import { ErrorCategory, logInfo, logSystemWarn } from "@/lib/logging";
+import { ErrorCategory, logInfo, logSystemWarn, logWarn } from "@/lib/logging";
 import { recordWorkflowExecutionFinished } from "@/lib/metrics/collectors/prometheus";
 import { NA_ERROR_TYPE } from "@/lib/metrics/metric-constants";
 import { resolveOrgSlugForCounter } from "@/lib/metrics/org-slug.server";
@@ -20,9 +20,9 @@ import {
 } from "@/lib/web3/verify-receipt";
 
 /**
- * Settles direct executions left in `unconfirmed`: a transaction was broadcast
- * but the chain had not yet told us whether it landed by the time the request
- * had to answer.
+ * Settles executions left in `unconfirmed`: a transaction was broadcast but
+ * the chain had not yet told us whether it landed by the time the request had
+ * to answer. Covers direct executions and workflow runs alike.
  *
  * Holding these open is the point. Reporting a broadcast as failed is what
  * makes a caller retry an action that already moved funds, so the row keeps its
@@ -37,13 +37,24 @@ import {
 const DROPPED_AFTER_MS = 24 * 60 * 60 * 1000;
 // Give the write path's own retries room to finish before re-reading.
 const MIN_AGE_MS = 30 * 1000;
-const DEFAULT_BATCH_SIZE = 200;
+// Every eligible row is read in one narrow query, so a backlog of rows that
+// stay unreadable cannot hide the rows behind them. This cap only bounds memory;
+// the work a run does is bounded by the time budget below.
+const DEFAULT_MAX_ROWS = 2000;
+// Wall-clock budget for one run. The CronJob fires every two minutes with
+// concurrencyPolicy Forbid, and a receipt lookup against an endpoint that times
+// out instead of answering can take tens of seconds, so without a budget one
+// unreachable chain would keep a run going indefinitely and every other row
+// would wait behind it.
+const DEFAULT_TIME_BUDGET_MS = 60 * 1000;
 
 export type ReconcileSummary = {
   examined: number;
   completed: number;
   failed: number;
   stillUnconfirmed: number;
+  // Eligible rows the run did not reach before its time budget ran out.
+  deferred: number;
 };
 
 export type ReconcileReport = {
@@ -51,8 +62,28 @@ export type ReconcileReport = {
   workflows: ReconcileSummary;
 };
 
-function emptySummary(examined: number): ReconcileSummary {
-  return { examined, completed: 0, failed: 0, stillUnconfirmed: 0 };
+type SettleOutcome = "completed" | "failed" | "unconfirmed";
+
+type UnconfirmedDirectExecution = Pick<
+  DirectExecution,
+  "id" | "transactionHash" | "network" | "receipts" | "createdAt"
+>;
+
+type UnconfirmedWorkflowExecution = {
+  id: string;
+  workflowId: string;
+  transactionHashes: TransactionHashEntry[] | null;
+  startedAt: Date;
+};
+
+function emptySummary(): ReconcileSummary {
+  return {
+    examined: 0,
+    completed: 0,
+    failed: 0,
+    stillUnconfirmed: 0,
+    deferred: 0,
+  };
 }
 
 function tally(summary: ReconcileSummary, outcome: SettleOutcome): void {
@@ -65,9 +96,7 @@ function tally(summary: ReconcileSummary, outcome: SettleOutcome): void {
   }
 }
 
-type SettleOutcome = "completed" | "failed" | "unconfirmed";
-
-function resolveChainId(execution: DirectExecution): number | null {
+function resolveChainId(execution: UnconfirmedDirectExecution): number | null {
   const fromReceipt = execution.receipts.find(
     (receipt) => receipt.chainId !== undefined
   )?.chainId;
@@ -92,6 +121,8 @@ function toReceiptEntries(
   }));
 }
 
+// Every write below is guarded on the row still being unconfirmed, so a run
+// never overwrites a verdict something else reached first.
 async function settle(
   executionId: string,
   status: "completed" | "failed",
@@ -101,13 +132,18 @@ async function settle(
   await db
     .update(directExecutions)
     .set({ status, error, receipts, completedAt: new Date() })
-    .where(eq(directExecutions.id, executionId));
+    .where(
+      and(
+        eq(directExecutions.id, executionId),
+        eq(directExecutions.status, "unconfirmed")
+      )
+    );
 }
 
 async function reconcileOne(
-  execution: DirectExecution,
+  execution: UnconfirmedDirectExecution,
   now: Date
-): Promise<"completed" | "failed" | "unconfirmed"> {
+): Promise<SettleOutcome> {
   const chainId = resolveChainId(execution);
   const hash = execution.transactionHash;
   if (!hash || chainId === null) {
@@ -160,17 +196,15 @@ async function reconcileOne(
   await db
     .update(directExecutions)
     .set({ receipts })
-    .where(eq(directExecutions.id, execution.id));
+    .where(
+      and(
+        eq(directExecutions.id, execution.id),
+        eq(directExecutions.status, "unconfirmed")
+      )
+    );
   return "unconfirmed";
 }
 
-/**
- * Settle one unconfirmed workflow run.
- *
- * A workflow claims many hashes, so it settles to success only when every hash
- * verifies, and to error only when at least one is conclusively bad. While any
- * hash is merely unreadable the run stays open.
- */
 /**
  * Emit the finished sample that logWorkflowCompleteDb deliberately skipped for
  * an unconfirmed run, so the counter still means "finished" and a success rate
@@ -191,13 +225,41 @@ async function recordSettled(
   }
 }
 
+/**
+ * Apply a verdict to a workflow run that is still unconfirmed. The finished
+ * sample is emitted only when this call performed the transition: a late
+ * finalizer or a second reconciler run that settled the row first has already
+ * emitted it, and the counter is append-only.
+ */
+async function settleWorkflow(
+  execution: UnconfirmedWorkflowExecution,
+  status: "success" | "error",
+  error: string | null
+): Promise<void> {
+  const updated = await db
+    .update(workflowExecutions)
+    .set({ status, error, completedAt: new Date() })
+    .where(
+      and(
+        eq(workflowExecutions.id, execution.id),
+        eq(workflowExecutions.status, "unconfirmed")
+      )
+    )
+    .returning({ id: workflowExecutions.id });
+  if (updated.length > 0) {
+    await recordSettled(execution.workflowId, status);
+  }
+}
+
+/**
+ * Settle one unconfirmed workflow run.
+ *
+ * A workflow claims many hashes, so it settles to success only when every hash
+ * verifies, and to error only when at least one is conclusively bad. While any
+ * hash is merely unreadable the run stays open.
+ */
 async function reconcileWorkflow(
-  execution: {
-    id: string;
-    workflowId: string;
-    transactionHashes: TransactionHashEntry[] | null;
-    startedAt: Date;
-  },
+  execution: UnconfirmedWorkflowExecution,
   now: Date
 ): Promise<SettleOutcome> {
   const entries = execution.transactionHashes ?? [];
@@ -207,14 +269,11 @@ async function reconcileWorkflow(
   );
 
   if (verifiable.length === 0) {
-    await db
-      .update(workflowExecutions)
-      .set({
-        status: "error",
-        error: "On-chain verification failed: no verifiable transaction hashes",
-      })
-      .where(eq(workflowExecutions.id, execution.id));
-    await recordSettled(execution.workflowId, "error");
+    await settleWorkflow(
+      execution,
+      "error",
+      "On-chain verification failed: no verifiable transaction hashes"
+    );
     return "failed";
   }
 
@@ -223,11 +282,7 @@ async function reconcileWorkflow(
   );
 
   if (allVerified) {
-    await db
-      .update(workflowExecutions)
-      .set({ status: "success", error: null, completedAt: new Date() })
-      .where(eq(workflowExecutions.id, execution.id));
-    await recordSettled(execution.workflowId, "success");
+    await settleWorkflow(execution, "success", null);
     return "completed";
   }
 
@@ -237,30 +292,77 @@ async function reconcileWorkflow(
     return "unconfirmed";
   }
 
-  await db
-    .update(workflowExecutions)
-    .set({
-      status: "error",
-      error: stillUnreadable
-        ? `Transactions were broadcast but never appeared on chain; treating them as dropped after ${Math.round(
-            DROPPED_AFTER_MS / 3_600_000
-          )}h`
-        : describeVerificationFailure(results),
-      completedAt: new Date(),
-    })
-    .where(eq(workflowExecutions.id, execution.id));
-  await recordSettled(execution.workflowId, "error");
+  await settleWorkflow(
+    execution,
+    "error",
+    stillUnreadable
+      ? `Transactions were broadcast but never appeared on chain; treating them as dropped after ${Math.round(
+          DROPPED_AFTER_MS / 3_600_000
+        )}h`
+      : describeVerificationFailure(results)
+  );
   return "failed";
 }
 
+/**
+ * Re-verify rows in order until the list is exhausted or the deadline passes.
+ * The deadline is checked between rows, so a run can overshoot it by one
+ * lookup; rows not reached are reported as deferred and picked up next run.
+ */
+async function drain<T extends { id: string }>(
+  rows: T[],
+  deadline: number,
+  reconcile: (row: T) => Promise<SettleOutcome>,
+  failureMessage: string
+): Promise<ReconcileSummary> {
+  const summary = emptySummary();
+  for (const row of rows) {
+    if (Date.now() >= deadline) {
+      summary.deferred = rows.length - summary.examined;
+      break;
+    }
+    summary.examined += 1;
+    try {
+      tally(summary, await reconcile(row));
+    } catch (error) {
+      summary.stillUnconfirmed += 1;
+      logSystemWarn(
+        ErrorCategory.NETWORK_RPC,
+        failureMessage,
+        error instanceof Error ? error : new Error(String(error)),
+        { execution_id: row.id }
+      );
+    }
+  }
+  return summary;
+}
+
+/**
+ * Rows are read newest first. A row that has sat unconfirmed for hours has
+ * already been re-read many times and is the least likely to change, while a
+ * row broadcast a minute ago usually settles on its first re-read. So when the
+ * budget does run out it is the stale rows that wait, and the one verdict that
+ * is delayed is "dropped after 24h", which is the safe direction to be late in.
+ *
+ * Direct rows get at most half the budget so a slow direct backlog cannot
+ * starve workflow rows; whatever they leave unused rolls over.
+ */
 export async function reconcileUnconfirmedExecutions(
   now: Date = new Date(),
-  batchSize: number = DEFAULT_BATCH_SIZE
+  maxRows: number = DEFAULT_MAX_ROWS,
+  timeBudgetMs: number = DEFAULT_TIME_BUDGET_MS
 ): Promise<ReconcileReport> {
   const cutoff = new Date(now.getTime() - MIN_AGE_MS);
+  const startedAt = Date.now();
 
   const pending = await db
-    .select()
+    .select({
+      id: directExecutions.id,
+      transactionHash: directExecutions.transactionHash,
+      network: directExecutions.network,
+      receipts: directExecutions.receipts,
+      createdAt: directExecutions.createdAt,
+    })
     .from(directExecutions)
     .where(
       and(
@@ -269,24 +371,15 @@ export async function reconcileUnconfirmedExecutions(
         lt(directExecutions.createdAt, cutoff)
       )
     )
-    .orderBy(asc(directExecutions.createdAt))
-    .limit(batchSize);
+    .orderBy(desc(directExecutions.createdAt))
+    .limit(maxRows);
 
-  const direct = emptySummary(pending.length);
-
-  for (const execution of pending) {
-    try {
-      tally(direct, await reconcileOne(execution, now));
-    } catch (error) {
-      direct.stillUnconfirmed += 1;
-      logSystemWarn(
-        ErrorCategory.NETWORK_RPC,
-        "[Reconciler] Failed to re-verify an unconfirmed execution; leaving it open",
-        error instanceof Error ? error : new Error(String(error)),
-        { execution_id: execution.id }
-      );
-    }
-  }
+  const direct = await drain(
+    pending,
+    startedAt + timeBudgetMs / 2,
+    (execution) => reconcileOne(execution, now),
+    "[Reconciler] Failed to re-verify an unconfirmed execution; leaving it open"
+  );
 
   const pendingWorkflows = await db
     .select({
@@ -302,23 +395,25 @@ export async function reconcileUnconfirmedExecutions(
         lt(workflowExecutions.startedAt, cutoff)
       )
     )
-    .orderBy(asc(workflowExecutions.startedAt))
-    .limit(batchSize);
+    .orderBy(desc(workflowExecutions.startedAt))
+    .limit(maxRows);
 
-  const workflows = emptySummary(pendingWorkflows.length);
+  const workflows = await drain(
+    pendingWorkflows,
+    startedAt + timeBudgetMs,
+    (execution) => reconcileWorkflow(execution, now),
+    "[Reconciler] Failed to re-verify an unconfirmed workflow run; leaving it open"
+  );
 
-  for (const execution of pendingWorkflows) {
-    try {
-      tally(workflows, await reconcileWorkflow(execution, now));
-    } catch (error) {
-      workflows.stillUnconfirmed += 1;
-      logSystemWarn(
-        ErrorCategory.NETWORK_RPC,
-        "[Reconciler] Failed to re-verify an unconfirmed workflow run; leaving it open",
-        error instanceof Error ? error : new Error(String(error)),
-        { execution_id: execution.id }
-      );
-    }
+  if (direct.deferred > 0 || workflows.deferred > 0) {
+    logWarn(
+      "[Reconciler] Time budget exhausted before every unconfirmed row was examined",
+      {
+        direct_deferred: String(direct.deferred),
+        workflow_deferred: String(workflows.deferred),
+        budget_ms: String(timeBudgetMs),
+      }
+    );
   }
 
   if (direct.examined > 0 || workflows.examined > 0) {

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -187,6 +187,18 @@ const workflowExecutionsFinishedAgeSeconds = getOrCreateGauge(
   []
 );
 
+// Executions parked in `unconfirmed`: broadcast, but the receipt could not be
+// read at finalize time. Only the execution-reconciler CronJob settles them, so
+// a value that climbs and never comes down means the reconciler is not running
+// or cannot reach the chain. DB-sourced (see getUnconfirmedExecutionCountsFromDb)
+// and labeled by which table the rows live in.
+const executionsUnconfirmed = getOrCreateGauge(
+  dbRegistry,
+  "keeperhub_executions_unconfirmed",
+  "Executions currently in the unconfirmed state (transaction broadcast, receipt not yet readable), by kind (workflow or direct)",
+  ["kind"]
+);
+
 // KEEP-545: the previous DB-sourced gauge `keeperhub_workflow_execution_errors_total`
 // has been removed. It was named with the `_total` counter suffix but was
 // actually a poll-driven gauge that overwrote itself on every scrape with the
@@ -1765,6 +1777,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     const {
       getWorkflowStatsFromDb,
       getLastFinishedExecutionAgeSecondsFromDb,
+      getUnconfirmedExecutionCountsFromDb,
       getWorkflowErrorsByWorkflowFromDb,
       getSystemErrorsByCategoryFromDb,
       getStepStatsFromDb,
@@ -1783,6 +1796,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     const [
       workflowStats,
       lastFinishedAgeSeconds,
+      unconfirmedCounts,
       errorsByWorkflow,
       systemErrorsByCategoryRows,
       stepStats,
@@ -1800,6 +1814,7 @@ async function refreshDbMetricsNow(): Promise<void> {
     ] = await Promise.all([
       getWorkflowStatsFromDb(),
       getLastFinishedExecutionAgeSecondsFromDb(),
+      getUnconfirmedExecutionCountsFromDb(),
       getWorkflowErrorsByWorkflowFromDb(),
       getSystemErrorsByCategoryFromDb(),
       getStepStatsFromDb(),
@@ -1836,6 +1851,16 @@ async function refreshDbMetricsNow(): Promise<void> {
     // staleness / the alert's no_data_state governs instead of a misleading 0.
     if (lastFinishedAgeSeconds !== null) {
       workflowExecutionsFinishedAgeSeconds.set(lastFinishedAgeSeconds);
+    }
+
+    // Same null handling: on a query error keep the last real backlog size
+    // rather than reporting an empty one.
+    if (unconfirmedCounts !== null) {
+      executionsUnconfirmed.set(
+        { kind: "workflow" },
+        unconfirmedCounts.workflow
+      );
+      executionsUnconfirmed.set({ kind: "direct" }, unconfirmedCounts.direct);
     }
 
     // KEEP-545: the per-org error gauge that used to live here was removed.

--- a/lib/metrics/db-metrics.ts
+++ b/lib/metrics/db-metrics.ts
@@ -16,6 +16,7 @@ import {
   eq,
   gte,
   inArray,
+  ne,
   notInArray,
   or,
   sql,
@@ -35,6 +36,7 @@ import { metricsDb as db } from "@/lib/db";
 import {
   apiKeys,
   chains,
+  directExecutions,
   integrations,
   invitation,
   member,
@@ -292,6 +294,12 @@ export async function getWorkflowStatsFromDb(): Promise<WorkflowStats> {
  * index scan for max() rather than a full-table scan that would trip the 8s
  * metrics statement_timeout.
  *
+ * `unconfirmed` rows are excluded: the finalizer stamps completed_at on them
+ * (lib/workflow/executor/logging.ts) but they have not finished, so a pipeline
+ * that only produces unconfirmed rows must still read as stalled. The filter
+ * sits on top of the same partial index; the backward scan just steps past any
+ * unconfirmed rows at the top, and those are rare.
+ *
  * Returns null when the table has no finished executions yet (max is NULL) or
  * on query error; the caller leaves the gauge unset in that case so Prometheus
  * staleness / the alert's no_data_state governs rather than a misleading 0.
@@ -307,7 +315,12 @@ export async function getLastFinishedExecutionAgeSecondsFromDb(): Promise<
         >`EXTRACT(EPOCH FROM (now() - max(${workflowExecutions.completedAt})))`,
       })
       .from(workflowExecutions)
-      .where(sql`${workflowExecutions.completedAt} IS NOT NULL`);
+      .where(
+        and(
+          sql`${workflowExecutions.completedAt} IS NOT NULL`,
+          ne(workflowExecutions.status, "unconfirmed")
+        )
+      );
 
     const raw = rows[0]?.ageSeconds;
     return raw == null ? null : Number(raw);
@@ -315,6 +328,51 @@ export async function getLastFinishedExecutionAgeSecondsFromDb(): Promise<
     logSystemWarn(
       ErrorCategory.DATABASE,
       "[Metrics] Failed to query last finished execution age from DB",
+      error
+    );
+    return null;
+  }
+}
+
+export type UnconfirmedExecutionCounts = {
+  workflow: number;
+  direct: number;
+};
+
+/**
+ * Rows currently parked in `unconfirmed`: a transaction was broadcast but its
+ * receipt could not be read when the run finalized. Only the
+ * execution-reconciler CronJob moves these on, so a value that climbs and never
+ * comes down means the reconciler is not running or cannot reach the chain.
+ *
+ * Both counts are equality lookups on a plain btree over status
+ * (idx_workflow_executions_status, idx_direct_executions_status), and
+ * `unconfirmed` is a rare value, so each is a small index scan rather than a
+ * table scan.
+ *
+ * Returns null on query error; the caller leaves the gauge untouched so the
+ * last real value stands rather than a misleading 0.
+ */
+export async function getUnconfirmedExecutionCountsFromDb(): Promise<UnconfirmedExecutionCounts | null> {
+  try {
+    const [workflowRows, directRows] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(workflowExecutions)
+        .where(eq(workflowExecutions.status, "unconfirmed")),
+      db
+        .select({ count: count() })
+        .from(directExecutions)
+        .where(eq(directExecutions.status, "unconfirmed")),
+    ]);
+    return {
+      workflow: Number(workflowRows[0]?.count) || 0,
+      direct: Number(directRows[0]?.count) || 0,
+    };
+  } catch (error) {
+    logSystemWarn(
+      ErrorCategory.DATABASE,
+      "[Metrics] Failed to query unconfirmed execution counts from DB",
       error
     );
     return null;

--- a/tests/integration/audit-retention-route.test.ts
+++ b/tests/integration/audit-retention-route.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Contract test for GET /api/cron/audit-retention. Reachable through the same
+ * HMAC wrapper (deploy/scripts/reaper.sh) as the other cron routes, so
+ * authenticateInternalService is mocked the same way the reaper route test
+ * mocks it; this file asserts the route's handling of the verdict, not the
+ * verdict logic.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InternalServiceAuthResult } from "@/lib/internal-service-auth";
+
+let mockAuthResult: InternalServiceAuthResult = {
+  authenticated: true,
+  caller: "scheduler",
+  scheme: "hmac",
+};
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: vi.fn(() => Promise.resolve(mockAuthResult)),
+}));
+
+const { mockPurge, mockLogSystemError } = vi.hoisted(() => ({
+  mockPurge: vi.fn(),
+  mockLogSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/security/audit-retention", () => ({
+  AUDIT_RETENTION_DAYS: 730,
+  purgeExpiredAuditEvents: mockPurge,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: mockLogSystemError,
+}));
+
+import { GET } from "@/app/api/cron/audit-retention/route";
+import { authenticateInternalService } from "@/lib/internal-service-auth";
+
+function createRequest(): Request {
+  return new Request("http://localhost:3000/api/cron/audit-retention", {
+    headers: { "X-KH-Caller": "scheduler" },
+  });
+}
+
+describe("/api/cron/audit-retention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPurge.mockResolvedValue(0);
+    mockAuthResult = {
+      authenticated: true,
+      caller: "scheduler",
+      scheme: "hmac",
+    };
+    delete process.env.CRON_SECRET;
+  });
+
+  it("passes the request to authenticateInternalService", async () => {
+    const request = createRequest();
+    await GET(request);
+
+    expect(authenticateInternalService).toHaveBeenCalledWith(request);
+  });
+
+  it("returns the auth verdict's status and error when rejected", async () => {
+    mockAuthResult = {
+      authenticated: false,
+      error: "Invalid signature",
+      status: 401,
+    };
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Invalid signature" });
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("no longer accepts a CRON_SECRET bearer token", async () => {
+    process.env.CRON_SECRET = "legacy-cron-secret";
+    mockAuthResult = {
+      authenticated: false,
+      error: "Missing auth headers",
+      status: 401,
+    };
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/audit-retention", {
+        headers: { authorization: "Bearer legacy-cron-secret" },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockPurge).not.toHaveBeenCalled();
+  });
+
+  it("purges as of now and reports the count and window", async () => {
+    mockPurge.mockResolvedValue(12);
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ purged: 12, retentionDays: 730 });
+    expect(mockPurge).toHaveBeenCalledWith(expect.any(Date));
+  });
+
+  it("returns 500 and logs when the purge throws", async () => {
+    mockPurge.mockRejectedValue(new Error("deadlock detected"));
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "purge failed" });
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "database",
+      "Failed to purge expired audit events",
+      expect.any(Error),
+      { endpoint: "/api/cron/audit-retention" }
+    );
+  });
+});

--- a/tests/integration/cron-routes-hmac-signature.test.ts
+++ b/tests/integration/cron-routes-hmac-signature.test.ts
@@ -1,0 +1,157 @@
+/**
+ * End-to-end auth check for the two cron routes this change migrated off
+ * `CRON_SECRET`: the signature is verified by the REAL
+ * authenticateInternalService, not a stand-in for it.
+ *
+ * The per-route contract tests (execution-reconciler-route, audit-retention-route)
+ * mock the auth module, so they pin how a route handles a verdict but cannot
+ * show that a legacy `Authorization: Bearer $CRON_SECRET` request is now
+ * rejected by the verifier itself. Only the secret store and the loggers are
+ * stubbed here; the signing string comes from the shared test signer, which
+ * mirrors deploy/scripts/reaper.sh.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signInternalServiceHeaders } from "../utils/internal-service-auth";
+
+vi.mock("server-only", () => ({}));
+
+const SECRET = "test-internal-service-hmac-secret";
+
+const { mockReconcile, mockPurge, mockLogInternalAuthEvent } = vi.hoisted(
+  () => ({
+    mockReconcile: vi.fn(),
+    mockPurge: vi.fn(),
+    mockLogInternalAuthEvent: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/internal-service-hmac-store", () => ({
+  listActiveHmacSecrets: vi.fn(() =>
+    Promise.resolve([{ secret: SECRET, keyVersion: 1 }])
+  ),
+  lookupHmacSecret: vi.fn(() =>
+    Promise.resolve({ secret: SECRET, keyVersion: 1 })
+  ),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: vi.fn(),
+  logInternalAuthEvent: mockLogInternalAuthEvent,
+}));
+
+vi.mock("@/lib/execute/reconcile-executions", () => ({
+  reconcileUnconfirmedExecutions: mockReconcile,
+}));
+
+vi.mock("@/lib/security/audit-retention", () => ({
+  AUDIT_RETENTION_DAYS: 730,
+  purgeExpiredAuditEvents: mockPurge,
+}));
+
+import { GET as auditRetentionGet } from "@/app/api/cron/audit-retention/route";
+import { GET as reconcilerGet } from "@/app/api/cron/execution-reconciler/route";
+
+const EMPTY_SUMMARY = {
+  examined: 0,
+  completed: 0,
+  failed: 0,
+  stillUnconfirmed: 0,
+  deferred: 0,
+};
+
+const ROUTES = [
+  {
+    name: "/api/cron/execution-reconciler",
+    url: "http://localhost:3000/api/cron/execution-reconciler",
+    handler: reconcilerGet,
+    handlerMock: mockReconcile,
+  },
+  {
+    name: "/api/cron/audit-retention",
+    url: "http://localhost:3000/api/cron/audit-retention",
+    handler: auditRetentionGet,
+    handlerMock: mockPurge,
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReconcile.mockResolvedValue({
+    direct: EMPTY_SUMMARY,
+    workflows: EMPTY_SUMMARY,
+  });
+  mockPurge.mockResolvedValue(0);
+  delete process.env.CRON_SECRET;
+});
+
+describe.each(ROUTES)("$name internal-service HMAC", (route) => {
+  it("accepts a request signed the way reaper.sh signs it", async () => {
+    const response = await route.handler(
+      new Request(route.url, {
+        headers: signInternalServiceHeaders({
+          method: "GET",
+          url: route.url,
+          caller: "scheduler",
+          secret: SECRET,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(route.handlerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a CRON_SECRET bearer token", async () => {
+    process.env.CRON_SECRET = "legacy-cron-secret";
+
+    const response = await route.handler(
+      new Request(route.url, {
+        headers: { authorization: "Bearer legacy-cron-secret" },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Missing auth headers" });
+    expect(route.handlerMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signature made with the wrong secret", async () => {
+    const response = await route.handler(
+      new Request(route.url, {
+        headers: signInternalServiceHeaders({
+          method: "GET",
+          url: route.url,
+          caller: "scheduler",
+          secret: "not-the-shared-secret",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Invalid signature" });
+    expect(route.handlerMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a signature made for the other cron route's path", async () => {
+    const other = ROUTES.find((candidate) => candidate.url !== route.url);
+    if (!other) {
+      throw new Error("expected a second route to borrow a signature from");
+    }
+
+    const response = await route.handler(
+      new Request(route.url, {
+        headers: signInternalServiceHeaders({
+          method: "GET",
+          url: other.url,
+          caller: "scheduler",
+          secret: SECRET,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(route.handlerMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/execution-reconciler-route.test.ts
+++ b/tests/integration/execution-reconciler-route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Contract test for GET /api/cron/execution-reconciler. The route is the only
+ * thing that settles `unconfirmed` executions, and it is reached by the
+ * `execution-reconciler` CronJob through deploy/scripts/reaper.sh, which signs
+ * with the internal-service HMAC scheme. This file asserts the route's handling
+ * of the auth verdict and of the reconciler's result, not the verdict logic
+ * itself (covered by tests/unit/internal-service-auth.test.ts), so
+ * authenticateInternalService is mocked the same way the reaper route test
+ * mocks it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InternalServiceAuthResult } from "@/lib/internal-service-auth";
+
+let mockAuthResult: InternalServiceAuthResult = {
+  authenticated: true,
+  caller: "scheduler",
+  scheme: "hmac",
+};
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: vi.fn(() => Promise.resolve(mockAuthResult)),
+}));
+
+const { mockReconcile, mockLogSystemError } = vi.hoisted(() => ({
+  mockReconcile: vi.fn(),
+  mockLogSystemError: vi.fn(),
+}));
+
+vi.mock("@/lib/execute/reconcile-executions", () => ({
+  reconcileUnconfirmedExecutions: mockReconcile,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemError: mockLogSystemError,
+}));
+
+import { GET } from "@/app/api/cron/execution-reconciler/route";
+import { authenticateInternalService } from "@/lib/internal-service-auth";
+
+const EMPTY_SUMMARY = {
+  examined: 0,
+  completed: 0,
+  failed: 0,
+  stillUnconfirmed: 0,
+  deferred: 0,
+};
+
+function createRequest(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost:3000/api/cron/execution-reconciler", {
+    headers: { "X-KH-Caller": "scheduler", ...headers },
+  });
+}
+
+describe("/api/cron/execution-reconciler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReconcile.mockResolvedValue({
+      direct: EMPTY_SUMMARY,
+      workflows: EMPTY_SUMMARY,
+    });
+    mockAuthResult = {
+      authenticated: true,
+      caller: "scheduler",
+      scheme: "hmac",
+    };
+    delete process.env.CRON_SECRET;
+  });
+
+  it("passes the request to authenticateInternalService", async () => {
+    const request = createRequest();
+    await GET(request);
+
+    expect(authenticateInternalService).toHaveBeenCalledWith(request);
+  });
+
+  it("returns the auth verdict's status and error when rejected", async () => {
+    mockAuthResult = {
+      authenticated: false,
+      error: "Timestamp outside replay window",
+      status: 401,
+    };
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      error: "Timestamp outside replay window",
+    });
+    expect(mockReconcile).not.toHaveBeenCalled();
+  });
+
+  it("no longer accepts a CRON_SECRET bearer token", async () => {
+    process.env.CRON_SECRET = "legacy-cron-secret";
+    mockAuthResult = {
+      authenticated: false,
+      error: "Missing auth headers",
+      status: 401,
+    };
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/cron/execution-reconciler", {
+        headers: { authorization: "Bearer legacy-cron-secret" },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockReconcile).not.toHaveBeenCalled();
+  });
+
+  it("returns the reconcile report on success", async () => {
+    const report = {
+      direct: { ...EMPTY_SUMMARY, examined: 2, completed: 1, failed: 1 },
+      workflows: { ...EMPTY_SUMMARY, examined: 1, stillUnconfirmed: 1 },
+    };
+    mockReconcile.mockResolvedValue(report);
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(report);
+    expect(mockReconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 and logs when reconciliation throws", async () => {
+    mockReconcile.mockRejectedValue(new Error("connection refused"));
+
+    const response = await GET(createRequest());
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "reconcile failed" });
+    expect(mockLogSystemError).toHaveBeenCalledWith(
+      "database",
+      "Failed to reconcile unconfirmed executions",
+      expect.any(Error),
+      { endpoint: "/api/cron/execution-reconciler" }
+    );
+  });
+});

--- a/tests/unit/db-metrics-cache.test.ts
+++ b/tests/unit/db-metrics-cache.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_DB_RETURNS: Record<string, unknown> = {
     durationCount: 0,
   },
   getLastFinishedExecutionAgeSecondsFromDb: null,
+  getUnconfirmedExecutionCountsFromDb: { workflow: 0, direct: 0 },
   getWorkflowErrorsByWorkflowFromDb: [],
   getSystemErrorsByCategoryFromDb: [],
   getStepStatsFromDb: {
@@ -157,6 +158,12 @@ const FINISHED_AGE_17_RE =
   /keeperhub_workflow_executions_finished_age_seconds\s+17(\s|$)/m;
 const FINISHED_AGE_ZERO_RE =
   /keeperhub_workflow_executions_finished_age_seconds\s+0(\s|$)/m;
+const UNCONFIRMED_WORKFLOW_3_RE =
+  /keeperhub_executions_unconfirmed\{kind="workflow"\}\s+3(\s|$)/m;
+const UNCONFIRMED_DIRECT_5_RE =
+  /keeperhub_executions_unconfirmed\{kind="direct"\}\s+5(\s|$)/m;
+const UNCONFIRMED_WORKFLOW_ZERO_RE =
+  /keeperhub_executions_unconfirmed\{kind="workflow"\}\s+0(\s|$)/m;
 
 // MRR series. Label order follows the object passed to .set()
 // (plan, tier, billing_status), but stay tolerant of extra labels.
@@ -561,6 +568,58 @@ describe("keeperhub_workflow_executions_finished_age_seconds gauge", () => {
     const out = await getDbMetrics();
     expect(out).toMatch(FINISHED_AGE_17_RE);
     expect(out).not.toMatch(FINISHED_AGE_ZERO_RE);
+  });
+});
+
+// The unconfirmed backlog gauge is the only visibility into rows the
+// execution-reconciler has yet to settle, so it carries one series per table
+// and, like the finished-age gauge, keeps its last value across a query error.
+describe("keeperhub_executions_unconfirmed gauge", () => {
+  const originalTtl = process.env.DB_METRICS_CACHE_TTL_MS;
+
+  beforeEach(() => {
+    __resetDbMetricsCacheForTest();
+    for (const fn of Object.values(dbMocks)) {
+      fn.mockReset();
+    }
+    rebindDefaultDbMockImplementations();
+    process.env.DB_METRICS_CACHE_TTL_MS = "0";
+  });
+
+  afterEach(() => {
+    if (originalTtl === undefined) {
+      delete process.env.DB_METRICS_CACHE_TTL_MS;
+    } else {
+      process.env.DB_METRICS_CACHE_TTL_MS = originalTtl;
+    }
+  });
+
+  it("emits one series per kind from the DB counts", async () => {
+    dbMocks.getUnconfirmedExecutionCountsFromDb.mockResolvedValue({
+      workflow: 3,
+      direct: 5,
+    });
+
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+
+    expect(out).toMatch(UNCONFIRMED_WORKFLOW_3_RE);
+    expect(out).toMatch(UNCONFIRMED_DIRECT_5_RE);
+  });
+
+  it("holds the last value (not 0) when the query returns null", async () => {
+    dbMocks.getUnconfirmedExecutionCountsFromDb.mockResolvedValue({
+      workflow: 3,
+      direct: 5,
+    });
+    await updateDbMetrics();
+    expect(await getDbMetrics()).toMatch(UNCONFIRMED_WORKFLOW_3_RE);
+
+    dbMocks.getUnconfirmedExecutionCountsFromDb.mockResolvedValue(null);
+    await updateDbMetrics();
+    const out = await getDbMetrics();
+    expect(out).toMatch(UNCONFIRMED_WORKFLOW_3_RE);
+    expect(out).not.toMatch(UNCONFIRMED_WORKFLOW_ZERO_RE);
   });
 });
 

--- a/tests/unit/db-metrics-finished-age.test.ts
+++ b/tests/unit/db-metrics-finished-age.test.ts
@@ -1,0 +1,69 @@
+/**
+ * getLastFinishedExecutionAgeSecondsFromDb() feeds the fast "zero finished
+ * executions" alert, so what it counts as finished is load-bearing. The
+ * finalizer stamps completed_at on `unconfirmed` rows even though they have not
+ * finished, so those rows must be excluded or a pipeline producing nothing but
+ * unconfirmed rows would keep reading as healthy.
+ *
+ * The predicate is asserted on the SQL the query would run, rendered through
+ * PgDialect, because the exclusion is invisible in the returned value.
+ */
+
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+let capturedWhere: SQL | undefined;
+let queryRows: unknown[] = [];
+
+vi.mock("@/lib/db", () => {
+  const select = () => ({
+    from: () => ({
+      where: (condition: SQL) => {
+        capturedWhere = condition;
+        return Promise.resolve(queryRows);
+      },
+    }),
+  });
+  return { db: { select }, metricsDb: { select } };
+});
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { DATABASE: "database" },
+  logSystemWarn: vi.fn(),
+}));
+
+import { getLastFinishedExecutionAgeSecondsFromDb } from "@/lib/metrics/db-metrics";
+
+const dialect = new PgDialect();
+
+beforeEach(() => {
+  capturedWhere = undefined;
+  queryRows = [{ ageSeconds: 12 }];
+});
+
+describe("getLastFinishedExecutionAgeSecondsFromDb", () => {
+  it("excludes unconfirmed rows from the finished set", async () => {
+    await getLastFinishedExecutionAgeSecondsFromDb();
+
+    if (!capturedWhere) {
+      throw new Error("expected the query to carry a where clause");
+    }
+    const { sql, params } = dialect.sqlToQuery(capturedWhere);
+    expect(sql).toContain('"workflow_executions"."completed_at" IS NOT NULL');
+    expect(sql).toMatch(/"workflow_executions"\."status" <> \$\d+/);
+    expect(params).toEqual(["unconfirmed"]);
+  });
+
+  it("returns the age when the query answers", async () => {
+    expect(await getLastFinishedExecutionAgeSecondsFromDb()).toBe(12);
+  });
+
+  it("returns null when no row has finished yet", async () => {
+    queryRows = [{ ageSeconds: null }];
+
+    expect(await getLastFinishedExecutionAgeSecondsFromDb()).toBeNull();
+  });
+});

--- a/tests/unit/reconcile-executions.test.ts
+++ b/tests/unit/reconcile-executions.test.ts
@@ -173,12 +173,24 @@ function verifyResolves(status: ReceiptVerificationResult["status"]): void {
   });
 }
 
+// Each table is read twice per run (newest-first, then the oldest-first slice)
+// and the stub hands out result sets in call order, so one run consumes four.
 function run(
   direct: Row[],
   workflows: Row[],
-  options: { maxRows?: number; budgetMs?: number } = {}
+  options: {
+    maxRows?: number;
+    budgetMs?: number;
+    oldestDirect?: Row[];
+    oldestWorkflows?: Row[];
+  } = {}
 ) {
-  selectResults = [direct, workflows];
+  selectResults = [
+    direct,
+    options.oldestDirect ?? [],
+    workflows,
+    options.oldestWorkflows ?? [],
+  ];
   return reconcileUnconfirmedExecutions(
     NOW,
     options.maxRows ?? 2000,
@@ -306,6 +318,22 @@ describe("direct executions", () => {
     expect(sql).toMatch(/"id" = \$1 and .*"status" = \$2/);
     expect(params).toEqual(["de_1", "unconfirmed"]);
   });
+
+  it("does not tally a settle another writer won the race for", async () => {
+    verifyResolves("success");
+    returningRows = [];
+
+    const report = await run([directRow()], []);
+
+    expect(directUpdates()).toHaveLength(1);
+    expect(report.direct).toEqual({
+      examined: 1,
+      completed: 0,
+      failed: 0,
+      stillUnconfirmed: 1,
+      deferred: 0,
+    });
+  });
 });
 
 describe("workflow runs", () => {
@@ -403,19 +431,65 @@ describe("workflow runs", () => {
 });
 
 describe("scheduling safety", () => {
-  it("reads the whole eligible set newest first, up to the row cap", async () => {
+  it("reads each table newest first up to the row cap, plus an oldest-first slice", async () => {
     verifyResolves("success");
 
     await run([], [], { maxRows: 2000 });
 
-    expect(selectCalls).toHaveLength(2);
-    expect(render(selectCalls[0].orderBy).sql).toBe(
-      '"direct_executions"."created_at" desc'
-    );
-    expect(render(selectCalls[1].orderBy).sql).toBe(
-      '"workflow_executions"."started_at" desc'
-    );
-    expect(selectCalls.map((call) => call.limit)).toEqual([2000, 2000]);
+    expect(selectCalls).toHaveLength(4);
+    expect(selectCalls.map((call) => render(call.orderBy).sql)).toEqual([
+      '"direct_executions"."created_at" desc',
+      '"direct_executions"."created_at" asc',
+      '"workflow_executions"."started_at" desc',
+      '"workflow_executions"."started_at" asc',
+    ]);
+    expect(selectCalls.map((call) => call.limit)).toEqual([
+      2000, 100, 2000, 100,
+    ]);
+  });
+
+  it("never asks for a slice wider than the row cap", async () => {
+    verifyResolves("success");
+
+    await run([], [], { maxRows: 10 });
+
+    expect(selectCalls.map((call) => call.limit)).toEqual([10, 10, 10, 10]);
+  });
+
+  it("examines the oldest slice before the newest-first sweep", async () => {
+    verifyResolves("success");
+
+    await run([directRow({ id: "de_new" })], [], {
+      oldestDirect: [directRow({ id: "de_old" })],
+    });
+
+    const settled = directUpdates().map((call) => render(call.where).params[0]);
+    expect(settled).toEqual(["de_old", "de_new"]);
+  });
+
+  it("examines a row returned by both reads only once", async () => {
+    verifyResolves("success");
+    const row = directRow({ id: "de_1" });
+
+    const report = await run([row], [], { oldestDirect: [row] });
+
+    expect(report.direct.examined).toBe(1);
+    expect(directUpdates()).toHaveLength(1);
+  });
+
+  it("reaches the tail of a backlog larger than the row cap", async () => {
+    verifyResolves("success");
+    // The newest-first read is capped at 2 rows and can never see de_tail; the
+    // oldest-first slice is the only thing that settles it.
+    const newest = [directRow({ id: "de_a" }), directRow({ id: "de_b" })];
+
+    await run(newest, [], {
+      maxRows: 2,
+      oldestDirect: [directRow({ id: "de_tail" })],
+    });
+
+    const settled = directUpdates().map((call) => render(call.where).params[0]);
+    expect(settled).toEqual(["de_tail", "de_a", "de_b"]);
   });
 
   it("examines every row it read rather than the first 200", async () => {

--- a/tests/unit/reconcile-executions.test.ts
+++ b/tests/unit/reconcile-executions.test.ts
@@ -1,0 +1,486 @@
+/**
+ * reconcileUnconfirmedExecutions runs from the execution-reconciler CronJob
+ * and is the only path that settles `unconfirmed` rows. These tests drive it
+ * against a recording stand-in for the drizzle builder and a mocked receipt
+ * lookup, and render the captured fragments through PgDialect so the ordering
+ * and the status guard are asserted on the SQL that would run.
+ */
+
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { directExecutions, workflowExecutions } from "@/lib/db/schema";
+import type { ReceiptVerificationResult } from "@/lib/web3/verify-receipt";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  mockVerify,
+  mockRecordFinished,
+  mockLogInfo,
+  mockLogWarn,
+  mockLogSystemWarn,
+} = vi.hoisted(() => ({
+  mockVerify: vi.fn(),
+  mockRecordFinished: vi.fn(),
+  mockLogInfo: vi.fn(),
+  mockLogWarn: vi.fn(),
+  mockLogSystemWarn: vi.fn(),
+}));
+
+type Row = Record<string, unknown>;
+type UpdateCall = { table: unknown; values: Row; where?: SQL };
+type SelectCall = { orderBy?: SQL; limit?: number };
+
+// Result sets handed out in call order: direct executions first, then
+// workflow runs, matching the order the reconciler queries them.
+let selectResults: Row[][] = [];
+let selectCalls: SelectCall[] = [];
+let updateCalls: UpdateCall[] = [];
+// Rows the guarded workflow UPDATE reports back; empty means another writer
+// settled the row first.
+let returningRows: { id: string }[] = [];
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => {
+      const call: SelectCall = {};
+      selectCalls.push(call);
+      return {
+        from: () => ({
+          where: () => ({
+            orderBy: (order: SQL) => {
+              call.orderBy = order;
+              return {
+                limit: (n: number) => {
+                  call.limit = n;
+                  return Promise.resolve(selectResults.shift() ?? []);
+                },
+              };
+            },
+          }),
+        }),
+      };
+    },
+    update: (table: unknown) => ({
+      set: (values: Row) => {
+        const call: UpdateCall = { table, values };
+        updateCalls.push(call);
+        return {
+          where: (condition: SQL) => {
+            call.where = condition;
+            return {
+              returning: () => Promise.resolve(returningRows),
+              // biome-ignore lint/suspicious/noThenProperty: drizzle's builder is itself a thenable and the direct-execution path awaits it without returning(), so the stub has to be one too.
+              then: (resolve: (value: unknown) => unknown) =>
+                resolve(undefined),
+            };
+          },
+        };
+      },
+    }),
+  },
+}));
+
+vi.mock("@/lib/web3/verify-receipt", () => ({
+  verifyExecutionReceipts: mockVerify,
+  // Same predicate as the real module: a receipt is unreadable when it neither
+  // verified nor came back with a conclusive status.
+  hasUnreadableReceipt: (results: ReceiptVerificationResult[]) =>
+    results.some(
+      (result) =>
+        !(
+          result.verified ||
+          ["success", "reverted", "safe_inner_failure"].includes(result.status)
+        )
+    ),
+  describeVerificationFailure: (results: ReceiptVerificationResult[]) =>
+    `On-chain verification failed for ${results.filter((r) => !r.verified).length} transaction`,
+}));
+
+vi.mock("@/lib/metrics/collectors/prometheus", () => ({
+  recordWorkflowExecutionFinished: mockRecordFinished,
+}));
+
+vi.mock("@/lib/metrics/org-slug.server", () => ({
+  resolveOrgSlugForCounter: vi.fn(async () => "org-a"),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { NETWORK_RPC: "network_rpc" },
+  logInfo: mockLogInfo,
+  logWarn: mockLogWarn,
+  logSystemWarn: mockLogSystemWarn,
+}));
+
+import { reconcileUnconfirmedExecutions } from "@/lib/execute/reconcile-executions";
+
+const dialect = new PgDialect();
+const render = (fragment: SQL | undefined) => {
+  if (!fragment) {
+    throw new Error("expected a SQL fragment");
+  }
+  return dialect.sqlToQuery(fragment);
+};
+
+const NOW = new Date("2026-09-02T12:00:00.000Z");
+const HOUR_MS = 60 * 60 * 1000;
+const CHAIN_ID = 11_155_111;
+const HASH = "0xabc";
+
+const minutesAgo = (minutes: number) =>
+  new Date(NOW.getTime() - minutes * 60_000);
+
+function directRow(overrides: Row = {}): Row {
+  return {
+    id: "de_1",
+    transactionHash: HASH,
+    network: String(CHAIN_ID),
+    receipts: [],
+    createdAt: minutesAgo(5),
+    ...overrides,
+  };
+}
+
+function workflowRow(overrides: Row = {}): Row {
+  return {
+    id: "we_1",
+    workflowId: "wf_1",
+    transactionHashes: [
+      { hash: HASH, nodeId: "n1", nodeName: "Transfer", chainId: CHAIN_ID },
+    ],
+    startedAt: minutesAgo(5),
+    ...overrides,
+  };
+}
+
+function receipt(
+  status: ReceiptVerificationResult["status"]
+): ReceiptVerificationResult {
+  return {
+    hash: HASH,
+    chainId: CHAIN_ID,
+    verified: status === "success",
+    status,
+    verifiedAt: NOW.toISOString(),
+  };
+}
+
+function verifyResolves(status: ReceiptVerificationResult["status"]): void {
+  mockVerify.mockResolvedValue({
+    allVerified: status === "success",
+    results: [receipt(status)],
+  });
+}
+
+function run(
+  direct: Row[],
+  workflows: Row[],
+  options: { maxRows?: number; budgetMs?: number } = {}
+) {
+  selectResults = [direct, workflows];
+  return reconcileUnconfirmedExecutions(
+    NOW,
+    options.maxRows ?? 2000,
+    options.budgetMs ?? 60_000
+  );
+}
+
+const directUpdates = () =>
+  updateCalls.filter((call) => call.table === directExecutions);
+const workflowUpdates = () =>
+  updateCalls.filter((call) => call.table === workflowExecutions);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResults = [];
+  selectCalls = [];
+  updateCalls = [];
+  returningRows = [{ id: "we_1" }];
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("direct executions", () => {
+  it("settles as completed once the receipt verifies", async () => {
+    verifyResolves("success");
+
+    const report = await run([directRow()], []);
+
+    expect(report.direct).toEqual({
+      examined: 1,
+      completed: 1,
+      failed: 0,
+      stillUnconfirmed: 0,
+      deferred: 0,
+    });
+    expect(mockVerify).toHaveBeenCalledWith([
+      { hash: HASH, chainId: CHAIN_ID },
+    ]);
+    const [update] = directUpdates();
+    expect(update.values).toEqual({
+      status: "completed",
+      error: null,
+      receipts: [
+        expect.objectContaining({
+          hash: HASH,
+          chainId: CHAIN_ID,
+          verified: true,
+          receiptStatus: "success",
+        }),
+      ],
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it("fails a row whose chain cannot be resolved and stamps completedAt", async () => {
+    const report = await run([directRow({ network: "sepolia" })], []);
+
+    expect(report.direct.failed).toBe(1);
+    expect(mockVerify).not.toHaveBeenCalled();
+    const [update] = directUpdates();
+    expect(update.values).toEqual({
+      status: "failed",
+      error: "Unable to verify transaction: chain could not be resolved",
+      receipts: [],
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it("fails a conclusively reverted transaction", async () => {
+    verifyResolves("reverted");
+
+    const report = await run([directRow()], []);
+
+    expect(report.direct.failed).toBe(1);
+    expect(directUpdates()[0].values).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("On-chain verification failed"),
+        completedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("keeps a young unreadable row open and only refreshes its receipts", async () => {
+    verifyResolves("not_found");
+
+    const report = await run([directRow()], []);
+
+    expect(report.direct.stillUnconfirmed).toBe(1);
+    const [update] = directUpdates();
+    expect(Object.keys(update.values)).toEqual(["receipts"]);
+    expect(update.values.receipts).toEqual([
+      expect.objectContaining({ receiptStatus: "not_found", verified: false }),
+    ]);
+  });
+
+  it("treats a transaction unseen for 24h as dropped", async () => {
+    verifyResolves("not_found");
+
+    const report = await run(
+      [directRow({ createdAt: new Date(NOW.getTime() - 25 * HOUR_MS) })],
+      []
+    );
+
+    expect(report.direct.failed).toBe(1);
+    expect(directUpdates()[0].values).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        error: expect.stringContaining("dropped after 24h"),
+        completedAt: expect.any(Date),
+      })
+    );
+  });
+
+  it("guards every write on the row still being unconfirmed", async () => {
+    verifyResolves("success");
+
+    await run([directRow()], []);
+
+    const { sql, params } = render(directUpdates()[0].where);
+    expect(sql).toMatch(/"id" = \$1 and .*"status" = \$2/);
+    expect(params).toEqual(["de_1", "unconfirmed"]);
+  });
+});
+
+describe("workflow runs", () => {
+  it("fails a run with no verifiable hashes and stamps completedAt", async () => {
+    const report = await run(
+      [],
+      [
+        workflowRow({
+          transactionHashes: [
+            { hash: HASH, nodeId: "n1", nodeName: "Transfer" },
+          ],
+        }),
+      ]
+    );
+
+    expect(report.workflows.failed).toBe(1);
+    expect(mockVerify).not.toHaveBeenCalled();
+    const [update] = workflowUpdates();
+    expect(update.values).toEqual({
+      status: "error",
+      error: "On-chain verification failed: no verifiable transaction hashes",
+      completedAt: expect.any(Date),
+    });
+    expect(mockRecordFinished).toHaveBeenCalledTimes(1);
+    expect(mockRecordFinished).toHaveBeenCalledWith({
+      status: "error",
+      orgSlug: "org-a",
+      errorType: "na",
+    });
+  });
+
+  it("settles a verified run as success and emits one finished sample", async () => {
+    verifyResolves("success");
+
+    const report = await run([], [workflowRow()]);
+
+    expect(report.workflows.completed).toBe(1);
+    expect(workflowUpdates()[0].values).toEqual({
+      status: "success",
+      error: null,
+      completedAt: expect.any(Date),
+    });
+    expect(mockRecordFinished).toHaveBeenCalledTimes(1);
+    expect(mockRecordFinished).toHaveBeenCalledWith({
+      status: "success",
+      orgSlug: "org-a",
+      errorType: "na",
+    });
+  });
+
+  it("emits no finished sample when another writer settled the row first", async () => {
+    verifyResolves("success");
+    returningRows = [];
+
+    await run([], [workflowRow()]);
+
+    expect(workflowUpdates()).toHaveLength(1);
+    expect(mockRecordFinished).not.toHaveBeenCalled();
+  });
+
+  it("guards the settle on the row still being unconfirmed", async () => {
+    verifyResolves("success");
+
+    await run([], [workflowRow()]);
+
+    const { sql, params } = render(workflowUpdates()[0].where);
+    expect(sql).toMatch(/"id" = \$1 and .*"status" = \$2/);
+    expect(params).toEqual(["we_1", "unconfirmed"]);
+  });
+
+  it("keeps a young run with an unreadable receipt open without writing", async () => {
+    verifyResolves("timeout");
+
+    const report = await run([], [workflowRow()]);
+
+    expect(report.workflows.stillUnconfirmed).toBe(1);
+    expect(workflowUpdates()).toHaveLength(0);
+    expect(mockRecordFinished).not.toHaveBeenCalled();
+  });
+
+  it("leaves a run open and warns when the lookup throws", async () => {
+    mockVerify.mockRejectedValue(new Error("rpc unreachable"));
+
+    const report = await run([], [workflowRow()]);
+
+    expect(report.workflows.stillUnconfirmed).toBe(1);
+    expect(workflowUpdates()).toHaveLength(0);
+    expect(mockLogSystemWarn).toHaveBeenCalledWith(
+      "network_rpc",
+      expect.stringContaining("leaving it open"),
+      expect.any(Error),
+      { execution_id: "we_1" }
+    );
+  });
+});
+
+describe("scheduling safety", () => {
+  it("reads the whole eligible set newest first, up to the row cap", async () => {
+    verifyResolves("success");
+
+    await run([], [], { maxRows: 2000 });
+
+    expect(selectCalls).toHaveLength(2);
+    expect(render(selectCalls[0].orderBy).sql).toBe(
+      '"direct_executions"."created_at" desc'
+    );
+    expect(render(selectCalls[1].orderBy).sql).toBe(
+      '"workflow_executions"."started_at" desc'
+    );
+    expect(selectCalls.map((call) => call.limit)).toEqual([2000, 2000]);
+  });
+
+  it("examines every row it read rather than the first 200", async () => {
+    verifyResolves("success");
+    const rows = Array.from({ length: 450 }, (_, i) =>
+      directRow({ id: `de_${i}` })
+    );
+
+    const report = await run(rows, []);
+
+    expect(report.direct.examined).toBe(450);
+    expect(report.direct.deferred).toBe(0);
+    expect(mockVerify).toHaveBeenCalledTimes(450);
+  });
+
+  it("stops at the time budget, splitting it so direct rows cannot starve workflows", async () => {
+    // Each lookup costs 20s of wall clock. With a 60s budget direct rows get
+    // the first 30s (two lookups) and workflows the remainder (one lookup).
+    mockVerify.mockImplementation(async () => {
+      vi.setSystemTime(Date.now() + 20_000);
+      return { allVerified: true, results: [receipt("success")] };
+    });
+    const direct = Array.from({ length: 10 }, (_, i) =>
+      directRow({ id: `de_${i}` })
+    );
+    const workflows = Array.from({ length: 10 }, (_, i) =>
+      workflowRow({ id: `we_${i}` })
+    );
+
+    const report = await run(direct, workflows, { budgetMs: 60_000 });
+
+    expect(report.direct.examined).toBe(2);
+    expect(report.direct.deferred).toBe(8);
+    expect(report.workflows.examined).toBe(1);
+    expect(report.workflows.deferred).toBe(9);
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Time budget exhausted"),
+      { direct_deferred: "8", workflow_deferred: "9", budget_ms: "60000" }
+    );
+  });
+
+  it("rolls unused direct budget over to workflow rows", async () => {
+    mockVerify.mockImplementation(async () => {
+      vi.setSystemTime(Date.now() + 20_000);
+      return { allVerified: true, results: [receipt("success")] };
+    });
+    const workflows = Array.from({ length: 10 }, (_, i) =>
+      workflowRow({ id: `we_${i}` })
+    );
+
+    const report = await run([], workflows, { budgetMs: 60_000 });
+
+    expect(report.workflows.examined).toBe(3);
+    expect(report.workflows.deferred).toBe(7);
+  });
+
+  it("does not warn when everything was examined", async () => {
+    verifyResolves("success");
+
+    await run([directRow()], [workflowRow()]);
+
+    expect(mockLogWarn).not.toHaveBeenCalled();
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      "[Reconciler] Settled unconfirmed executions",
+      expect.objectContaining({ direct_examined: "1", workflow_examined: "1" })
+    );
+  });
+});


### PR DESCRIPTION
## Failure mode

`/api/cron/execution-reconciler` is the only thing that settles `unconfirmed` executions (both `workflow_executions` and `direct_executions`) and applies the 24h "dropped" verdict. Its header said it is invoked by a Kubernetes CronJob and authorized by `Authorization: Bearer $CRON_SECRET`. Neither was true in practice: no CronJob in `deploy/keeperhub-stack/{prod,staging}/values.yaml` called it, and `CRON_SECRET` existed only in two route handlers (this one and `audit-retention`), in no deploy, infra, or CI file. Every other cron goes through `deploy/scripts/reaper.sh` and `authenticateInternalService` (HMAC with the shared `INTERNAL_SERVICE_HMAC_SECRET`).

Consequence: every `unconfirmed` row was terminal in practice, and the finished sample the finalizer deliberately skips for unconfirmed runs (`recordSettled` in `lib/execute/reconcile-executions.ts`) was never emitted.

## Changes

### Route auth
- `app/api/cron/execution-reconciler/route.ts` and `app/api/cron/audit-retention/route.ts` now authenticate with `authenticateInternalService`, mirroring `app/api/internal/reaper/route.ts` (the verdict's `error` and `status` are returned as-is). The `CRON_SECRET` bearer check is gone; there was no wiring for it anywhere. Header comments updated.
- New contract tests `tests/integration/execution-reconciler-route.test.ts` and `tests/integration/audit-retention-route.test.ts`, following the reaper route test's auth mocking. Each asserts how the route handles an auth verdict, with `authenticateInternalService` mocked as the reaper route test mocks it. A third file, `tests/integration/cron-routes-hmac-signature.test.ts`, runs the real `authenticateInternalService` against both routes - only the HMAC secret store and the loggers are stubbed - and covers the regression directly: a `CRON_SECRET` bearer token is rejected by the verifier, a request signed the way `reaper.sh` signs it is accepted, and a signature made with the wrong secret or for the other route's path is rejected. There were no existing tests for either route; `tests/unit/audit-retention.test.ts` only covers the retention cutoff helper.

### Scheduling
- `execution-reconciler` CronJob added to `prod/values.yaml` and `staging/values.yaml`, copied from the `reaper` entry (same image templating, `INTERNAL_SERVICE_HMAC_SECRET` from parameterStore, same resources, `concurrencyPolicy: Forbid`, `restartPolicy: OnFailure`), calling `reaper.sh http://keeperhub-common:3000/api/cron/execution-reconciler`. `reaper.sh` is URL-generic; `security-behavioral-scan` and `scan-cache-sweeper` already use it for `/api/cron/*` paths.
- Schedule: `1-59/2 * * * *` (offset by one minute, matching the convention every other job in these files follows). The route header asked for "on the order of every minute"; the reconciler only re-reads rows older than 30s and every run now reads the whole eligible set (below), so a fresh broadcast is settled within two minutes of becoming eligible (one minute on average) while halving the scheduling load.
- `deploy/pr-environment/values.template.yaml` mirrors a subset of the crons (reaper, tempo-broadcast-due, security-behavioral-scan) at `* * * * *`; the reconciler is added there the same way so PR environments settle unconfirmed rows. The self-hosted profile sets `cronjob.enabled: false` for every component, so nothing is mirrored there.

### Making the reconciler safe on a schedule (`lib/execute/reconcile-executions.ts`)
- Starvation: it read `ORDER BY created_at ASC LIMIT 200`, so more than 200 rows that stay unreadable would hide every newer row until they aged out at 24h. It now reads only the columns it needs (the `direct_executions` select previously pulled the full row including the `input`/`output` jsonb) and reads each table twice per run: newest first up to a 2000-row memory valve, plus an oldest-first slice of 100 rows. Both lists are merged with the slice at the front and processed under a 60s wall-clock budget. The newest-first read alone cannot reach the tail of an eligible set larger than the cap, and that tail is exactly the set old enough to reach the 24h dropped verdict and leave, so without the slice a backlog with inflow at or above the drain rate would never shrink from the bottom. Rows not reached are reported as `deferred` in the summary and a warn line is logged. Direct rows get at most half the budget so a slow direct backlog cannot starve workflow rows; unused budget rolls over. Ordering newest-first for the bulk of the run means that when the budget runs out it is the stale rows (already re-read many times, least likely to change) that wait, and the one verdict delayed is "dropped after 24h", the safe direction to be late in. The oldest-first slice is bounded at 100 rows so it cannot itself consume a run.
- Why a budget matters: a receipt lookup against an endpoint that times out rather than answers can take tens of seconds per row (`LOOKUP_BUDGET_MS` plus an in-flight retry round in `lib/web3/verify-receipt.ts`), so one unreachable chain would otherwise keep a run going indefinitely.
- Double emission: no DB lock was added; `concurrencyPolicy: Forbid` prevents overlapping runs. In addition every settle is now guarded on `status = 'unconfirmed'`, and the workflow settle emits the finished sample only when its guarded UPDATE actually changed a row. That closes the double-emit even if a manual invocation overlaps the CronJob or a late finalizer settles the row first.
- The no-chainId branch of `reconcileWorkflow` failed the row without `completedAt`; it now stamps it like the other branches.
- New `tests/unit/reconcile-executions.test.ts` (22 cases) covers both tables' verdicts, the `completedAt` regression, the status guard (asserted on the rendered SQL via `PgDialect`), the sample-once behaviour, the newest-first ordering, the row cap, the budget split, and the rollover.

### Observability (`lib/metrics/**`)
- New gauge `keeperhub_executions_unconfirmed{kind="workflow"|"direct"}` from `getUnconfirmedExecutionCountsFromDb`, wired into the DB metrics refresh next to the finished-age gauge, with the same null handling (query error keeps the last value rather than reporting 0).
- `getLastFinishedExecutionAgeSecondsFromDb` now excludes `unconfirmed` rows. The finalizer stamps `completed_at` on them (`lib/workflow/executor/logging.ts`) although they have not finished, which let a pipeline producing only unconfirmed rows look healthy to the zero-finished alert.
- `tests/unit/db-metrics-cache.test.ts` extended with the new helper and two gauge assertions.

## Index findings behind the metrics queries

Checked for the two new metrics aggregates. The reconciler's own reads are covered separately below.
- `workflow_executions(status)`: plain btree `idx_workflow_executions_status` (`drizzle/0026_puzzling_thunderball.sql`, also declared in `lib/db/schema.ts`). There is also the partial `idx_workflow_executions_status_duration` (0095) but it is restricted to `success`/`error`, so it does not apply here.
- `direct_executions(status)`: plain btree `idx_direct_executions_status` (`drizzle/0022_daily_zuras.sql`, declared in `lib/db/schema-extensions.ts`).
- Both new counts are `COUNT(*) WHERE status = 'unconfirmed'`, an equality lookup on those btrees; `unconfirmed` is a rare value so each is a small index scan. No new index is needed.
- The finished-age query still matches the partial index `idx_workflow_executions_completed_at` (`drizzle/0119`, predicate `completed_at IS NOT NULL`); the added `status <> 'unconfirmed'` filter is applied on the backward index scan and only steps past unconfirmed rows at the top.

This PR touches `lib/metrics/**`, so `metrics-db-review-gate` stays red until the `metrics-db-reviewed` label is applied. I have not applied it.

## Follow-up: audit-retention scheduling

`/api/cron/audit-retention` is now reachable through the same wrapper, but no CronJob was added for it. Scheduling a retention deletion of the security audit log is a product decision (it is the only path that can remove audit data), so it is left for a separate change once that decision is taken.

## Verification

Run in a `node:22-slim` container against this worktree (the host has no node):
- `tsx scripts/discover-plugins.ts`: generated.
- `tsc --noEmit`: 75 pre-existing errors, all missing optional modules in unrelated files (`ioredis`, `@coral-xyz/anchor`, `@solana/spl-token`, `driver.js`, `deep-diff`); the error output is byte-identical to a run on the `staging` checkout at `b26c49113`. No errors in any touched file.
- `biome check` on the nine touched files: clean.
- `vitest run tests/unit/reconcile-executions.test.ts tests/integration/execution-reconciler-route.test.ts tests/integration/audit-retention-route.test.ts tests/unit/db-metrics-cache.test.ts`: 4 files, 46 tests passed.
- Neighbouring suites `tests/unit/{db-metrics-billing-mrr,api-metrics,metrics,workflow-metrics}.test.ts`, `tests/integration/{reaper-route,security-behavioral-scan}.test.ts`: 6 files, 83 tests passed.
- `tsx scripts/check-api-docs-routes.ts`: no drift (`/api/cron/` is allowlisted).
- `prod/values.yaml` and `staging/values.yaml` parse as YAML; the new entries are byte-for-byte copies of the `reaper` entry apart from name, schedule, and URL.

### The reconciler's own reads

Not covered by the index audit above: the reconciler's own queries, which are the more expensive pair. Both are `status = 'unconfirmed' AND <ts> < cutoff ORDER BY <ts> LIMIT n` on `direct_executions(created_at)` and `workflow_executions(started_at)`, in both directions, so four reads every two minutes. Neither table has an index supporting that ordering - `direct_executions` has nothing on `created_at`, and `workflow_executions` has `started_at` only as the second column of `(workflow_id, started_at DESC)`, unusable without a `workflow_id` predicate. Each read therefore plans as an index scan on `idx_*_status` plus a top-N heapsort over the whole unconfirmed set: cheap while the set is small, growing with the backlog. If it is material, the fix is one partial index per table on the timestamp `WHERE status = 'unconfirmed'`, applied `CONCURRENTLY` as a `@requires-db-prep` migration.

### Before enabling the cron

The reconciler has never run in production - `CRON_SECRET` is set in no values file, `.env.example` or workflow, so both routes have returned 401 to nobody. Every existing `unconfirmed` row is therefore older than 24h and reaches the terminal dropped verdict on the first passes, each workflow row emitting one `recordWorkflowExecutionFinished{status:"error"}` sample. Size that backlog before enabling, on both `workflow_executions` and `direct_executions`, and compare the count of rows older than 24h against a normal hour of finished executions. If the burst exceeds an hour of finished samples, or either table holds more than `DEFAULT_MAX_ROWS` unconfirmed rows, land the metrics ahead of the cron and read `keeperhub_executions_unconfirmed` for a day first - the gauge that would size the backlog currently ships in the same change that drains it, so the pre-drain value is never observable.

The `ne(status, 'unconfirmed')` filter on the finished-age query needs its own `EXPLAIN (ANALYZE, BUFFERS)` under the metrics pool's 8s `statement_timeout` before anyone applies `metrics-db-reviewed`. `status` is not in `idx_workflow_executions_completed_at`, so the filter is applied per row with a heap fetch, and the number that decides it is `Rows Removed by Filter`. The failure mode is specific: the finalizer stamps `completed_at` on unconfirmed rows, so a stalled reconciler puts them at the top of that index; on timeout the helper returns null and the caller holds the gauge at its last value, leaving the zero-finished alert quiet exactly when the pipeline is stalled.

### Not applied

`activeDeadlineSeconds` on the CronJob would be a silent no-op. The deploy pins `keeperhub-stack` 0.3.0 from the external chart repository, and that chart's `charts/common` CronJob template renders only `concurrencyPolicy`, `failedJobsHistoryLimit`, `backoffLimit`, `schedule`, `successfulJobsHistoryLimit` and the pod spec - Helm drops unrecognised values keys silently. The gap is real: with `concurrencyPolicy: Forbid` and no `curl --max-time` in `deploy/scripts/reaper.sh`, a hung pod leaves the Job `Running` forever, suppressing every later run without ever reaching `Failed`. Closing it means either adding the key to the shared chart and bumping the pin, or `curl --max-time` in `reaper.sh`, which bounds all eight prod crons and so is a separate decision.
