### PR TITLE
fix: KEEP-1289 raise RPC failover exhaustion to error severity, ship runner metrics on SIGTERM, classify RPC timeouts

### DIFF
--- a/keeperhub-executor/workflow-runner.test.ts
+++ b/keeperhub-executor/workflow-runner.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
+
+// The runner opens its database client, registers the signal handlers, and
+// starts main() when it is imported. Everything main() reaches for is stubbed
+// so the module loads under vitest and parks on a workflow that never finishes,
+// which is the state a SIGTERM finds a live pod in.
+const mocks = vi.hoisted(() => ({
+  updateExecutionStatus: vi.fn(),
+  updateScheduleStatus: vi.fn(),
+  initializeExecutionProgress: vi.fn(),
+  applyExecutionResult: vi.fn(),
+  shipMetricsToExecutor: vi.fn(),
+  queryClientEnd: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("postgres", () => ({
+  default: () => ({ end: mocks.queryClientEnd }),
+}));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: () => ({}) }));
+vi.mock("../lib/db/integrations", () => ({
+  validateWorkflowIntegrations: () => Promise.resolve({ valid: true }),
+}));
+vi.mock("../lib/workflow/load-for-execution", () => ({
+  loadWorkflowForExecution: () =>
+    Promise.resolve({
+      status: "ok",
+      workflow: {
+        id: "wf-1",
+        name: "Parked workflow",
+        nodes: [],
+        edges: [],
+        organizationId: "org-1",
+      },
+      organizationName: "Org",
+    }),
+}));
+vi.mock("../lib/workflow/executor/build-executor-input", () => ({
+  buildExecutorInput: () => ({}),
+}));
+vi.mock("../lib/workflow/executor/executor.workflow", () => ({
+  executeWorkflow: () => new Promise(() => undefined),
+}));
+vi.mock("./lib/db-helpers", () => ({
+  updateExecutionStatus: mocks.updateExecutionStatus,
+  updateScheduleStatus: mocks.updateScheduleStatus,
+  initializeExecutionProgress: mocks.initializeExecutionProgress,
+  applyExecutionResult: mocks.applyExecutionResult,
+}));
+vi.mock("./lib/ship-metrics", () => ({
+  shipMetricsToExecutor: mocks.shipMetricsToExecutor,
+}));
+
+type SignalListener = (...args: unknown[]) => unknown;
+
+/**
+ * Import a fresh runner instance and return the SIGTERM listener it
+ * registered. The listener is invoked directly rather than by emitting a
+ * signal, which would also reach the listeners the test runner installs on
+ * this process.
+ */
+async function loadRunner(): Promise<SignalListener> {
+  const before = new Set(process.listeners("SIGTERM"));
+  vi.resetModules();
+  await import("./workflow-runner");
+  const added = process
+    .listeners("SIGTERM")
+    .filter((listener) => !before.has(listener));
+  expect(added).toHaveLength(1);
+  // main() has parked on executeWorkflow once progress initialization ran.
+  await vi.waitFor(() =>
+    expect(mocks.initializeExecutionProgress).toHaveBeenCalled()
+  );
+  return added[0] as SignalListener;
+}
+
+function firstCallOrder(fn: { mock: { invocationCallOrder: number[] } }): number {
+  return fn.mock.invocationCallOrder[0];
+}
+
+describe("handleGracefulShutdown", () => {
+  beforeEach(() => {
+    for (const fn of Object.values(mocks)) {
+      fn.mockReset();
+    }
+    mocks.updateExecutionStatus.mockResolvedValue(undefined);
+    mocks.updateScheduleStatus.mockResolvedValue(undefined);
+    mocks.initializeExecutionProgress.mockResolvedValue(undefined);
+    mocks.queryClientEnd.mockResolvedValue(undefined);
+    process.env.DATABASE_URL =
+      "postgresql://runner:runner@localhost:5432/runner";
+    process.env.WORKFLOW_ID = "wf-1";
+    process.env.EXECUTION_ID = "exec-1";
+    process.env.SCHEDULE_ID = "sched-1";
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("ships the terminal counters after the status write and before exiting", async () => {
+    mocks.shipMetricsToExecutor.mockResolvedValue(undefined);
+    const onSigterm = await loadRunner();
+    mocks.updateExecutionStatus.mockClear();
+
+    await onSigterm("SIGTERM");
+
+    expect(mocks.updateExecutionStatus).toHaveBeenCalledWith(
+      expect.anything(),
+      "exec-1",
+      "error",
+      { error: "Workflow terminated by SIGTERM signal" }
+    );
+    expect(mocks.shipMetricsToExecutor).toHaveBeenCalledTimes(1);
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(firstCallOrder(mocks.updateExecutionStatus)).toBeLessThan(
+      firstCallOrder(mocks.shipMetricsToExecutor)
+    );
+    expect(firstCallOrder(mocks.shipMetricsToExecutor)).toBeLessThan(
+      firstCallOrder(vi.mocked(process.exit))
+    );
+  });
+
+  it("still force-exits on the shutdown timer when shipping hangs", async () => {
+    mocks.shipMetricsToExecutor.mockReturnValue(
+      new Promise<void>(() => undefined)
+    );
+    const onSigterm = await loadRunner();
+    vi.useFakeTimers();
+
+    onSigterm("SIGTERM");
+    await vi.waitFor(() =>
+      expect(mocks.shipMetricsToExecutor).toHaveBeenCalledTimes(1)
+    );
+    expect(process.exit).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_TIMEOUT_MS);
+
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/keeperhub-executor/workflow-runner.test.ts
+++ b/keeperhub-executor/workflow-runner.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   updateScheduleStatus: vi.fn(),
   initializeExecutionProgress: vi.fn(),
   applyExecutionResult: vi.fn(),
+  executeWorkflow: vi.fn(),
   shipMetricsToExecutor: vi.fn(),
   queryClientEnd: vi.fn(),
 }));
@@ -40,7 +41,7 @@ vi.mock("../lib/workflow/executor/build-executor-input", () => ({
   buildExecutorInput: () => ({}),
 }));
 vi.mock("../lib/workflow/executor/executor.workflow", () => ({
-  executeWorkflow: () => new Promise(() => undefined),
+  executeWorkflow: mocks.executeWorkflow,
 }));
 vi.mock("./lib/db-helpers", () => ({
   updateExecutionStatus: mocks.updateExecutionStatus,
@@ -54,25 +55,39 @@ vi.mock("./lib/ship-metrics", () => ({
 
 type SignalListener = (...args: unknown[]) => unknown;
 
+let onSigint: SignalListener | null = null;
+
 /**
  * Import a fresh runner instance and return the SIGTERM listener it
- * registered. The listener is invoked directly rather than by emitting a
+ * registered; the SIGINT listener from the same instance is stashed in
+ * `onSigint`. Listeners are invoked directly rather than by emitting a
  * signal, which would also reach the listeners the test runner installs on
  * this process.
  */
 async function loadRunner(): Promise<SignalListener> {
-  const before = new Set(process.listeners("SIGTERM"));
+  const beforeTerm = new Set(process.listeners("SIGTERM"));
+  const beforeInt = new Set(process.listeners("SIGINT"));
   vi.resetModules();
   await import("./workflow-runner");
-  const added = process
+  const addedTerm = process
     .listeners("SIGTERM")
-    .filter((listener) => !before.has(listener));
-  expect(added).toHaveLength(1);
+    .filter((listener) => !beforeTerm.has(listener));
+  const addedInt = process
+    .listeners("SIGINT")
+    .filter((listener) => !beforeInt.has(listener));
+  expect(addedTerm).toHaveLength(1);
+  expect(addedInt).toHaveLength(1);
+  onSigint = addedInt[0] as SignalListener;
   // main() has parked on executeWorkflow once progress initialization ran.
   await vi.waitFor(() =>
     expect(mocks.initializeExecutionProgress).toHaveBeenCalled()
   );
-  return added[0] as SignalListener;
+  return addedTerm[0] as SignalListener;
+}
+
+/** Let already-queued continuations run without advancing any timer. */
+function drainMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 function firstCallOrder(fn: { mock: { invocationCallOrder: number[] } }): number {
@@ -87,7 +102,12 @@ describe("handleGracefulShutdown", () => {
     mocks.updateExecutionStatus.mockResolvedValue(undefined);
     mocks.updateScheduleStatus.mockResolvedValue(undefined);
     mocks.initializeExecutionProgress.mockResolvedValue(undefined);
+    mocks.applyExecutionResult.mockResolvedValue({ errorMessage: undefined });
+    // Park on the workflow: the state a SIGTERM finds a live pod in. Tests
+    // that need the run to settle mid-shutdown override this.
+    mocks.executeWorkflow.mockReturnValue(new Promise(() => undefined));
     mocks.queryClientEnd.mockResolvedValue(undefined);
+    onSigint = null;
     process.env.DATABASE_URL =
       "postgresql://runner:runner@localhost:5432/runner";
     process.env.WORKFLOW_ID = "wf-1";
@@ -122,6 +142,85 @@ describe("handleGracefulShutdown", () => {
     expect(firstCallOrder(mocks.shipMetricsToExecutor)).toBeLessThan(
       firstCallOrder(vi.mocked(process.exit))
     );
+  });
+
+  it("ships the shutdown write's counters when the run settles mid-shutdown", async () => {
+    // The interleaving that made a memoized snapshot lose data: the workflow
+    // finishes while the shutdown handler is still inside its status write, so
+    // main() reaches its finally first. Shipping there would send the
+    // pre-terminal snapshot and then exit the process out from under the write.
+    let settleWorkflow: (() => void) | undefined;
+    mocks.executeWorkflow.mockReturnValue(
+      new Promise((resolve) => {
+        settleWorkflow = (): void => resolve({ success: true });
+      })
+    );
+    mocks.shipMetricsToExecutor.mockResolvedValue(undefined);
+    const onSigterm = await loadRunner();
+
+    let completeStatusWrite: (() => void) | undefined;
+    mocks.updateExecutionStatus.mockClear();
+    mocks.updateExecutionStatus.mockReturnValue(
+      new Promise((resolve) => {
+        completeStatusWrite = (): void => resolve(undefined);
+      })
+    );
+
+    onSigterm("SIGTERM");
+    await vi.waitFor(() =>
+      expect(mocks.updateExecutionStatus).toHaveBeenCalledTimes(1)
+    );
+
+    settleWorkflow?.();
+    await vi.waitFor(() =>
+      expect(mocks.applyExecutionResult).toHaveBeenCalled()
+    );
+    await drainMicrotasks();
+
+    // main() is in its finally with the shutdown still in flight.
+    expect(mocks.shipMetricsToExecutor).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+
+    completeStatusWrite?.();
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled());
+
+    expect(mocks.shipMetricsToExecutor).toHaveBeenCalledTimes(1);
+    expect(firstCallOrder(mocks.updateExecutionStatus)).toBeLessThan(
+      firstCallOrder(mocks.shipMetricsToExecutor)
+    );
+    // The handler, not main(), decides how the pod exits.
+    expect(vi.mocked(process.exit).mock.calls[0][0]).toBe(1);
+  });
+
+  it("ignores a repeat signal without releasing the shutdown in flight", async () => {
+    let completeStatusWrite: (() => void) | undefined;
+    mocks.shipMetricsToExecutor.mockResolvedValue(undefined);
+    const onSigterm = await loadRunner();
+
+    mocks.updateExecutionStatus.mockClear();
+    mocks.updateExecutionStatus.mockReturnValue(
+      new Promise((resolve) => {
+        completeStatusWrite = (): void => resolve(undefined);
+      })
+    );
+
+    onSigterm("SIGTERM");
+    await vi.waitFor(() =>
+      expect(mocks.updateExecutionStatus).toHaveBeenCalledTimes(1)
+    );
+
+    onSigterm("SIGTERM");
+    onSigint?.("SIGINT");
+    await drainMicrotasks();
+
+    // The repeats returned early: no second status write, no early exit.
+    expect(mocks.updateExecutionStatus).toHaveBeenCalledTimes(1);
+    expect(mocks.shipMetricsToExecutor).not.toHaveBeenCalled();
+    expect(process.exit).not.toHaveBeenCalled();
+
+    completeStatusWrite?.();
+    await vi.waitFor(() => expect(process.exit).toHaveBeenCalled());
+    expect(mocks.shipMetricsToExecutor).toHaveBeenCalledTimes(1);
   });
 
   it("still force-exits on the shutdown timer when shipping hangs", async () => {

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -110,6 +110,18 @@ let isShuttingDown = false;
 let currentExecutionId: string | null = null;
 let currentScheduleId: string | null = null;
 
+// A SIGTERM that lands while the workflow is finishing lets both the shutdown
+// handler and main()'s finally reach the end of the run. The counter snapshot
+// is cumulative, so shipping it twice would double-count: share one shipment.
+let metricsShipment: Promise<void> | null = null;
+
+function shipMetricsOnce(): Promise<void> {
+  if (!metricsShipment) {
+    metricsShipment = shipMetricsToExecutor();
+  }
+  return metricsShipment;
+}
+
 async function handleGracefulShutdown(signal: string): Promise<void> {
   if (isShuttingDown) {
     console.log(`[Runner] Already shutting down, ignoring ${signal}`);
@@ -148,6 +160,11 @@ async function handleGracefulShutdown(signal: string): Promise<void> {
   } catch (error) {
     console.error("[Runner] Error during graceful shutdown:", error);
   } finally {
+    // The status write above incremented the terminal counters in this
+    // process; they only reach the executor if shipped before exit. Shipping
+    // is bounded by its own fetch timeout, and the forced-exit timer stays
+    // armed until it resolves.
+    await shipMetricsOnce();
     clearTimeout(shutdownTimeout);
     console.log("[Runner] Graceful shutdown complete");
     process.exit(1);
@@ -287,7 +304,7 @@ async function main(): Promise<void> {
       console.log("[Runner] Error recorded to database, exiting normally");
     }
   } finally {
-    await shipMetricsToExecutor();
+    await shipMetricsOnce();
     if (!isShuttingDown) {
       await queryClient.end();
       console.log("[Runner] Database connection closed");

--- a/keeperhub-executor/workflow-runner.ts
+++ b/keeperhub-executor/workflow-runner.ts
@@ -111,9 +111,17 @@ let currentExecutionId: string | null = null;
 let currentScheduleId: string | null = null;
 
 // A SIGTERM that lands while the workflow is finishing lets both the shutdown
-// handler and main()'s finally reach the end of the run. The counter snapshot
-// is cumulative, so shipping it twice would double-count: share one shipment.
+// handler and main()'s finally reach the end of the run. collectCounterDeltas
+// reads absolute counter values with no last-shipped baseline, so a second
+// shipment would re-send everything the first one did: the two paths share one
+// shipment rather than each starting their own.
 let metricsShipment: Promise<void> | null = null;
+
+// The promise for the shutdown the first signal started. main() waits on it
+// instead of returning, because returning runs the top-level process.exit and
+// would kill the pod out from under a shutdown that has not written its
+// terminal status yet - the write whose counters this all exists to ship.
+let shutdownCompletion: Promise<void> | null = null;
 
 function shipMetricsOnce(): Promise<void> {
   if (!metricsShipment) {
@@ -171,8 +179,17 @@ async function handleGracefulShutdown(signal: string): Promise<void> {
   }
 }
 
-process.on("SIGTERM", () => handleGracefulShutdown("SIGTERM"));
-process.on("SIGINT", () => handleGracefulShutdown("SIGINT"));
+// Keep the FIRST shutdown's promise: a later signal returns the early-exit
+// path, which settles immediately and would release main() while the real
+// shutdown is still mid-flight.
+function onShutdownSignal(signal: string): Promise<void> {
+  const completion = handleGracefulShutdown(signal);
+  shutdownCompletion ??= completion;
+  return completion;
+}
+
+process.on("SIGTERM", () => onShutdownSignal("SIGTERM"));
+process.on("SIGINT", () => onShutdownSignal("SIGINT"));
 
 async function main(): Promise<void> {
   const startTime = Date.now();
@@ -304,8 +321,14 @@ async function main(): Promise<void> {
       console.log("[Runner] Error recorded to database, exiting normally");
     }
   } finally {
-    await shipMetricsOnce();
-    if (!isShuttingDown) {
+    if (isShuttingDown) {
+      // The handler owns the rest: it writes the terminal status, ships the
+      // counters that write increments, closes the connection and exits.
+      // Shipping here instead would send the pre-terminal snapshot and, worse,
+      // let main() resolve into process.exit before that write lands.
+      await shutdownCompletion;
+    } else {
+      await shipMetricsOnce();
       await queryClient.end();
       console.log("[Runner] Database connection closed");
     }

--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -339,6 +339,29 @@ describe("classifyExecutionError", () => {
     });
   });
 
+  describe("a chain rejection quoted inside a failover exhaustion", () => {
+    // The wrapper rules match the wrapper, not the body, so without a rule
+    // above them a deterministic chain verdict would be read as an endpoint
+    // outage and take N-0001's message and system_error status.
+    it.each([
+      "RPC failed on primary endpoint: nonce too low",
+      "RPC failed on primary endpoint: replacement transaction underpriced",
+      "RPC failed on primary endpoint: already known",
+      "RPC failed on primary endpoint: intrinsic gas too low",
+      "RPC failed on both endpoints. Primary: nonce too low. Fallback: nonce too low",
+    ])("keeps %s off the network_rpc code", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).not.toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.code).not.toBe("N-0001");
+      expect(isDefaultClassification(r)).toBe(true);
+    });
+
+    it("leaves an unwrapped chain rejection where it already landed", () => {
+      const r = classifyExecutionError("nonce too low");
+      expect(r).toEqual(classifyExecutionError("some unmatched failure"));
+    });
+  });
+
   describe("system: KeeperHub-managed RPC failures", () => {
     it("RPC failed on both endpoints: network_rpc + system", () => {
       const r = classifyExecutionError(

--- a/lib/errors/__tests__/classify.test.ts
+++ b/lib/errors/__tests__/classify.test.ts
@@ -356,6 +356,45 @@ describe("classifyExecutionError", () => {
       expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
       expect(r.errorType).toBe("system");
     });
+
+    // A chain with no fallback configured exhausts on `primary endpoint`, and
+    // the manager's own per-attempt timeout can surface bare. Both are the
+    // same KeeperHub-managed endpoint failure as the both-endpoints shape.
+    it.each([
+      "RPC failed on primary endpoint: Timeout after 30000ms",
+      "Solana RPC failed on primary endpoint: request timeout",
+      "Timeout after 30000ms",
+    ])("classifies %s as network_rpc + system + N-0001", (input) => {
+      const r = classifyExecutionError(input);
+      expect(r.errorCategory).toBe(ErrorCategory.NETWORK_RPC);
+      expect(r.errorType).toBe("system");
+      expect(r.code).toBe("N-0001");
+      expect(isDefaultClassification(r)).toBe(false);
+    });
+
+    it("keeps the reaper's execution timeout on the workflow-engine code", () => {
+      const r = classifyExecutionError(
+        "Execution timed out: no progress for 30 minutes"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.WORKFLOW_ENGINE);
+      expect(r.code).toBe("E-0001");
+    });
+
+    it("leaves a timeout quoted inside a third-party response with that endpoint", () => {
+      const r = classifyExecutionError("HTTP 504: Timeout after 30000ms");
+      expect(r.errorCategory).toBe(ErrorCategory.EXTERNAL_SERVICE);
+      expect(r.errorType).toBe("external");
+      expect(r.code).toBeNull();
+    });
+
+    it("attributes a single-endpoint exhaustion that quotes a funding shortfall to the wallet", () => {
+      const r = classifyExecutionError(
+        "RPC failed on primary endpoint: insufficient funds for intrinsic transaction cost"
+      );
+      expect(r.errorCategory).toBe(ErrorCategory.TRANSACTION);
+      expect(r.errorType).toBe("user");
+      expect(r.code).toBeNull();
+    });
   });
 
   describe("system: database / persistence", () => {

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -62,6 +62,21 @@ type Rule = {
 };
 
 /**
+ * Verdicts the chain returned about the transaction we built, not about the
+ * endpoint that carried them: a nonce the chain has already consumed, a
+ * resubmission it already holds or that did not bump enough, a gas limit below
+ * the intrinsic cost. Like a funding shortfall, every endpoint answers the same
+ * way, so the answer keeps its own fault domain even when a failover-exhaustion
+ * message quotes it.
+ */
+const CHAIN_REJECTION_PATTERNS: readonly RegExp[] = [
+  /nonce too low/i,
+  /replacement transaction underpriced/i,
+  /\balready known\b/i,
+  /intrinsic gas too low/i,
+];
+
+/**
  * Ordered list of rules. First match wins. Order matters when patterns
  * overlap; more specific patterns should come before broader ones.
  */
@@ -283,6 +298,20 @@ const RULES: readonly Rule[] = [
     errorCategory: ErrorCategory.TRANSACTION,
     errorType: ExecutionErrorType.USER,
     code: null,
+  })),
+
+  // A quoted chain rejection is not an endpoint failure, so it must not be
+  // read as one. This rule exists to deny the RPC wrapper rules below rather
+  // than to reclassify: it reproduces the unmatched-message default exactly,
+  // so these failures keep the plain `error` status, the C-0001 code and the
+  // generic customer message they carry when they arrive unwrapped, instead of
+  // taking N-0001's "a network provider was unavailable". Unanchored and above
+  // the RPC rules for the same reason the funding-shortfall rules are.
+  ...CHAIN_REJECTION_PATTERNS.map((pattern) => ({
+    pattern,
+    errorCategory: ErrorCategory.WORKFLOW_ENGINE,
+    errorType: ExecutionErrorType.SYSTEM,
+    code: DEFAULT_SYSTEM_ERROR_CODE,
   })),
 
   // System: RPC endpoints are KeeperHub-managed infrastructure, so a failover

--- a/lib/errors/classify.ts
+++ b/lib/errors/classify.ts
@@ -293,8 +293,20 @@ const RULES: readonly Rule[] = [
     errorType: ExecutionErrorType.SYSTEM,
     code: "N-0001",
   },
+  // `primary endpoint` is the same exhaustion when no fallback is configured.
   {
-    pattern: /RPC failed on both endpoints/i,
+    pattern: /RPC failed on (both endpoints|primary endpoint)/i,
+    errorCategory: ErrorCategory.NETWORK_RPC,
+    errorType: ExecutionErrorType.SYSTEM,
+    code: "N-0001",
+  },
+  // The RPC managers' per-attempt timeout wrapper produces this shape, so a
+  // timeout that surfaces without the `RPC failed on` prefix is still a
+  // KeeperHub-managed endpoint that did not answer. Start-anchored: a
+  // third-party body quoted after `HTTP NNN:` can carry the same words and
+  // must keep its own rules below.
+  {
+    pattern: /^Timeout after \d+ms/i,
     errorCategory: ErrorCategory.NETWORK_RPC,
     errorType: ExecutionErrorType.SYSTEM,
     code: "N-0001",

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -388,7 +388,7 @@ export function logSystemError(
  * | ---------------------- | ----------- | --------------- | --------- |
  * | logSystemError         | error       | error event     | counter+1 |
  * | logSystemWarn (this)   | warn        | warning event   | none      |
- * | logUserError           | warn        | warning event   | counter+1 |
+ * | logUserError           | warn        | none            | counter+1 |
  *
  * Sentry tag policy:
  *   - error_type is intentionally NOT set. At the call sites where this

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -1,5 +1,5 @@
 import { ethers, isError } from "ethers";
-import { ErrorCategory, logUserError } from "@/lib/logging";
+import { ErrorCategory, logSystemError, logSystemWarn } from "@/lib/logging";
 import { sleep } from "@/lib/sleep";
 import { safeEthersGetUrl } from "../safe-ethers-fetch";
 import { redactAllUrls, scrubRpcUrls } from "../scrub-rpc-urls";
@@ -327,8 +327,9 @@ export class RpcProviderManager {
           return fallbackResult.result as T;
         }
 
-        // Fallback failed - try primary in case it recovered
-        logUserError(
+        // Fallback failed - try primary in case it recovered. Not an outage
+        // yet, so a Sentry warning with no error metric and no page.
+        logSystemWarn(
           ErrorCategory.NETWORK_RPC,
           `[RPC] Fallback RPC failed for ${this.config.chainName}, attempting primary recovery`,
           fallbackResult.error,
@@ -371,7 +372,9 @@ export class RpcProviderManager {
 
         // Both failed -- throw without redundant retry
         this.metricsCollector.recordBothFailed(this.config.chainName);
-        logUserError(
+        // Both endpoints are KeeperHub-managed, so exhausting them is a
+        // platform fault: error level, system-error metric, Sentry.
+        logSystemError(
           ErrorCategory.NETWORK_RPC,
           `[RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,
           `Fallback: ${fallbackResult.error}. Primary: ${primaryResult.error}`,
@@ -426,7 +429,9 @@ export class RpcProviderManager {
       );
 
       if (fallbackResult.success) {
-        logUserError(
+        // The call was served, so this is a recovery event rather than an
+        // outage: Sentry warning, no error metric, no page.
+        logSystemWarn(
           ErrorCategory.NETWORK_RPC,
           `[RPC] Primary RPC failed for ${this.config.chainName}, switching to fallback`,
           primaryResult.error,
@@ -443,7 +448,7 @@ export class RpcProviderManager {
       }
 
       this.metricsCollector.recordBothFailed(this.config.chainName);
-      logUserError(
+      logSystemError(
         ErrorCategory.NETWORK_RPC,
         `[RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,
         `Primary: ${primaryResult.error}. Fallback: ${fallbackResult.error}`,

--- a/lib/rpc/providers/index.ts
+++ b/lib/rpc/providers/index.ts
@@ -373,7 +373,9 @@ export class RpcProviderManager {
         // Both failed -- throw without redundant retry
         this.metricsCollector.recordBothFailed(this.config.chainName);
         // Both endpoints are KeeperHub-managed, so exhausting them is a
-        // platform fault: error level, system-error metric, Sentry.
+        // platform fault: error level and the system-error metric. The Sentry
+        // event only reaches Sentry from the Next.js runtimes - the
+        // workflow-runner pods initialise no Sentry client.
         logSystemError(
           ErrorCategory.NETWORK_RPC,
           `[RPC] Both primary and fallback RPC failed for ${this.config.chainName}`,

--- a/tests/unit/rpc-provider.test.ts
+++ b/tests/unit/rpc-provider.test.ts
@@ -1,3 +1,4 @@
+import { captureException } from "@sentry/nextjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // `lib/rpc/providers` now transitively imports `lib/safe-fetch` via
@@ -5,15 +6,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // would otherwise throw under vitest.
 vi.mock("server-only", () => ({}));
 vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+const recordErrorMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/metrics", () => ({
   getMetricsCollector: () => ({
     incrementCounter: vi.fn(),
     recordLatency: vi.fn(),
-    recordError: vi.fn(),
+    recordError: recordErrorMock,
     setGauge: vi.fn(),
   }),
 }));
 
+import { MetricNames } from "@/lib/metrics/types";
 import {
   clearRpcProviderManagerCache,
   consoleMetricsCollector,
@@ -264,6 +267,133 @@ describe("RpcProviderManager", () => {
 
       await expect(manager.executeWithFailover(mockOperation)).rejects.toThrow(
         "RPC failed on both endpoints"
+      );
+    });
+
+    it("reports an exhausted failover as a system error, not a user warning", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      await expect(
+        manager.executeWithFailover(
+          vi.fn().mockRejectedValue(new Error("down"))
+        )
+      ).rejects.toThrow("RPC failed on both endpoints");
+
+      expect(recordErrorMock).toHaveBeenCalledTimes(1);
+      expect(recordErrorMock).toHaveBeenCalledWith(
+        MetricNames.NETWORK_RPC_ERRORS,
+        expect.anything(),
+        expect.objectContaining({
+          error_type: "system",
+          event: "RPC_BOTH_ENDPOINTS_FAILED",
+          chain: "Ethereum",
+        })
+      );
+      expect(captureException).toHaveBeenCalledTimes(1);
+      const [reported, context] = vi.mocked(captureException).mock.calls[0];
+      expect(reported).toBeInstanceOf(Error);
+      expect(context).toEqual(
+        expect.objectContaining({
+          tags: expect.objectContaining({ error_category: "network_rpc" }),
+          extra: expect.objectContaining({
+            event: "RPC_BOTH_ENDPOINTS_FAILED",
+          }),
+        })
+      );
+      expect(context).not.toHaveProperty("level");
+    });
+
+    it("records a failover that served the call as a warning, not an error", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Primary failed"))
+        .mockResolvedValue("fallback success");
+
+      await expect(manager.executeWithFailover(operation)).resolves.toBe(
+        "fallback success"
+      );
+
+      expect(recordErrorMock).not.toHaveBeenCalled();
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(captureException).mock.calls[0][1]).toEqual(
+        expect.objectContaining({
+          level: "warning",
+          tags: expect.objectContaining({ error_category: "network_rpc" }),
+          extra: expect.objectContaining({ event: "RPC_FAILOVER_ACTIVATED" }),
+        })
+      );
+    });
+
+    it("escalates from a warning to a system error when the sticky fallback and primary both fail", async () => {
+      const manager = new RpcProviderManager({
+        config: {
+          primaryRpcUrl: "https://primary.example.com",
+          fallbackRpcUrl: "https://fallback.example.com",
+          maxRetries: 1,
+          timeoutMs: 100,
+          chainName: "Ethereum",
+        },
+        metricsCollector,
+      });
+
+      const enterFailover = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Primary failed"))
+        .mockResolvedValue("fallback ok");
+      await manager.executeWithFailover(enterFailover);
+      expect(manager.isCurrentlyUsingFallback()).toBe(true);
+      vi.mocked(captureException).mockClear();
+      recordErrorMock.mockClear();
+
+      await expect(
+        manager.executeWithFailover(
+          vi.fn().mockRejectedValue(new Error("down"))
+        )
+      ).rejects.toThrow("RPC failed on both endpoints");
+
+      const contexts = vi
+        .mocked(captureException)
+        .mock.calls.map(([, context]) => context);
+      expect(contexts).toHaveLength(2);
+      expect(contexts[0]).toEqual(
+        expect.objectContaining({
+          level: "warning",
+          extra: expect.objectContaining({ event: "RPC_FALLBACK_FAILED" }),
+        })
+      );
+      expect(contexts[1]).toEqual(
+        expect.objectContaining({
+          extra: expect.objectContaining({
+            event: "RPC_BOTH_ENDPOINTS_FAILED",
+          }),
+        })
+      );
+      expect(contexts[1]).not.toHaveProperty("level");
+      expect(recordErrorMock).toHaveBeenCalledTimes(1);
+      expect(recordErrorMock).toHaveBeenCalledWith(
+        MetricNames.NETWORK_RPC_ERRORS,
+        expect.anything(),
+        expect.objectContaining({ error_type: "system" })
       );
     });
 


### PR DESCRIPTION
## Summary

Three observability defects in how KeeperHub-managed RPC failures and runner terminations reach on-call, verified against `staging` at `b26c49113`.

### 1. RPC failover exhaustion was logged as a user error

`lib/rpc/providers/index.ts` logged `RPC_BOTH_ENDPOINTS_FAILED` (both the sticky-fallback and the normal path of `executeWithFailover`) and `RPC_FAILOVER_ACTIVATED` / `RPC_FALLBACK_FAILED` through `logUserError`. Per `lib/logging.ts` that is warn level, counted on the user-error metric, and never sent to Sentry, while `lib/errors/classify.ts` states the opposite for the same failure: RPC endpoints are KeeperHub-managed, so exhausting them is a platform fault. A platform RPC outage was therefore logged at warn with no Sentry event, reaching on-call only indirectly once enough steps finalized into `system_error`.

This raises it to error level with a Sentry event. It does not create a paging path, and the title should not be read as claiming one. No alert rule reads `keeperhub_errors_network_rpc_total` - the counter family appears in the infra repo only in prose noting it emitted no series in prod - and no Loki alert keys on log level. Two further limits are worth stating plainly: `recordErrorCounter` overwrites `error_type` with the JS error name and drops `chain`, since neither survives `filterLabelsForMetric`, so the `error_type: "system"` label never lands on that counter; and in workflow-runner pods, where the RPC calls actually happen, `captureException` is a no-op because `Sentry.init` runs only in the three Next.js runtimes, while `keeperhub_errors_*` is absent from `SHIPPABLE_COUNTER_NAMES` so the metric never leaves the pod. In the dominant path the whole observable effect is the Loki line moving from warn to error.

Paging on exhaustion needs a Grafana rule on `keeperhub_rpc_both_failed_total`, which is already shipped from runner pods, is already dashboarded so a threshold can be calibrated from history, and is recorded immediately before both of these log sites. Grouped `sum by (chain)`, it carries the one label the Sentry title cannot. That rule lives in the infra repo and is out of scope here.

Change:
- Both `RPC_BOTH_ENDPOINTS_FAILED` sites now use `logSystemError` (category `NETWORK_RPC`): error level, `error_type="system"` on the network-RPC error counter, and a Sentry error event.
- `RPC_FAILOVER_ACTIVATED` and `RPC_FALLBACK_FAILED` now use `logSystemWarn`: a Sentry warning event with no error metric and no page, since a call that was ultimately served is a recovery event rather than an outage.
- Message strings and label objects are unchanged, so existing log-based dashboards keep matching. `logSystemError` / `logSystemWarn` accept `unknown` and wrap non-Error values themselves, so the detail strings are passed exactly as before.

Sentry volume: during an outage this emits one Sentry error event per exhausted call. The detail at these call sites is a string, so `logSystemError` synthesises `new Error(String(error))` inside `lib/logging.ts`. Every such event's stack therefore originates in `lib/logging.ts` and is identical across every string-passing call site, so grouping falls back to the message. The title is the upstream reason (`Fallback: ... Primary: ...`); the chain name lives in the `message` argument, which is not passed to `captureException`, so it reaches Sentry only as a tag and an extra, never the title.

Volume is the open question on this half. In sticky-fallback state every failing call emits `RPC_FALLBACK_FAILED` as a warning event and, if the primary also fails, `RPC_BOTH_ENDPOINTS_FAILED` as an error event - two events per call, from zero before, with no rate limit, sampling or debounce. `app/api/user/wallet/balances/route.ts` calls `executeWithFailover` once for the native balance and once per token, so a single poll can emit `2 x (1 + tokens)` events. Sentry's grouping does not help here: each capture is a distinct event that happens to group into one issue. A debounce keyed on `chain:event` with the structured console line left unconditional would fix it, and needs to cover the error sites too - dropping only the warn sites still leaves one event per call during a total outage.

Metric side effects worth knowing: the user-error network-RPC counter no longer increments on failover or fallback-failed events (the dedicated `keeperhub_rpc_failover_events_total` / `keeperhub_rpc_recovery_events_total` counters recorded by the RPC metrics collector are untouched), and exhaustion now increments the same network-RPC error metric with `error_type="system"` instead of `"user"`. No panel reads this counter: `keeperhub_errors_*` appears in no dashboard under `grafana/keeperhub-dashboards/git-sync/` and in no alert rule. Two of the four call sites now emit no counter at all, since `logSystemWarn` emits none, and at the two that still do, `recordErrorCounter` overwrites `error_type` with the JS error name - so a user/system label was never on the series to move.

### 2. Runner terminal counters were lost on SIGTERM

`keeperhub-executor/workflow-runner.ts` `handleGracefulShutdown` writes the terminal `error` row (which increments the terminal counters in-process via `recordTerminalSample`) and then calls `process.exit(1)`. `main()`'s `finally { await shipMetricsToExecutor() }` never runs, so the increment dies with the pod, and because the row is already terminal the reaper never re-emits it. This undercounts exactly the infrastructure-kill class (deadline, OOM, node drain) the SLA alerts exist for.

Change:
- The handler now awaits the metrics shipment in its `finally`, after the status writes and before `process.exit(1)`. It runs in `finally` rather than after the write so counters accumulated during the run are still shipped when the terminal write itself fails.
- The shipment is bounded by `shipMetricsToExecutor`'s own 5s `AbortSignal.timeout` on the POST (and it is fail-silent), so the handler stays within `SHUTDOWN_TIMEOUT_MS`. `clearTimeout(shutdownTimeout)` moves after the await, so the existing forced-exit timer stays armed while shipping and still fires at 25s if the POST hangs.
- Shipping is shared through a module-level `shipMetricsOnce()` used by both the handler and `main()`'s `finally`. A SIGTERM that lands while the workflow is finishing lets both paths reach the end of the run, and `collectCounterDeltas` keeps no last-shipped baseline - it emits absolute values that the executor side applies with `counter.inc` - so two independent shipments would double-count.

The memoized shipment alone was not enough, for a reason the shipping code does not control: `main().then(() => process.exit(...))` means that once `main()`'s `finally` completes the pod exits, potentially before the handler's terminal status write has landed. Shipping earlier, later, or chained from `main()` cannot help if the process dies first. So during shutdown `main()` now awaits the shutdown handler's completion instead of racing it, leaving the handler as the single shipper and letting it ship the post-terminal snapshot. A repeat signal returns the early-exit path and cannot release the first shutdown's promise. On the non-shutdown path nothing changes. Where both paths could still call the shipper - main ships, then a signal arrives - the execution id is already cleared or the row is terminal, so the status write is a no-op under its own guard and no counter is added.

Tests: the existing `tests/unit/workflow-runner.test.ts` re-implements the shutdown logic inline and never imports the runner, so it could not catch this. Added `keeperhub-executor/workflow-runner.test.ts`, which imports the real module with its collaborators stubbed, parks `main()` on a never-resolving `executeWorkflow`, invokes the registered SIGTERM listener directly, and asserts (a) the terminal status write, the shipment, and `process.exit(1)` happen in that order, and (b) with a hanging shipment the forced-exit timer still exits at `SHUTDOWN_TIMEOUT_MS`. No refactor of the runner was needed.

### 3. Bare RPC timeouts and single-endpoint exhaustion fell to `C-0001`

The manager's `withTimeout` wrapper produces `Timeout after <n>ms`, and a chain with no fallback configured exhausts with `RPC failed on primary endpoint: ...`. Neither matched a rule in `lib/errors/classify.ts`, so both fell to the default `WORKFLOW_ENGINE` / `C-0001` "Internal error" instead of `NETWORK_RPC` / `N-0001`, the code the `RPC failed on both endpoints` rule already assigns.

Change:
- The existing unanchored RPC rule is broadened to `RPC failed on (both endpoints|primary endpoint)`, which also covers the Solana manager's `Solana RPC failed on primary endpoint` shape and step-wrapped forms.
- A new start-anchored rule `^Timeout after \d+ms` maps the bare wrapper message to `NETWORK_RPC` / system / `N-0001`. It is anchored because third-party response bodies are quoted after `HTTP NNN:` and could contain the same words; those must keep their own external/user rules.
- Both sit directly after the existing RPC rules, so first-match ordering is preserved: the funding-shortfall rules above still win (an exhaustion that quotes `insufficient funds` stays a wallet fault), and `^Execution timed out` stays `E-0001`.

Note on the bare form: at this base `executeWithFailover` always prefixes the thrown message with `RPC failed on ... endpoint`, so in practice the `primary endpoint` alternative is the rule that fires for single-endpoint chains. The bare `Timeout after` rule is defensive for any path that surfaces the wrapper message unprefixed.

## Out of scope, flagged

- `lib/rpc/providers/solana.ts` logs the same three events through `logUserError` and has the same severity problem. Left untouched here because this change is scoped to the EVM manager; it should get the same treatment.
- The side-effects table in the `logSystemWarn` jsdoc in `lib/logging.ts` says `logUserError` emits a Sentry warning event; the code has no Sentry call there. The table is stale, not the code.
- `keeperhub-executor/index.ts`, `lib/metrics/**`, and any infrastructure repository are untouched.

## Verification

Run in a `node:22-slim` container against the repo's `node_modules` (the host has no node). Every failure below was baselined against `b26c49113` with the change stashed before being attributed.

- `tsx scripts/discover-plugins.ts`: generated the step registry (prerequisite for vitest and tsc).
- `vitest run tests/unit/rpc-provider.test.ts tests/unit/write-failover.test.ts tests/unit/safe-rpc-failover.test.ts tests/unit/verify-receipt.test.ts lib/errors/__tests__/classify.test.ts keeperhub-executor/lib/ship-metrics.test.ts keeperhub-executor/workflow-runner.test.ts tests/unit/workflow-runner.test.ts`: 8 files, 185 tests passed (rpc-provider 36 to 39, classify 82 to 88, runner test 2 new).
- `biome check lib/rpc/providers/index.ts lib/errors/classify.ts lib/errors/__tests__/classify.test.ts tests/unit/rpc-provider.test.ts`: one formatter error in `lib/errors/__tests__/classify.test.ts` on pre-existing `it.each` blocks; identical output (modulo line numbers) with the change stashed, so it is pre-existing at the base. The other three files are clean. `keeperhub-executor/` is excluded from biome by `biome.jsonc`.
- `tsc --noEmit` and `tsc -p keeperhub-executor --noEmit`: identical error sets before and after the change (74 and 15 errors respectively), none in the touched files. Locally both already fail at the base on `Cannot find module '@coral-xyz/anchor'` / `'@solana/spl-token'` (packages missing from the local install), so the comparison is on error sets, not exit codes.
- Not runnable locally: `tests/unit/write-contract-core.test.ts` fails at import with `Cannot find package 'ioredis'` both before and after the change (same class of local-install noise as the known `undici` failures). It mocks `@/lib/rpc/provider-factory` and imports only `lib/rpc/providers/transport-error`, so it never reaches the changed call sites.

## Classification of chain rejections

Anchoring the RPC wrapper match does not work: `RPC failed on primary endpoint: nonce too low` starts with the wrapper, so an anchored pattern still matches and still swallows the body. Instead, `CHAIN_REJECTION_PATTERNS` (`nonce too low`, `replacement transaction underpriced`, `already known`, `intrinsic gas too low`) is spread above the RPC wrapper rules and below the funding-shortfall rules, preserving the ordering the funding tests pin. These are deterministic chain rejections, not network faults, and `executeWithFailover` interpolates them into the wrapper text with the typed code dropped - a shape `lib/web3/submit-signed.ts` already documents.

They classify to `workflow_engine` / system / `C-0001`, reproducing the unmatched-message default exactly, so the change is zero-delta for the bare shapes while short-circuiting the wrapper rules below. `ErrorCategory.TRANSACTION` would be more truthful, but `(transaction, system)` is a label pair that does not exist today and the P3 by-category rule fires per category into a manual-resolution contact point, so a new series would mean a new class of manual-resolution incidents; that is a deliberate deferral rather than an oversight.

One consequence to flag: this also moves `RPC failed on both endpoints. Primary: nonce too low` off N-0001, a shape that was already N-0001 before this PR. That is intended and consistent with the funding-shortfall precedent.

## Decision needed: the managed-org carve-out

`getSystemErrorsByCategoryFromDb` counts `network_rpc` rows only for `MANAGED_ORG_SLUGS`; every other category is platform-wide. That gauge is the only source of the P3 by-category rule. So routing more shapes into `network_rpc` cuts both ways: single-endpoint exhaustion and bare timeouts for a non-managed org previously defaulted to `workflow_engine` and counted, and now drop out of that P3 entirely, while for a managed org the first one in an hour opens a separate manual-resolution incident. The two P2 pagers are unaffected either way - they filter `error_type="system"` with no category filter, and the default was already `system`. Whether that carve-out should still hold now that more shapes route into the category is a call for review.
