### PR TITLE
ci: KEEP-1296 re-run check-issue-link when an issue is accepted

### DIFF
--- a/.github/workflows/recheck-issue-link.yml
+++ b/.github/workflows/recheck-issue-link.yml
@@ -1,0 +1,141 @@
+name: Recheck Issue Link
+
+# `pr-issue-link.yml` decides whether a pull request references an issue that
+# carries `accepted`. It runs on `pull_request_target`, so it re-evaluates on
+# pull request events and never on issue events - which means a red result
+# outlives the condition that produced it. Label an issue `accepted` and every
+# open pull request referencing it keeps its failing `check-issue-link` until
+# someone pushes, edits the title, or churns a label to force a re-run.
+#
+# That is not hypothetical. On #2217 the gate ran at 02:29:38 and failed
+# because #2211 was unlabelled; #2211 was labelled `accepted` 70 seconds later
+# and the red result stood. The same pull request's timeline shows a label
+# added and removed three seconds apart, three times - the manual workaround.
+#
+# This workflow closes the loop from the other side: when an issue gains or
+# loses `accepted`, find the open pull requests that reference it and re-run
+# their gate. It changes no verdict of its own. `pr-issue-link.yml` remains the
+# single place the rule lives; this only makes it look again.
+#
+# The candidate extraction below is duplicated from that workflow rather than
+# shared. It has to be: the gate runs as `pull_request_target` and is forbidden
+# from checking out, so there is no file both jobs can read. When the rule
+# changes there, change it here. The two must agree, or this re-runs the wrong
+# pull requests and leaves the right ones red.
+#
+# SAFETY: this reads pull request titles, bodies and branch names, all of which
+# are contributor-controlled. They are never interpolated into a shell command
+# or a workflow expression - the API response goes to a file and jq does the
+# matching. The only event data used directly is the issue number and the label
+# name, and the label name only in an `if:` expression.
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+# Keyed by issue, so two issues labelled at once do not queue behind each
+# other. Not cancel-in-progress: a run part-way through its pull request list
+# has already re-run some and not others, and cancelling it would leave the
+# rest red with nothing to trigger them again.
+concurrency:
+  group: recheck-issue-link-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  recheck:
+    if: github.event.label.name == 'accepted'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Re-run the issue-link gate on pull requests referencing this issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GATE_PATH: .github/workflows/pr-issue-link.yml
+          # Kept in step with the `branches:` list in pr-issue-link.yml. A pull
+          # request the gate never runs on has nothing to re-run.
+          GATE_BASES: staging prod
+        run: |
+          set -euo pipefail
+
+          gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > pulls.json
+
+          # Same reference shapes as pr-issue-link.yml: every `#N` in the title
+          # or the body with HTML comments stripped, so the pull request
+          # template's own examples do not count, plus an explicit issue-N /
+          # issue/N / gh-N branch name. A bare number in a branch name is not a
+          # reference. First ten distinct candidates only, matching the gate -
+          # if this issue is the eleventh, the gate ignores it and so must we.
+          jq -r --argjson want "$ISSUE_NUMBER" --arg bases "$GATE_BASES" '
+            ($bases | split(" ")) as $ok
+            | .[]
+            | select(.base.ref as $b | $ok | index($b))
+            | . as $pr
+            | (($pr.body // "") | gsub("<!--.*?-->"; ""; "m")) as $body
+            | ( [ ($pr.title, $body) | match("#([0-9]+)"; "g").captures[0].string ]
+                + [ ($pr.head.ref // "")
+                    | match("(^|/)(issue|gh)[-/]?([0-9]+)"; "gi").captures[2].string ]
+              )
+            | map(tonumber)
+            | reduce .[] as $n ([]; if index($n) then . else . + [$n] end)
+            | .[0:10]
+            | select(index($want))
+            | "\($pr.number) \($pr.head.sha)"
+          ' pulls.json > referencing.txt || true
+
+          if [ ! -s referencing.txt ]; then
+            echo "No open pull request references #$ISSUE_NUMBER. Nothing to re-run."
+            exit 0
+          fi
+
+          rerun=0
+          skipped=0
+          missing=0
+
+          while read -r pr sha; do
+            [ -n "$pr" ] || continue
+
+            run_json=$(gh api "repos/$REPO/actions/runs?head_sha=$sha&per_page=100" \
+              --jq "[.workflow_runs[] | select(.path == \"$GATE_PATH\")]
+                    | sort_by(.created_at) | last // empty" 2>/dev/null || true)
+
+            if [ -z "$run_json" ]; then
+              echo "PR #$pr: no $GATE_PATH run on $sha - nothing to re-run."
+              missing=$((missing + 1))
+              continue
+            fi
+
+            run_id=$(printf '%s' "$run_json" | jq -r '.id')
+            status=$(printf '%s' "$run_json" | jq -r '.status')
+            conclusion=$(printf '%s' "$run_json" | jq -r '.conclusion // ""')
+
+            if [ "$status" != "completed" ]; then
+              echo "PR #$pr: run $run_id is $status - it will pick up the label itself."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            if [ "$conclusion" = "success" ]; then
+              echo "PR #$pr: run $run_id already passed."
+              skipped=$((skipped + 1))
+              continue
+            fi
+
+            # Re-runs the whole run rather than only its failed jobs: a run
+            # cancelled by the gate's own concurrency group has no failed job
+            # to re-run, and this workflow has a single job either way.
+            if gh api -X POST "repos/$REPO/actions/runs/$run_id/rerun" >/dev/null 2>&1; then
+              echo "PR #$pr: re-ran run $run_id (was $conclusion)."
+              rerun=$((rerun + 1))
+            else
+              echo "::warning title=recheck-issue-link::PR #$pr: could not re-run run $run_id."
+            fi
+          done < referencing.txt
+
+          echo "Re-ran $rerun, skipped $skipped, no run found for $missing."


### PR DESCRIPTION
## Issue

No GitHub issue. Team change, tracked as KEEP-1296, which is in the branch name and the commit.

## What this changes

`pr-issue-link.yml` runs on `pull_request_target`, so it re-evaluates on pull request events and never on issue events. A failing `check-issue-link` therefore outlives the condition that produced it: label an issue `accepted` and every open pull request referencing it stays red until someone pushes, edits the title, or churns a label.

That happened on #2217. The gate ran at 02:29:38 and failed because #2211 was unlabelled; #2211 was labelled `accepted` at 02:30:48, and the red result stood until the run was re-run by hand. That pull request's timeline also shows a label added and removed three seconds apart, three times, which is the workaround people are already using.

`recheck-issue-link.yml` triggers on `issues: [labeled, unlabeled]`, filtered to the `accepted` label. It lists open pull requests, extracts issue references exactly as the gate does, and re-runs the `pr-issue-link` run of any pull request that references the labelled issue. It reaches no verdict of its own - `pr-issue-link.yml` remains the only place the rule lives.

Things a reader would not predict from the title:

- **New CI file, and it needs `actions: write`** to call the re-run endpoint. `contents: read` and `pull-requests: read` otherwise. No checkout, no secrets beyond `GITHUB_TOKEN`.
- **The reference extraction is duplicated from `pr-issue-link.yml`, not shared.** It has to be: that workflow runs as `pull_request_target` and its own header forbids adding a checkout, so there is no file both jobs can read. A comment in each names the other. When the rule changes in one, it must change in the other, or this re-runs the wrong pull requests and leaves the right ones red.
- **`/rerun` rather than `/rerun-failed-jobs`.** A run cancelled by the gate's own `cancel-in-progress` group has no failed job to re-run. The gate is a single job, so the two are equivalent when it did fail.
- **Untrusted input is never interpolated.** Pull request titles, bodies and branch names go to a file and are matched by `jq`. The only event data used directly is the issue number and the label name, the latter only in an `if:` expression.
- Concurrency is keyed by issue and deliberately not `cancel-in-progress`: a run part-way through its list has re-run some pull requests and not others, and cancelling it would leave the rest red with nothing to trigger them again.

## Scope

One change. The workflow is a single file and nothing else in the repository refers to it.

Worth stating plainly: `check-issue-link` is not currently in the required status checks of the `protected-branches` ruleset, so this corrects a misleading red X rather than unblocking a merge. #2212 merged today with that check red. Making it a required check is a separate ruleset change and needs a GitHub org owner.

## How it was verified

No TypeScript or JavaScript changed, so the application toolchain is not exercised by this diff. What I did run, against live repository data rather than fixtures:

- **Reference extraction over the 17 currently-open pull requests.** `#2211` resolves to PR #2217, `#2206` to #2213, `#2208` to #2215, `#2196` to #2197. `#2230` resolves to nothing, which is correct - #2228 carries no reference, so labelling that issue would not rescue that pull request, and this agrees with the gate rather than second-guessing it.
- **Run lookup and the skip branches**, against the live Actions API: #2217 and #2213 resolve to `completed/success` and are skipped; #2197 and #2228 resolve to `completed/failure` and would be re-run.
- **The end-to-end effect, by hand.** Re-running #2217's failed run turned `check-issue-link` green on attempt 2, which is what this automates. I did the same for #2213.
- YAML parses; the extracted `run:` body passes `sh -n`.

Not verified: the `issues` trigger firing in anger. That cannot be exercised until this is on the default branch.

## Screenshots

Renders nothing.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [ ] `pnpm check` and `pnpm type-check` pass - not run; this diff adds one YAML file and touches no TypeScript
- [x] No secrets, `.env` files, or credentials committed
