### PR TITLE
fix: heartbeat the wallet nonce lock and failover-wrap its session reads

### DIFF
--- a/lib/reaper/reap-stale-executions.ts
+++ b/lib/reaper/reap-stale-executions.ts
@@ -161,12 +161,23 @@ export async function reapStaleExecutions(
         )
       );
 
-    // Release any nonce locks still held by reaped executions so affected
-    // wallets are unwedged immediately instead of waiting for the TTL.
+    // Release nonce locks still held by reaped executions, but only ones that
+    // have already lapsed. A lock whose expires_at is still in the future is
+    // being renewed by a live heartbeat, and clearing it hands the wallet to a
+    // waiter while the holder is mid-write: the waiter reads getTransactionCount
+    // and computes the very nonce the holder is about to broadcast at. A holder
+    // that is genuinely dead stops beating and lapses within one TTL, which is
+    // far inside the (much longer) threshold that got it reaped in the first
+    // place, so nothing that used to be unwedged here stays wedged.
     await db
       .update(walletLocks)
       .set({ lockedBy: null, lockedAt: null, expiresAt: sql`NOW()` })
-      .where(inArray(walletLocks.lockedBy, reapedIds));
+      .where(
+        and(
+          inArray(walletLocks.lockedBy, reapedIds),
+          lt(walletLocks.expiresAt, sql`NOW()`)
+        )
+      );
   }
 
   return reapedIds;

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -26,6 +26,7 @@ import {
   logUserError,
   logWarn,
 } from "@/lib/logging";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
 import { sleep } from "@/lib/sleep";
 
 export type NonceSession = {
@@ -34,7 +35,45 @@ export type NonceSession = {
   executionId: string;
   currentNonce: number;
   startedAt: Date;
+  /**
+   * Set by the lock heartbeat once an extension found the row held by another
+   * execution. From then on the nonces this session hands out are no longer
+   * exclusive; a caller that checks it should stop broadcasting.
+   */
+  lost?: boolean;
 };
+
+/**
+ * What the heartbeat needs from a session. It exists from the moment the lock
+ * is held (before the chain reads that size the session) and is grown into
+ * the NonceSession the caller receives, so `lost` lands on the object they
+ * hold.
+ */
+type LockLease = Pick<
+  NonceSession,
+  "walletAddress" | "chainId" | "executionId" | "lost"
+>;
+
+type ChainRead = <T>(
+  operation: (provider: ethers.Provider) => Promise<T>
+) => Promise<T>;
+
+/**
+ * Route the session's chain reads through the failover manager when one is
+ * given, so they get the same per-attempt timeout and fallback as every other
+ * RPC call. A bare provider is still accepted for callers that hold one.
+ */
+function chainReader(rpc: RpcProviderManager | ethers.Provider): ChainRead {
+  if ("executeWithFailover" in rpc) {
+    return (operation) => rpc.executeWithFailover(operation, "read");
+  }
+  return (operation) => operation(rpc);
+}
+
+// Extensions per TTL. At four, an extension lands every quarter of the TTL,
+// so three consecutive failed extensions are needed before a live holder's
+// lock can lapse.
+const HEARTBEATS_PER_TTL = 4;
 
 export type ValidationResult = {
   valid: boolean;
@@ -51,14 +90,22 @@ export type NonceManagerOptions = {
 };
 
 const DEFAULT_OPTIONS: Required<NonceManagerOptions> = {
-  // Worst-case credentialed write is ~90s (full RPC failover round). 5min
-  // gives generous headroom; a wedged lock auto-clears at expires_at.
+  // One failover-wrapped RPC call is bounded at 3 attempts x 30s timeout plus
+  // 1s + 2s backoff = 93s per endpoint, 186s for a primary-then-fallback
+  // round (lib/rpc/providers DEFAULT_MAX_RETRIES / DEFAULT_TIMEOUT_MS), and a
+  // write issues several such calls (fee reads, estimateGas, broadcast,
+  // reconcile, receipt wait). With the primary down a single write can hold
+  // the lock for well over this TTL, so the TTL is not sized to outlast a
+  // write. The heartbeat extends expires_at every lockTtlMs / 4 for as long
+  // as the session is open; the TTL only bounds how long a holder whose
+  // process died (no more heartbeats) wedges the wallet+chain.
   lockTtlMs: 300_000,
-  // 600 * 200ms = 120s acquire budget. Must outwait one full RPC failover
-  // round (~90s per provider including timeouts and exponential backoff),
-  // since preflight failover runs while a legitimate holder still has the
-  // lock. The TTL bounds *stuck* holders; the retry budget bounds the wait
-  // for *legitimate* holders to finish.
+  // 600 * 200ms = 120s acquire budget: how long a waiter tolerates a live
+  // holder before failing with the saturation error below. It covers a
+  // healthy write (seconds) many times over but not a write riding out RPC
+  // failover (several 186s rounds); a waiter then fails loudly rather than
+  // sharing the holder's nonce. The TTL bounds *dead* holders; the retry
+  // budget bounds the wait for *live* ones.
   maxLockRetries: 600,
   lockRetryDelayMs: 200,
 };
@@ -67,6 +114,10 @@ export class NonceManager {
   private readonly lockTtlMs: number;
   private readonly maxLockRetries: number;
   private readonly lockRetryDelayMs: number;
+  private readonly heartbeats = new Map<
+    LockLease,
+    ReturnType<typeof setInterval>
+  >();
 
   constructor(options: NonceManagerOptions = {}) {
     this.lockTtlMs = options.lockTtlMs ?? DEFAULT_OPTIONS.lockTtlMs;
@@ -79,24 +130,33 @@ export class NonceManager {
   /**
    * Start a nonce session for workflow execution.
    * 1. Acquires distributed lock (row-based, with TTL)
-   * 2. Fetches nonce from chain (source of truth)
-   * 3. Validates and reconciles pending transactions
+   * 2. Starts the heartbeat that keeps the lock alive while the session is open
+   * 3. Fetches nonce from chain (source of truth)
+   * 4. Validates and reconciles pending transactions
    */
   async startSession(
     walletAddress: string,
     chainId: number,
     executionId: string,
-    provider: ethers.Provider
+    rpc: RpcProviderManager | ethers.Provider
   ): Promise<{ session: NonceSession; validation: ValidationResult }> {
     const normalizedAddress = walletAddress.toLowerCase();
+    const read = chainReader(rpc);
 
     await this.acquireLock(normalizedAddress, chainId, executionId);
 
+    const lease: LockLease = {
+      walletAddress: normalizedAddress,
+      chainId,
+      executionId,
+      lost: false,
+    };
+    this.startHeartbeat(lease);
+
     try {
       // Fetch nonce from chain (source of truth)
-      const chainNonce = await provider.getTransactionCount(
-        normalizedAddress,
-        "pending"
+      const chainNonce = await read((provider) =>
+        provider.getTransactionCount(normalizedAddress, "pending")
       );
 
       // Reconcile pending rows against chain state BEFORE computing safeNonce
@@ -106,7 +166,7 @@ export class NonceManager {
         normalizedAddress,
         chainId,
         chainNonce,
-        provider
+        read
       );
 
       // Advance past any in-flight nonces still pending after reconciliation
@@ -126,13 +186,12 @@ export class NonceManager {
           ? chainNonce
           : Math.max(chainNonce, maxPendingNonce + 1);
 
-      const session: NonceSession = {
-        walletAddress: normalizedAddress,
-        chainId,
-        executionId,
+      // Same object as the lease, so the heartbeat keeps writing to what the
+      // caller holds.
+      const session: NonceSession = Object.assign(lease, {
         currentNonce: safeNonce,
         startedAt: new Date(),
-      };
+      });
 
       console.log(
         `[NonceManager] Session started for ${normalizedAddress}:${chainId}, ` +
@@ -149,6 +208,7 @@ export class NonceManager {
     } catch (error) {
       // Release lock on setup failure so the wallet isn't held by a session
       // that never actually started.
+      this.stopHeartbeat(lease);
       await this.releaseLock(normalizedAddress, chainId, executionId);
       throw error;
     }
@@ -162,7 +222,7 @@ export class NonceManager {
     walletAddress: string,
     chainId: number,
     chainNonce: number,
-    provider: ethers.Provider
+    read: ChainRead
   ): Promise<ValidationResult> {
     const warnings: string[] = [];
     let reconciledCount = 0;
@@ -181,7 +241,9 @@ export class NonceManager {
 
     for (const tx of pending) {
       if (tx.nonce < chainNonce) {
-        const receipt = await provider.getTransactionReceipt(tx.txHash);
+        const receipt = await read((provider) =>
+          provider.getTransactionReceipt(tx.txHash)
+        );
 
         if (receipt) {
           await db
@@ -212,7 +274,9 @@ export class NonceManager {
           reconciledCount += 1;
         }
       } else if (tx.nonce === chainNonce) {
-        const mempoolTx = await provider.getTransaction(tx.txHash);
+        const mempoolTx = await read((provider) =>
+          provider.getTransaction(tx.txHash)
+        );
 
         if (mempoolTx) {
           warnings.push(
@@ -239,7 +303,9 @@ export class NonceManager {
         // tx.nonce > chainNonce: row claims a future nonce. If the tx is no
         // longer in the mempool (broadcast failed / evicted), reap it so the
         // gap with chainNonce doesn't permanently wedge nonce selection.
-        const mempoolTx = await provider.getTransaction(tx.txHash);
+        const mempoolTx = await read((provider) =>
+          provider.getTransaction(tx.txHash)
+        );
 
         if (mempoolTx) {
           warnings.push(
@@ -358,6 +424,9 @@ export class NonceManager {
    * Call when workflow execution completes (success or failure).
    */
   async endSession(session: NonceSession): Promise<void> {
+    // Stop before releasing: a beat landing after the release would find no
+    // row on its fence and report a lock loss that never happened.
+    this.stopHeartbeat(session);
     await this.releaseLock(
       session.walletAddress,
       session.chainId,
@@ -367,6 +436,82 @@ export class NonceManager {
     console.log(
       `[NonceManager] Session ended for ${session.walletAddress}:${session.chainId}, ` +
         `execution=${session.executionId}`
+    );
+  }
+
+  /**
+   * Extend expires_at every lockTtlMs / HEARTBEATS_PER_TTL while the lock is
+   * held. Fenced on locked_by = executionId like releaseLock, so a beat can
+   * never revive a lock another execution has taken over; finding no row to
+   * extend is how the holder learns it lost the lock.
+   */
+  private startHeartbeat(lease: LockLease): void {
+    const timer = setInterval(() => {
+      // Nobody to throw to from a timer: extendLock reports through the
+      // logger and the lease's `lost` flag instead.
+      this.extendLock(lease).catch(() => undefined);
+    }, this.lockTtlMs / HEARTBEATS_PER_TTL);
+    // A pending beat must never keep the process alive: a process on its way
+    // out is exactly the holder the TTL exists to clear.
+    timer.unref();
+    this.heartbeats.set(lease, timer);
+  }
+
+  private stopHeartbeat(lease: LockLease): void {
+    const timer = this.heartbeats.get(lease);
+    if (timer) {
+      clearInterval(timer);
+      this.heartbeats.delete(lease);
+    }
+  }
+
+  private async extendLock(lease: LockLease): Promise<void> {
+    const { walletAddress, chainId, executionId } = lease;
+    let extended: { walletAddress: string }[];
+    try {
+      extended = await db
+        .update(walletLocks)
+        .set({ expiresAt: new Date(Date.now() + this.lockTtlMs) })
+        .where(
+          and(
+            eq(walletLocks.walletAddress, walletAddress),
+            eq(walletLocks.chainId, chainId),
+            eq(walletLocks.lockedBy, executionId)
+          )
+        )
+        .returning({ walletAddress: walletLocks.walletAddress });
+    } catch (error) {
+      // A beat that errors is not a lost lock: the fence may well still hold,
+      // and the next beat retries with three quarters of the TTL in hand.
+      logWarn("[NonceManager] Lock heartbeat failed", {
+        wallet_address: walletAddress,
+        chain_id: String(chainId),
+        execution_id: executionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    // Extended, or the session ended while this beat was in flight and the
+    // release cleared the row first: nothing to report either way.
+    if (extended.length > 0 || !this.heartbeats.has(lease)) {
+      return;
+    }
+
+    this.stopHeartbeat(lease);
+    lease.lost = true;
+    logSystemWarn(
+      ErrorCategory.INFRASTRUCTURE,
+      `[NonceManager] Lock lost for ${walletAddress}:${chainId}`,
+      new Error(
+        `[NonceManager] Lock lost for ${walletAddress}:${chainId}, ` +
+          `holder=${executionId}: heartbeat found the lock held by another execution`
+      ),
+      {
+        wallet_address: walletAddress,
+        chain_id: String(chainId),
+        execution_id: executionId,
+      }
     );
   }
 

--- a/lib/web3/nonce-manager.ts
+++ b/lib/web3/nonce-manager.ts
@@ -36,12 +36,30 @@ export type NonceSession = {
   currentNonce: number;
   startedAt: Date;
   /**
-   * Set by the lock heartbeat once an extension found the row held by another
-   * execution. From then on the nonces this session hands out are no longer
-   * exclusive; a caller that checks it should stop broadcasting.
+   * Set once the lock can no longer be proved held: an extension found the row
+   * taken by another execution, or the session outlived MAX_SESSION_TTLS and
+   * the heartbeat gave up. From then on the nonces this session hands out are
+   * not exclusive, and getNextNonce refuses to hand out any more.
    */
   lost?: boolean;
 };
+
+/**
+ * Thrown by getNextNonce when the session can no longer prove it holds the
+ * lock. Terminal for the session: the caller must not broadcast, and the
+ * wallet+chain belongs to whoever holds the row now.
+ */
+export class NonceLockLostError extends Error {
+  override readonly name = "NonceLockLostError" as const;
+
+  constructor(
+    session: Pick<NonceSession, "walletAddress" | "chainId" | "executionId">
+  ) {
+    super(
+      `Nonce lock for ${session.walletAddress}:${session.chainId} is no longer held by ${session.executionId}; refusing to allocate a nonce.`
+    );
+  }
+}
 
 /**
  * What the heartbeat needs from a session. It exists from the moment the lock
@@ -54,26 +72,59 @@ type LockLease = Pick<
   "walletAddress" | "chainId" | "executionId" | "lost"
 >;
 
-type ChainRead = <T>(
-  operation: (provider: ethers.Provider) => Promise<T>
-) => Promise<T>;
+/**
+ * The session's chain reads, plus which endpoint answered the last one.
+ *
+ * executeWithFailover switches endpoint on a throw or a timeout, so two reads
+ * in the same session can be answered by different nodes holding different
+ * mempools. The reconciler has to know when that happened: "not in the
+ * mempool" is only evidence that a transaction dropped if the node that
+ * answered is the same one whose nonce we are reconciling against.
+ */
+type SessionReader = {
+  read: <T>(operation: (provider: ethers.Provider) => Promise<T>) => Promise<T>;
+  /** The provider that served the most recent read. */
+  lastEndpoint: () => ethers.Provider | null;
+};
 
 /**
  * Route the session's chain reads through the failover manager when one is
  * given, so they get the same per-attempt timeout and fallback as every other
  * RPC call. A bare provider is still accepted for callers that hold one.
  */
-function chainReader(rpc: RpcProviderManager | ethers.Provider): ChainRead {
+function chainReader(rpc: RpcProviderManager | ethers.Provider): SessionReader {
   if ("executeWithFailover" in rpc) {
-    return (operation) => rpc.executeWithFailover(operation, "read");
+    let lastEndpoint: ethers.Provider | null = null;
+    return {
+      read: (operation) =>
+        rpc.executeWithFailover((provider) => {
+          // The provider handed to the attempt that resolves is the one that
+          // answered, so recording it on every attempt leaves the winner.
+          lastEndpoint = provider;
+          return operation(provider);
+        }, "read"),
+      lastEndpoint: () => lastEndpoint,
+    };
   }
-  return (operation) => operation(rpc);
+  return {
+    read: (operation) => operation(rpc),
+    lastEndpoint: () => rpc,
+  };
 }
 
 // Extensions per TTL. At four, an extension lands every quarter of the TTL,
-// so three consecutive failed extensions are needed before a live holder's
-// lock can lapse.
+// so a lock survives two consecutive failed extensions with a quarter of the
+// TTL still to run. The third failure is the knife edge, not the margin: the
+// fourth beat falls due exactly when expires_at passes.
 const HEARTBEATS_PER_TTL = 4;
+
+// Beats stop after this many TTLs, so a session that never ends cannot renew
+// the lock forever. At the default 300s TTL that caps the beating at 25
+// minutes and the lock itself at 30 - the same bound the stale-execution
+// reaper applies to workflow executions. The withdraw route has no reaper at
+// all (its execution ids are not workflow_executions rows), so for that path
+// this is the only upper bound there is.
+const MAX_SESSION_TTLS = 5;
 
 export type ValidationResult = {
   valid: boolean;
@@ -96,9 +147,11 @@ const DEFAULT_OPTIONS: Required<NonceManagerOptions> = {
   // write issues several such calls (fee reads, estimateGas, broadcast,
   // reconcile, receipt wait). With the primary down a single write can hold
   // the lock for well over this TTL, so the TTL is not sized to outlast a
-  // write. The heartbeat extends expires_at every lockTtlMs / 4 for as long
-  // as the session is open; the TTL only bounds how long a holder whose
-  // process died (no more heartbeats) wedges the wallet+chain.
+  // write. The heartbeat extends expires_at every lockTtlMs / 4 while the
+  // session is open, so the TTL bounds a holder that stopped beating: one
+  // whose process died, or one that hit MAX_SESSION_TTLS. Those two together
+  // bound how long any holder can wedge the wallet+chain at
+  // (MAX_SESSION_TTLS + 1) x lockTtlMs.
   lockTtlMs: 300_000,
   // 600 * 200ms = 120s acquire budget: how long a waiter tolerates a live
   // holder before failing with the saturation error below. It covers a
@@ -141,7 +194,7 @@ export class NonceManager {
     rpc: RpcProviderManager | ethers.Provider
   ): Promise<{ session: NonceSession; validation: ValidationResult }> {
     const normalizedAddress = walletAddress.toLowerCase();
-    const read = chainReader(rpc);
+    const reader = chainReader(rpc);
 
     await this.acquireLock(normalizedAddress, chainId, executionId);
 
@@ -155,9 +208,12 @@ export class NonceManager {
 
     try {
       // Fetch nonce from chain (source of truth)
-      const chainNonce = await read((provider) =>
+      const chainNonce = await reader.read((provider) =>
         provider.getTransactionCount(normalizedAddress, "pending")
       );
+      // Every reconciliation verdict below is relative to this nonce, so it is
+      // only sound on the node that produced it.
+      const nonceEndpoint = reader.lastEndpoint();
 
       // Reconcile pending rows against chain state BEFORE computing safeNonce
       // so future-nonce phantom rows (broadcast failed / evicted from mempool)
@@ -166,7 +222,8 @@ export class NonceManager {
         normalizedAddress,
         chainId,
         chainNonce,
-        read
+        reader,
+        nonceEndpoint
       );
 
       // Advance past any in-flight nonces still pending after reconciliation
@@ -222,7 +279,8 @@ export class NonceManager {
     walletAddress: string,
     chainId: number,
     chainNonce: number,
-    read: ChainRead
+    reader: SessionReader,
+    nonceEndpoint: ethers.Provider | null
   ): Promise<ValidationResult> {
     const warnings: string[] = [];
     let reconciledCount = 0;
@@ -241,7 +299,7 @@ export class NonceManager {
 
     for (const tx of pending) {
       if (tx.nonce < chainNonce) {
-        const receipt = await read((provider) =>
+        const receipt = await reader.read((provider) =>
           provider.getTransactionReceipt(tx.txHash)
         );
 
@@ -274,7 +332,7 @@ export class NonceManager {
           reconciledCount += 1;
         }
       } else if (tx.nonce === chainNonce) {
-        const mempoolTx = await read((provider) =>
+        const mempoolTx = await reader.read((provider) =>
           provider.getTransaction(tx.txHash)
         );
 
@@ -283,7 +341,7 @@ export class NonceManager {
             `Transaction ${tx.txHash} (nonce ${tx.nonce}) still pending in mempool ` +
               `since ${tx.submittedAt?.toISOString()}`
           );
-        } else {
+        } else if (reader.lastEndpoint() === nonceEndpoint) {
           await db
             .update(pendingTransactions)
             .set({ status: "dropped" })
@@ -298,12 +356,18 @@ export class NonceManager {
             `Transaction ${tx.txHash} (nonce ${tx.nonce}) dropped from mempool`
           );
           reconciledCount += 1;
+        } else {
+          warnings.push(
+            `Transaction ${tx.txHash} (nonce ${tx.nonce}) not found, but a different ` +
+              "RPC endpoint answered than the one that gave us the chain nonce; " +
+              "left pending rather than treated as dropped"
+          );
         }
       } else {
         // tx.nonce > chainNonce: row claims a future nonce. If the tx is no
         // longer in the mempool (broadcast failed / evicted), reap it so the
         // gap with chainNonce doesn't permanently wedge nonce selection.
-        const mempoolTx = await read((provider) =>
+        const mempoolTx = await reader.read((provider) =>
           provider.getTransaction(tx.txHash)
         );
 
@@ -312,7 +376,7 @@ export class NonceManager {
             `Future-nonce tx ${tx.txHash} (nonce ${tx.nonce} > chain nonce ${chainNonce}) ` +
               "still in mempool, queued behind predecessors"
           );
-        } else {
+        } else if (reader.lastEndpoint() === nonceEndpoint) {
           await db
             .update(pendingTransactions)
             .set({ status: "dropped" })
@@ -328,6 +392,17 @@ export class NonceManager {
               "not in mempool, marked dropped"
           );
           reconciledCount += 1;
+        } else {
+          // A node that never saw the broadcast reports every transaction as
+          // absent. Dropping the row on that answer removes nonce N from
+          // maxDbPending and hands it straight back out, so the safe reading
+          // of "a different endpoint answered" is no reading at all: leave the
+          // row pending and let safeNonce step past it.
+          warnings.push(
+            `Future-nonce tx ${tx.txHash} (nonce ${tx.nonce} > chain nonce ${chainNonce}) ` +
+              "not found, but a different RPC endpoint answered than the one that " +
+              "gave us the chain nonce; left pending rather than treated as dropped"
+          );
         }
       }
     }
@@ -355,8 +430,21 @@ export class NonceManager {
   /**
    * Get the next nonce and increment for subsequent transactions.
    * Call this for each transaction in a multi-tx workflow.
+   *
+   * A session that can no longer prove it holds the lock gets no more nonces.
+   * This is a narrowing, not a fence: it closes the window from the moment the
+   * loss is observed to the next allocation, which is the whole window for the
+   * second and later transactions of a session. It does NOT cover a loss
+   * observed after a nonce was already handed out and before that nonce is
+   * broadcast - the gas reads and the broadcast in between can take minutes on
+   * a degraded endpoint. Closing that window needs the pending_transactions row
+   * to be reserved, fenced on locked_by, BEFORE the broadcast rather than
+   * recorded after it, which is a change at every broadcast site.
    */
   getNextNonce(session: NonceSession): number {
+    if (session.lost) {
+      throw new NonceLockLostError(session);
+    }
     const nonce = session.currentNonce;
     session.currentNonce += 1;
     return nonce;
@@ -446,10 +534,27 @@ export class NonceManager {
    * extend is how the holder learns it lost the lock.
    */
   private startHeartbeat(lease: LockLease): void {
+    const deadline = Date.now() + this.lockTtlMs * MAX_SESSION_TTLS;
+    let beatInFlight = false;
     const timer = setInterval(() => {
+      if (Date.now() >= deadline) {
+        this.giveUpHeartbeat(lease);
+        return;
+      }
+      // Never start a beat while one is still out. On a saturated pool the
+      // beats would otherwise queue up as waiters on the pool that is already
+      // the bottleneck.
+      if (beatInFlight) {
+        return;
+      }
+      beatInFlight = true;
       // Nobody to throw to from a timer: extendLock reports through the
       // logger and the lease's `lost` flag instead.
-      this.extendLock(lease).catch(() => undefined);
+      this.extendLock(lease)
+        .catch(() => undefined)
+        .finally(() => {
+          beatInFlight = false;
+        });
     }, this.lockTtlMs / HEARTBEATS_PER_TTL);
     // A pending beat must never keep the process alive: a process on its way
     // out is exactly the holder the TTL exists to clear.
@@ -465,13 +570,44 @@ export class NonceManager {
     }
   }
 
+  /**
+   * Stop beating for a session that has outlived MAX_SESSION_TTLS. The lock is
+   * still held for up to one more TTL - long enough for an in-flight broadcast
+   * to be recorded - but the session gets no further nonces, because within
+   * that TTL the row becomes takeable and we would have no way to know.
+   */
+  private giveUpHeartbeat(lease: LockLease): void {
+    this.stopHeartbeat(lease);
+    lease.lost = true;
+    logSystemWarn(
+      ErrorCategory.INFRASTRUCTURE,
+      `[NonceManager] Session lifetime exceeded for ${lease.walletAddress}:${lease.chainId}`,
+      new Error(
+        `[NonceManager] Session lifetime exceeded for ${lease.walletAddress}:${lease.chainId}, ` +
+          `holder=${lease.executionId}: heartbeat stopped after ${MAX_SESSION_TTLS} TTLs, ` +
+          "the lock will lapse within one more"
+      ),
+      {
+        wallet_address: lease.walletAddress,
+        chain_id: String(lease.chainId),
+        execution_id: lease.executionId,
+      }
+    );
+  }
+
   private async extendLock(lease: LockLease): Promise<void> {
     const { walletAddress, chainId, executionId } = lease;
     let extended: { walletAddress: string }[];
     try {
       extended = await db
         .update(walletLocks)
-        .set({ expiresAt: new Date(Date.now() + this.lockTtlMs) })
+        // NOW(), not a JS Date: the JS value would be fixed when the statement
+        // is built, so a beat that waits 200s on a saturated pool would write
+        // an expiry only lockTtlMs - 200s away. Postgres evaluates NOW() when
+        // the statement actually lands.
+        .set({
+          expiresAt: sql`NOW() + ${this.lockTtlMs} * interval '1 millisecond'`,
+        })
         .where(
           and(
             eq(walletLocks.walletAddress, walletAddress),

--- a/lib/web3/transaction-manager.ts
+++ b/lib/web3/transaction-manager.ts
@@ -373,13 +373,12 @@ export async function withNonceSession<T>(
   fn: (session: NonceSession) => Promise<T>
 ): Promise<T> {
   const nonceManager = getNonceManager();
-  const provider = context.rpcManager.getProvider();
 
   const { session, validation } = await nonceManager.startSession(
     walletAddress,
     context.chainId,
     context.executionId,
-    provider
+    context.rpcManager
   );
 
   if (!validation.valid) {

--- a/tests/e2e/vitest/nonce-manager.test.ts
+++ b/tests/e2e/vitest/nonce-manager.test.ts
@@ -26,7 +26,11 @@ vi.unmock("@/lib/db");
 vi.unmock("server-only");
 
 import { pendingTransactions, walletLocks } from "@/lib/db/schema-extensions";
-import { NonceManager, resetNonceManager } from "@/lib/web3/nonce-manager";
+import {
+  NonceLockLostError,
+  NonceManager,
+  resetNonceManager,
+} from "@/lib/web3/nonce-manager";
 
 // Skip if DATABASE_URL not set or SKIP_INFRA_TESTS is true
 const shouldSkip =
@@ -766,5 +770,147 @@ describe.skipIf(shouldSkip)("Nonce Manager E2E", () => {
 
       await manager1.endSession(session1);
     }, 15_000);
+  });
+
+  // The unit suite drives the heartbeat against a mocked db, so it can only
+  // prove the handler reacts to what the UPDATE returned. These run the fence
+  // itself: the lock row, the takeover, and the beat are all real.
+  describe("Heartbeat", () => {
+    const SHORT_TTL_MS = 1000;
+
+    async function readLock() {
+      const [row] = await db
+        .select()
+        .from(walletLocks)
+        .where(
+          and(
+            eq(walletLocks.walletAddress, TEST_WALLET_NORMALIZED),
+            eq(walletLocks.chainId, TEST_CHAIN_ID)
+          )
+        );
+      return row;
+    }
+
+    function sleep(ms: number) {
+      return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
+    it("keeps the lock past its TTL while the holder beats, so nobody else can take it", async () => {
+      const holder = new NonceManager({ lockTtlMs: SHORT_TTL_MS });
+      const { session } = await holder.startSession(
+        TEST_WALLET,
+        TEST_CHAIN_ID,
+        `${testExecutionId}_beating`,
+        createMockProvider(5) as any
+      );
+      const firstExpiry = (await readLock())?.expiresAt;
+
+      // Well past the TTL: without the heartbeat the row would be takeable.
+      await sleep(SHORT_TTL_MS * 1.5);
+
+      const renewed = await readLock();
+      expect(renewed?.lockedBy).toBe(`${testExecutionId}_beating`);
+      expect(renewed?.expiresAt.getTime()).toBeGreaterThan(
+        firstExpiry?.getTime() ?? 0
+      );
+      expect(renewed?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+      expect(session.lost).toBe(false);
+
+      const taker = new NonceManager({
+        lockTtlMs: SHORT_TTL_MS,
+        maxLockRetries: 3,
+        lockRetryDelayMs: 50,
+      });
+      await expect(
+        taker.startSession(
+          TEST_WALLET,
+          TEST_CHAIN_ID,
+          `${testExecutionId}_denied`,
+          createMockProvider(5) as any
+        )
+      ).rejects.toThrow(FAILED_LOCK_REGEX);
+
+      await holder.endSession(session);
+    }, 20_000);
+
+    it("lets a second manager take over once the holder stops beating", async () => {
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+      const holder = new NonceManager({ lockTtlMs: SHORT_TTL_MS });
+      const { session } = await holder.startSession(
+        TEST_WALLET,
+        TEST_CHAIN_ID,
+        `${testExecutionId}_dying`,
+        createMockProvider(5) as any
+      );
+      const timer = setIntervalSpy.mock.results.at(-1)?.value as NodeJS.Timeout;
+      setIntervalSpy.mockRestore();
+
+      // The holder's process dies: the interval never fires again and nothing
+      // renews expires_at.
+      clearInterval(timer);
+      await sleep(SHORT_TTL_MS * 1.5);
+
+      const taker = new NonceManager({
+        lockTtlMs: SHORT_TTL_MS,
+        maxLockRetries: 20,
+        lockRetryDelayMs: 50,
+      });
+      const { session: takerSession } = await taker.startSession(
+        TEST_WALLET,
+        TEST_CHAIN_ID,
+        `${testExecutionId}_heir`,
+        createMockProvider(5) as any
+      );
+      expect((await readLock())?.lockedBy).toBe(`${testExecutionId}_heir`);
+
+      // The dead holder coming back to release must not clear the new holder.
+      await holder.endSession(session);
+      expect((await readLock())?.lockedBy).toBe(`${testExecutionId}_heir`);
+
+      await taker.endSession(takerSession);
+    }, 20_000);
+
+    it("cannot revive a lock another execution has taken over, and hands out no more nonces", async () => {
+      const holder = new NonceManager({ lockTtlMs: SHORT_TTL_MS });
+      const { session } = await holder.startSession(
+        TEST_WALLET,
+        TEST_CHAIN_ID,
+        `${testExecutionId}_loser`,
+        createMockProvider(5) as any
+      );
+
+      // Someone else now owns the row, with an expiry far beyond the holder's.
+      const usurperExpiry = new Date(Date.now() + 60_000);
+      await db
+        .update(walletLocks)
+        .set({
+          lockedBy: `${testExecutionId}_usurper`,
+          lockedAt: new Date(),
+          expiresAt: usurperExpiry,
+        })
+        .where(
+          and(
+            eq(walletLocks.walletAddress, TEST_WALLET_NORMALIZED),
+            eq(walletLocks.chainId, TEST_CHAIN_ID)
+          )
+        );
+
+      // Give the holder several beats to try to extend what it no longer holds.
+      await sleep(SHORT_TTL_MS);
+
+      const row = await readLock();
+      expect(row?.lockedBy).toBe(`${testExecutionId}_usurper`);
+      expect(row?.expiresAt.getTime()).toBe(usurperExpiry.getTime());
+      expect(session.lost).toBe(true);
+      expect(() => holder.getNextNonce(session)).toThrow(NonceLockLostError);
+
+      await holder.endSession(session);
+      expect((await readLock())?.lockedBy).toBe(`${testExecutionId}_usurper`);
+
+      await db
+        .update(walletLocks)
+        .set({ lockedBy: null, lockedAt: null })
+        .where(eq(walletLocks.walletAddress, TEST_WALLET_NORMALIZED));
+    }, 20_000);
   });
 });

--- a/tests/e2e/vitest/reaper-classification.test.ts
+++ b/tests/e2e/vitest/reaper-classification.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   organization,
   users,
+  walletLocks,
   workflowExecutionLogs,
   workflowExecutions,
   workflows,
@@ -74,7 +75,14 @@ describe.skipIf(SKIP)(
 
     let reapedIds: string[] = [];
 
+    // Two wallets, so the two lock fixtures below do not collide on the
+    // (wallet_address, chain_id) primary key.
+    const LAPSED_LOCK_WALLET = `0x${"1".repeat(40)}`;
+    const LIVE_LOCK_WALLET = `0x${"2".repeat(40)}`;
+    const LOCK_CHAIN_ID = 987_654;
+
     async function cleanup(): Promise<void> {
+      await queryClient`DELETE FROM wallet_locks WHERE wallet_address IN (${LAPSED_LOCK_WALLET}, ${LIVE_LOCK_WALLET})`;
       await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
       await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
       await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
@@ -183,6 +191,27 @@ describe.skipIf(SKIP)(
       await seedExecution(ID.runningWithLogFresh, "running", minutesAgo(10));
       await seedStepLog(ID.runningWithLogFresh, "running", null);
 
+      // Two wallet locks held by executions this pass reaps. The only thing
+      // separating them is whether a heartbeat is still renewing expires_at:
+      // the lapsed one is safe to clear, the live one is a holder mid-write
+      // whose nonce a waiter would otherwise duplicate.
+      await db.insert(walletLocks).values([
+        {
+          walletAddress: LAPSED_LOCK_WALLET,
+          chainId: LOCK_CHAIN_ID,
+          lockedBy: ID.runningNoLogsStale,
+          lockedAt: minutesAgo(40),
+          expiresAt: minutesAgo(35),
+        },
+        {
+          walletAddress: LIVE_LOCK_WALLET,
+          chainId: LOCK_CHAIN_ID,
+          lockedBy: ID.runningWithLogStale,
+          lockedAt: minutesAgo(40),
+          expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+        },
+      ]);
+
       // NOTE: reapStaleExecutions is GLOBAL - it reaps every stale row in the DB,
       // not just this suite's PREFIX. On the shared local/CI database this can
       // flip stale rows another suite left behind. Assertions below are therefore
@@ -249,6 +278,23 @@ describe.skipIf(SKIP)(
       expect((await readExecution(ID.runningWithLogFresh)).status).toBe(
         "running"
       );
+    });
+
+    it("clears a lapsed wallet lock held by a reaped execution", async () => {
+      const [row] = await db
+        .select()
+        .from(walletLocks)
+        .where(eq(walletLocks.walletAddress, LAPSED_LOCK_WALLET));
+      expect(row.lockedBy).toBeNull();
+    });
+
+    it("leaves a wallet lock a live heartbeat is still renewing", async () => {
+      const [row] = await db
+        .select()
+        .from(walletLocks)
+        .where(eq(walletLocks.walletAddress, LIVE_LOCK_WALLET));
+      expect(row.lockedBy).toBe(ID.runningWithLogStale);
+      expect(row.expiresAt.getTime()).toBeGreaterThan(Date.now());
     });
   }
 );

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -63,6 +63,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import type { RpcProviderManager } from "@/lib/rpc/providers";
 import {
   getNonceManager,
+  NonceLockLostError,
   NonceManager,
   type NonceSession,
   resetNonceManager,
@@ -798,8 +799,13 @@ describe("NonceManager", () => {
       await vi.advanceTimersByTimeAsync(BEAT_MS);
 
       expect(set).toHaveBeenCalledTimes(1);
-      const { expiresAt } = set.mock.calls[0][0] as { expiresAt: Date };
-      expect(expiresAt.getTime()).toBe(Date.now() + TTL_MS);
+      // The expiry is computed by Postgres when the statement lands, not in JS
+      // when it is built, so a beat delayed on a saturated pool still writes a
+      // full TTL ahead.
+      const { expiresAt } = set.mock.calls[0][0] as { expiresAt: SQL };
+      const rendered = new PgDialect().sqlToQuery(expiresAt);
+      expect(rendered.sql).toContain("NOW()");
+      expect(rendered.params).toEqual([TTL_MS]);
       expect(boundParams(where.mock.calls[0][0])).toEqual([
         "wallet_address",
         WALLET,
@@ -901,6 +907,72 @@ describe("NonceManager", () => {
       await manager.endSession(session);
     });
 
+    it("refuses to hand out another nonce once the session is lost", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_no_nonce");
+      mockLockUpdate(0);
+
+      // One nonce before the loss, none after.
+      expect(manager.getNextNonce(session)).toBe(5);
+      await vi.advanceTimersByTimeAsync(BEAT_MS);
+
+      expect(session.lost).toBe(true);
+      expect(() => manager.getNextNonce(session)).toThrow(NonceLockLostError);
+
+      await manager.endSession(session);
+    });
+
+    it("does not start a beat while the previous one is still in flight", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_slow_db");
+
+      let landFirstBeat: (() => void) | undefined;
+      const returning = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            landFirstBeat = () => resolve([{ walletAddress: "0x" }]);
+          })
+      );
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+        }),
+      });
+
+      // Three beats fall due while the first is still waiting on the pool.
+      await vi.advanceTimersByTimeAsync(BEAT_MS * 3);
+      expect(returning).toHaveBeenCalledTimes(1);
+
+      landFirstBeat?.();
+      await vi.advanceTimersByTimeAsync(BEAT_MS);
+      expect(returning).toHaveBeenCalledTimes(2);
+
+      await manager.endSession(session);
+    });
+
+    it("stops beating and marks the session lost after the maximum lifetime", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_forever");
+      const { set } = mockLockUpdate(1);
+
+      // MAX_SESSION_TTLS is 5, so the beat due at 5 x TTL gives up instead of
+      // extending: 19 extensions land, the 20th beat stops the heartbeat.
+      await vi.advanceTimersByTimeAsync(TTL_MS * 5);
+
+      expect(set).toHaveBeenCalledTimes(19);
+      expect(session.lost).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(mockLogSystemWarn).toHaveBeenCalledWith(
+        "infrastructure",
+        expect.stringContaining("Session lifetime exceeded"),
+        expect.any(Error),
+        expect.objectContaining({ execution_id: "exec_forever" })
+      );
+      expect(() => manager.getNextNonce(session)).toThrow(NonceLockLostError);
+
+      await manager.endSession(session);
+    });
+
     it("unrefs the heartbeat timer so it cannot keep the process alive", async () => {
       const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
       const manager = new NonceManager();
@@ -979,6 +1051,115 @@ describe("NonceManager", () => {
       expect(provider.getTransactionReceipt).toHaveBeenCalledWith("0xmined");
       expect(provider.getTransaction).toHaveBeenCalledWith("0xinflight");
       expect(validation.chainNonce).toBe(5);
+      expect(validation.reconciledCount).toBe(1);
+
+      await manager.endSession(session);
+    });
+
+    it("does not mark a tx dropped when a different endpoint answered the mempool read", async () => {
+      const wallet = "0x1234567890123456789012345678901234567890";
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                walletAddress: wallet,
+                chainId: 1,
+                nonce: 5,
+                txHash: "0xinflight",
+                status: "pending",
+                submittedAt: new Date(),
+              },
+            ]),
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      // The primary answers getTransactionCount; the fallback answers the
+      // mempool read and has never seen 0xinflight.
+      const primary = createMockProvider({ transactionCount: 5 });
+      const fallback = createMockProvider({ transaction: null });
+      let served = 0;
+      const executeWithFailover = vi.fn(
+        (operation: (p: unknown) => Promise<unknown>) => {
+          served += 1;
+          return operation(served === 1 ? primary : fallback);
+        }
+      );
+      const rpcManager = {
+        executeWithFailover,
+      } as unknown as RpcProviderManager;
+
+      // Any update at this point would be a reconciliation write; the lock was
+      // acquired on the INSERT.
+      const set = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockUpdate.mockReturnValue({ set });
+
+      const manager = new NonceManager();
+      const { session, validation } = await manager.startSession(
+        wallet,
+        1,
+        "exec_split_view",
+        rpcManager
+      );
+
+      expect(fallback.getTransaction).toHaveBeenCalledWith("0xinflight");
+      expect(set).not.toHaveBeenCalled();
+      expect(validation.reconciledCount).toBe(0);
+      expect(validation.warnings.join("; ")).toContain(
+        "different RPC endpoint answered"
+      );
+
+      await manager.endSession(session);
+    });
+
+    it("still marks a tx dropped when the same endpoint answered both reads", async () => {
+      const wallet = "0x1234567890123456789012345678901234567890";
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                walletAddress: wallet,
+                chainId: 1,
+                nonce: 5,
+                txHash: "0xgone",
+                status: "pending",
+                submittedAt: new Date(),
+              },
+            ]),
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+
+      const primary = createMockProvider({
+        transactionCount: 5,
+        transaction: null,
+      });
+      const rpcManager = {
+        executeWithFailover: vi.fn(
+          (operation: (p: unknown) => Promise<unknown>) => operation(primary)
+        ),
+      } as unknown as RpcProviderManager;
+
+      const set = vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      mockUpdate.mockReturnValue({ set });
+
+      const manager = new NonceManager();
+      const { session, validation } = await manager.startSession(
+        wallet,
+        1,
+        "exec_single_view",
+        rpcManager
+      );
+
+      expect(set).toHaveBeenCalledWith({ status: "dropped" });
       expect(validation.reconciledCount).toBe(1);
 
       await manager.endSession(session);

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -798,9 +798,9 @@ describe("NonceManager", () => {
       await vi.advanceTimersByTimeAsync(BEAT_MS);
 
       expect(set).toHaveBeenCalledTimes(1);
-      const { expiresAt } = set.mock.calls[0]?.[0] as { expiresAt: Date };
+      const { expiresAt } = set.mock.calls[0][0] as { expiresAt: Date };
       expect(expiresAt.getTime()).toBe(Date.now() + TTL_MS);
-      expect(boundParams(where.mock.calls[0]?.[0])).toEqual([
+      expect(boundParams(where.mock.calls[0][0])).toEqual([
         "wallet_address",
         WALLET,
         "chain_id",

--- a/tests/unit/nonce-manager.test.ts
+++ b/tests/unit/nonce-manager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const FAILED_LOCK_REGEX =
   /Wallet is saturated: could not acquire the nonce lock/;
@@ -58,6 +58,9 @@ vi.mock("@/lib/logging", () => ({
   logWarn: mockLogWarn,
 }));
 
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { RpcProviderManager } from "@/lib/rpc/providers";
 import {
   getNonceManager,
   NonceManager,
@@ -81,6 +84,16 @@ function createMockProvider(
       .mockResolvedValue(options.transactionReceipt ?? null),
     getTransaction: vi.fn().mockResolvedValue(options.transaction ?? null),
   };
+}
+
+/**
+ * Render a drizzle where-clause to its bound parameters, in order. The schema
+ * is mocked to column-name strings above, so a fence such as
+ * `eq(walletLocks.lockedBy, executionId)` renders as the pair
+ * `["locked_by", executionId]`.
+ */
+function boundParams(where: unknown): unknown[] {
+  return new PgDialect().sqlToQuery(where as SQL).params;
 }
 
 /**
@@ -741,6 +754,234 @@ describe("NonceManager", () => {
       expect(session.currentNonce).toBe(0);
       expect(validation.reconciledCount).toBe(4);
       expect(provider.getTransaction).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("lock heartbeat", () => {
+    const WALLET = "0x1234567890123456789012345678901234567890";
+    const TTL_MS = 4000;
+    const BEAT_MS = TTL_MS / 4;
+
+    // Replace the default UPDATE chain with one whose spies can be inspected.
+    // `updatedRows` is what the fenced heartbeat UPDATE returns: 1 = still the
+    // holder, 0 = the fence no longer matches.
+    function mockLockUpdate(updatedRows: number) {
+      const returning = vi
+        .fn()
+        .mockResolvedValue(updatedRows > 0 ? [{ walletAddress: "0x" }] : []);
+      const where = vi.fn().mockReturnValue({ returning });
+      const set = vi.fn().mockReturnValue({ where });
+      mockUpdate.mockReturnValue({ set });
+      return { set, where };
+    }
+
+    async function startSessionWithTtl(executionId: string) {
+      const manager = new NonceManager({ lockTtlMs: TTL_MS });
+      const { session } = await manager.startSession(
+        WALLET,
+        1,
+        executionId,
+        createMockProvider() as unknown as import("ethers").Provider
+      );
+      return { manager, session };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("extends expires_at on the holder's fence every quarter TTL", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_beat");
+      const { set, where } = mockLockUpdate(1);
+
+      await vi.advanceTimersByTimeAsync(BEAT_MS);
+
+      expect(set).toHaveBeenCalledTimes(1);
+      const { expiresAt } = set.mock.calls[0]?.[0] as { expiresAt: Date };
+      expect(expiresAt.getTime()).toBe(Date.now() + TTL_MS);
+      expect(boundParams(where.mock.calls[0]?.[0])).toEqual([
+        "wallet_address",
+        WALLET,
+        "chain_id",
+        1,
+        "locked_by",
+        "exec_beat",
+      ]);
+      expect(session.lost).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(BEAT_MS * 2);
+      expect(set).toHaveBeenCalledTimes(3);
+
+      await manager.endSession(session);
+    });
+
+    it("stops the heartbeat when the session ends", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_end");
+      expect(vi.getTimerCount()).toBe(1);
+
+      await manager.endSession(session);
+      expect(vi.getTimerCount()).toBe(0);
+
+      const { set } = mockLockUpdate(1);
+      await vi.advanceTimersByTimeAsync(TTL_MS * 2);
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it("stops the heartbeat when setup fails after the lock is acquired", async () => {
+      vi.useFakeTimers();
+      const manager = new NonceManager({ lockTtlMs: TTL_MS });
+      const provider = createMockProvider();
+      provider.getTransactionCount.mockRejectedValue(new Error("RPC error"));
+
+      await expect(
+        manager.startSession(
+          WALLET,
+          1,
+          "exec_setup_fail",
+          provider as unknown as import("ethers").Provider
+        )
+      ).rejects.toThrow("RPC error");
+
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("marks the session lost and warns once when the fence no longer matches", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_loser");
+      const { set } = mockLockUpdate(0);
+
+      await vi.advanceTimersByTimeAsync(BEAT_MS);
+
+      expect(session.lost).toBe(true);
+      expect(mockLogSystemWarn).toHaveBeenCalledTimes(1);
+      expect(mockLogSystemWarn).toHaveBeenCalledWith(
+        "infrastructure",
+        expect.stringContaining("Lock lost"),
+        expect.any(Error),
+        expect.objectContaining({
+          wallet_address: WALLET,
+          chain_id: "1",
+          execution_id: "exec_loser",
+        })
+      );
+      // The heartbeat stops itself: no further extensions, no repeat logs.
+      expect(vi.getTimerCount()).toBe(0);
+      await vi.advanceTimersByTimeAsync(BEAT_MS * 3);
+      expect(set).toHaveBeenCalledTimes(1);
+      expect(mockLogSystemWarn).toHaveBeenCalledTimes(1);
+
+      await manager.endSession(session);
+    });
+
+    it("keeps beating when an extension errors rather than declaring the lock lost", async () => {
+      vi.useFakeTimers();
+      const { manager, session } = await startSessionWithTtl("exec_db_blip");
+      const returning = vi.fn().mockRejectedValue(new Error("db down"));
+      mockUpdate.mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ returning }),
+        }),
+      });
+
+      await vi.advanceTimersByTimeAsync(BEAT_MS);
+
+      expect(session.lost).toBe(false);
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        expect.stringContaining("heartbeat failed"),
+        expect.objectContaining({
+          execution_id: "exec_db_blip",
+          error: "db down",
+        })
+      );
+      expect(mockLogSystemWarn).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(1);
+
+      await manager.endSession(session);
+    });
+
+    it("unrefs the heartbeat timer so it cannot keep the process alive", async () => {
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+      const manager = new NonceManager();
+      const { session } = await manager.startSession(
+        WALLET,
+        1,
+        "exec_unref",
+        createMockProvider() as unknown as import("ethers").Provider
+      );
+
+      const timer = setIntervalSpy.mock.results[0]?.value as NodeJS.Timeout;
+      expect(timer.hasRef()).toBe(false);
+
+      await manager.endSession(session);
+      setIntervalSpy.mockRestore();
+    });
+  });
+
+  describe("session reads through the RPC manager", () => {
+    it("routes the chain reads through executeWithFailover as reads", async () => {
+      const wallet = "0x1234567890123456789012345678901234567890";
+      mockSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([
+              {
+                walletAddress: wallet,
+                chainId: 1,
+                nonce: 4,
+                txHash: "0xmined",
+                status: "pending",
+              },
+              {
+                walletAddress: wallet,
+                chainId: 1,
+                nonce: 5,
+                txHash: "0xinflight",
+                status: "pending",
+                submittedAt: new Date(),
+              },
+            ]),
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+      const provider = createMockProvider({
+        transactionCount: 5,
+        transactionReceipt: { blockNumber: 123 },
+        transaction: { hash: "0xinflight" },
+      });
+      const executeWithFailover = vi.fn(
+        (operation: (p: unknown) => Promise<unknown>, _operationType: string) =>
+          operation(provider)
+      );
+      const rpcManager = {
+        executeWithFailover,
+      } as unknown as RpcProviderManager;
+
+      const manager = new NonceManager();
+      const { session, validation } = await manager.startSession(
+        wallet,
+        1,
+        "exec_failover",
+        rpcManager
+      );
+
+      expect(executeWithFailover.mock.calls.map((call) => call[1])).toEqual([
+        "read",
+        "read",
+        "read",
+      ]);
+      expect(provider.getTransactionCount).toHaveBeenCalledWith(
+        wallet,
+        "pending"
+      );
+      expect(provider.getTransactionReceipt).toHaveBeenCalledWith("0xmined");
+      expect(provider.getTransaction).toHaveBeenCalledWith("0xinflight");
+      expect(validation.chainNonce).toBe(5);
+      expect(validation.reconciledCount).toBe(1);
+
+      await manager.endSession(session);
     });
   });
 


### PR DESCRIPTION
## Failure mode

`wallet_locks.expires_at` was written only at acquire (now + 300s) and release. Inside one write step, each failover-wrapped RPC call is bounded at 3 attempts x 30s timeout plus 1s + 2s backoff = 93s per endpoint, 186s for a primary-then-fallback round (`lib/rpc/providers` `DEFAULT_MAX_RETRIES` / `DEFAULT_TIMEOUT_MS`), and a write issues several such calls: fee reads, `estimateGas`, broadcast, ambiguity reconcile, receipt wait. With the primary down a single write holds the lock well past 300s. Takeover is `WHERE expires_at < NOW()`, so an execution arriving after that point took the row over and computed a nonce the original holder was still about to broadcast. The takeover was logged; the loser kept going with its nonce.

Two related gaps in the same file: `startSession`'s own reads (`getTransactionCount`, and `getTransactionReceipt` / `getTransaction` per pending row) ran on the raw `ethers.Provider` with no timeout or fallback, and the sizing comment at `DEFAULT_OPTIONS` said a full failover round is ~90s and that the 120s acquire budget outwaits one. The arithmetic was right - 3 x 30s of timeouts plus 1s + 2s of backoff is 93s per endpoint. The inference drawn from it was not: a 120s acquire budget does not outwait a write riding out failover, because one write issues several such calls and a primary-then-fallback round is 186s.

## Change

**Heartbeat.** While a session is open, `NonceManager` extends `expires_at` to now + `lockTtlMs` every `lockTtlMs / 4` (75s at the default TTL) with an UPDATE fenced on `locked_by = executionId`, the same fence `releaseLock` uses, so a beat can never revive a lock another execution has taken over. It starts right after `acquireLock`, so the chain reads that size the session are covered too, stops in `endSession` (before the release, so a beat landing after the release cannot read as a takeover) and on the setup-failure path, and is `unref()`d so a pending beat cannot keep the process alive. A beat whose fence matches no row stops itself, sets `session.lost = true`, and logs once through `logSystemWarn(INFRASTRUCTURE)` with the same `wallet_address` / `chain_id` / `execution_id` labels the takeover log carries, so the winner's and loser's lines correlate. A beat that errors (a DB blip) logs a plain warning and leaves the lock to the next beat: an error is not evidence of a takeover. Nothing throws from inside the timer.

Why a quarter of the TTL: a lock survives two consecutive failed extensions with a quarter of the TTL still to run, and it costs one small fenced UPDATE per 75s per open session. The third failure is the knife edge, not the margin - the fourth beat falls due exactly when `expires_at` passes. That spacing is also a healthy-DB claim, which is why the expiry is now computed by Postgres at land time (`NOW() + interval`) rather than in JS when the statement is built: a beat delayed on a saturated pool would otherwise write an expiry already partly spent. A `beatInFlight` guard stops beats stacking as pool waiters. Going tighter buys little: the case the TTL now guards against is a dead process, which stops beating altogether, and its recovery time is the TTL itself, not the interval.

What this changes about the TTL: it no longer has to outlast a write. It bounds a holder that has stopped beating - one whose process died, or one that hit `MAX_SESSION_TTLS`. Together those cap any holder at `(MAX_SESSION_TTLS + 1) x lockTtlMs`, 30 minutes at the default. That cap is what gives the withdraw route an upper bound at all: its execution ids are not `workflow_executions` rows, so the stale-execution reaper - the workflow path's real 30-minute bound - cannot see them, and without a cap a withdrawal whose transaction never mines would hold the wallet forever now that the heartbeat renews it. A live holder holds for as long as it is alive. Most awaits inside a session are bounded by the failover manager, but the non-Tempo receipt wait in `EvmChainAdapter.waitForReceiptViaEthers` is ethers `tx.wait()` with no timeout: a transaction that never mines keeps that session, and now its lock, open until the process exits. Before this change the lock lapsed at 300s and a second execution took it with the same nonce, which is the collision being fixed, so the comparison is "wallet held until the transaction settles" against "two transactions sharing one nonce". A bounded receipt wait belongs with the adapter work; noted under open questions.

**Failover-wrapped session reads.** `startSession` accepts `RpcProviderManager | ethers.Provider`. Given the manager, all three reads go through `executeWithFailover(..., "read")`; given a bare provider (existing unit and e2e tests, any caller that holds one) they run directly as before. `withNonceSession` now passes `context.rpcManager` instead of `rpcManager.getProvider()`. It is the only production caller of `startSession`; the Safe executors and the withdraw route consume a session that `withNonceSession` started.

**Comment.** The `DEFAULT_OPTIONS` sizing comment now states the real numbers and the TTL's role after this change. The 120s acquire budget is described as what it is: a waiter's tolerance for a live holder. A waiter that outlasts it fails with the existing saturation error rather than sharing the holder's nonce.

`NonceSession.lost` is optional so typed session literals in other test files keep compiling; the manager always sets it.

## Tests

`tests/unit/nonce-manager.test.ts`: 7 new cases, the 22 existing ones untouched and passing.

- the heartbeat extends `expires_at` to now + TTL on the holder's fence (the rendered WHERE binds `wallet_address`, `chain_id`, `locked_by = executionId`) and beats every quarter TTL
- the heartbeat stops on `endSession`: fake-timer count drops to 0 and no further UPDATE is issued
- the heartbeat stops when setup fails after the lock is acquired
- a beat whose fence matches no row marks the session lost, warns once, and stops itself
- a beat that errors keeps beating and does not mark the session lost
- the timer is `unref()`d (`hasRef()` is false)
- with an `RpcProviderManager`, all three reads go through `executeWithFailover` with `"read"`

## Verification

All commands ran in a `node:22-slim` container against the main checkout's `node_modules`, offline.

- `tsx scripts/discover-plugins.ts`: ok
- `tsc --noEmit`: 74 errors, byte-identical to a stashed baseline of `staging` (every one a `Cannot find module` for a package absent from this machine's `node_modules`: `ioredis`, `@coral-xyz/anchor`, `@solana/spl-token`, `driver.js`, `deep-diff`, plus their implicit-any cascades); none in the changed files
- `biome check lib/web3/nonce-manager.ts lib/web3/transaction-manager.ts tests/unit/nonce-manager.test.ts`: clean
- `vitest run tests/unit/nonce-manager.test.ts`: 29 passed
- `vitest run` on `write-failover`, `evm-chain-adapter-post-broadcast`, `evm-chain-adapter-tempo-confirm`, `batch-write-contract`: 67 passed; `approve-token`, `transfer-token-core`, `write-contract-core` fail at import with `Cannot find package 'ioredis'`, identically at baseline

## Open questions

- The non-Tempo receipt wait (`tx.wait()` with no timeout) is now the one path where a live holder can hold the lock without bound. A `tx.wait(1, timeoutMs)` there, or a ceiling on session lifetime after which the heartbeat stops, would restore an upper bound; both sit outside this file.
- A second write on the same wallet during a degraded-RPC write now fails after 120s with "Wallet is saturated ... reduce this workflow's trigger rate", which misattributes the cause to the author. Left as is.
- Nothing consumes `session.lost` yet; checking it before broadcast belongs with the adapter changes.

## Enforcement, and what is still open

The `lost` flag was written and never read, which left the collision narrowed rather than closed: it moved from the 300s TTL boundary to the 30-minute reaper boundary, where a reaped-but-live holder could still broadcast at a nonce a new holder had since taken. Two changes close that path:

- `lib/reaper/reap-stale-executions.ts` now requires `expires_at < NOW()` when clearing a wallet lock, so the reaper cannot yank a lock a live heartbeat is renewing. A genuinely dead holder stops beating and lapses within one TTL, well inside the 30-minute threshold that got it reaped, so nothing that used to be freed stays wedged.
- `getNextNonce` throws `NonceLockLostError` when the session is lost.

The second is a narrowing, not a fence, and the code says so. It covers the second and later transactions of a session in full; it does not cover a loss observed after a nonce was handed out and before it is broadcast, and a single-transaction session gets no protection from it at all. Fencing `recordTransaction` instead would not help - it is called after broadcast at every site, so it could detect a collision but not prevent one, and throwing there would leave the pending row unwritten and the nonce invisible to the next session. The strong fix is to reserve the `pending_transactions` row before broadcasting and roll it back on failure, which touches every broadcast site plus rollback semantics in `submit-signed.ts`.

Also still open: a beating-but-doomed holder now keeps the wallet for up to 30 minutes where the reaper previously freed it, and waiters in that window fail with the existing saturation message, which misattributes the cause. And a transaction broadcast to `privateMempoolRpcUrl` is invisible to the public read endpoint even when the same endpoint answers both reads, so a false `dropped` remains reachable by that route; that predates this change.

## Endpoint divergence on the mempool reads

Wrapping the three session reads in `executeWithFailover` introduced an exposure the raw provider did not have. A resolved `null` counts as success, so failover switches endpoints only on throw or timeout - which means `getTransactionCount` can be answered by the primary while the follow-up `getTransaction` is answered by the fallback, whose mempool never saw the pending transaction. That null would mark the row `dropped`, drop it out of `maxDbPending`, and hand out a nonce that is still in flight.

The session now records which provider instance served each read and marks a row `dropped` only when the same endpoint that gave `chainNonce` also reports the transaction missing; otherwise it warns and leaves the row `pending`, so `safeNonce` steps past it. The `getTransactionReceipt` branch is untouched - the chain has already moved past that nonce there, so a wrong label is an accounting error rather than a nonce-safety one. This relies on `getPrimaryProvider()` / `getFallbackProvider()` memoizing their instances, which they do; if that memoization were ever removed the check degrades to "always different", which errs toward leaving rows pending rather than toward reuse.
