### PR TITLE
fix: give event triggers a dispatch key and drain the executor on shutdown

### DIFF
--- a/keeperhub-events/event-tracker/lib/phantom.ts
+++ b/keeperhub-events/event-tracker/lib/phantom.ts
@@ -7,6 +7,13 @@
  * dequeue. If the enqueue itself fails, the listener resolves the phantom to a
  * coded failure so it surfaces in the run logs.
  *
+ * The create carries a per-log dispatch key. The row's unique index on that key
+ * turns a second create for the same log (a WSS reconnect replaying it, a reorg
+ * re-emitting it, a crash between the SQS send and the Redis mark) into a no-op
+ * that reports `alreadyExisted`, so the caller skips its enqueue instead of
+ * starting a second run. The Redis dedup in front of this is best-effort; the
+ * key is what actually holds.
+ *
  * Both calls are best-effort and must never block or fail a real trigger: a
  * failed create degrades to the legacy id-less enqueue (the executor inserts
  * its own row), and a failed mark is swallowed (the reaper ages it out).
@@ -30,6 +37,12 @@ export type PhantomCreateResult = {
   /** Id of the phantom row, or undefined when the call failed. */
   executionId?: string;
   /**
+   * True when a row already existed for this dispatch key, i.e. an earlier
+   * delivery of the same log already created and enqueued it. The caller must
+   * then skip its own enqueue to avoid a duplicate SQS message and run.
+   */
+  alreadyExisted: boolean;
+  /**
    * Set when the platform refused this dispatch on plan grounds. The caller
    * must skip its enqueue: the executor would refuse the same run. Distinct
    * from an undefined `executionId` with no refusal, which is a transport
@@ -38,19 +51,93 @@ export type PhantomCreateResult = {
   refused?: PhantomRefusalReason;
 };
 
+/**
+ * Per-attempt budget and retry schedule for the internal API calls below. A
+ * transport failure (connection refused or reset, DNS, the timeout) or a 5xx
+ * reply is retried on the schedule; a 4xx is a definitive answer and is not.
+ * Retrying the create is only safe because the dispatch key makes it
+ * idempotent; the PATCH is idempotent through its status compare-and-set.
+ *
+ * Keep in sync with keeperhub-scheduler/lib/http-client.ts and
+ * keeperhub-events/solana-tracker/lib/phantom.ts (this package cannot import
+ * either).
+ */
+const REQUEST_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS: readonly number[] = [500, 1_000];
+const MAX_ATTEMPTS = RETRY_DELAYS_MS.length + 1;
+
+type FetchResult = {
+  response: Response;
+  /** 1 when the first attempt was answered; higher when a retry was. */
+  attempts: number;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /**
- * Pre-create a phantom execution row. Returns its id, a refusal when the
- * platform declined the dispatch on plan grounds, or neither when the call
- * fails (the caller then enqueues without an id and the executor inserts its
- * own row).
+ * Fetch with a per-attempt timeout, retrying transport failures and 5xx replies
+ * on the schedule above. Resolves with the first non-5xx response (or the last
+ * 5xx once the schedule is exhausted) and the attempt that produced it; rejects
+ * with the last transport error when every attempt failed to get a response.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+): Promise<FetchResult> {
+  for (let attempt = 1; ; attempt++) {
+    const isLast = attempt === MAX_ATTEMPTS;
+    let failure: string;
+    try {
+      const response = await fetchWithTimeout(url, init);
+      const serverError = !response.ok && response.status >= 500;
+      if (!serverError || isLast) {
+        return { response, attempts: attempt };
+      }
+      failure = `HTTP ${response.status}`;
+    } catch (error) {
+      if (isLast) {
+        throw error;
+      }
+      failure = formatError(error);
+    }
+    const delayMs = RETRY_DELAYS_MS[attempt - 1];
+    logger.warn(
+      `[Phantom] ${init.method ?? "GET"} ${url} attempt ${attempt}/${MAX_ATTEMPTS} failed (${failure}); retrying in ${delayMs}ms`,
+    );
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Pre-create a phantom execution row for one log, keyed by `dispatchKey`.
+ * Returns its id and whether a row already existed for that key, a refusal
+ * when the platform declined the dispatch on plan grounds, or neither when the
+ * call fails (the caller then enqueues without an id and the executor inserts
+ * its own row).
  */
 export async function createPhantomExecution(
   workflowId: string,
   userId: string,
+  dispatchKey: string,
 ): Promise<PhantomCreateResult> {
   const url = `${KEEPERHUB_API_URL}/api/internal/executions`;
   const body = JSON.stringify({
@@ -58,9 +145,10 @@ export async function createPhantomExecution(
     userId,
     status: "phantom",
     triggerSource: "event",
+    dispatchKey,
   });
   try {
-    const response = await fetch(url, {
+    const { response, attempts } = await fetchWithRetry(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -73,6 +161,7 @@ export async function createPhantomExecution(
     }
     const data = (await response.json()) as {
       executionId?: string;
+      alreadyExisted?: boolean;
       refused?: boolean;
       reason?: PhantomRefusalReason;
       error?: string;
@@ -82,14 +171,22 @@ export async function createPhantomExecution(
       logger.log(
         `[Phantom] Dispatch refused for ${workflowId} (${reason}): ${data.error ?? ""}`,
       );
-      return { refused: reason };
+      return { alreadyExisted: false, refused: reason };
     }
-    return { executionId: data.executionId };
+    // A dedup hit is only trustworthy on the first attempt. After a retry the
+    // existing row may be this listener's own, created by an attempt whose
+    // reply was lost, so nobody has enqueued it yet: report it as fresh and let
+    // the caller enqueue. If an earlier delivery did enqueue it, the second
+    // message is harmless (the executor's status CAS drops the duplicate
+    // delivery); skipping instead would strand the phantom until the reaper
+    // marks it P-0005 and the event would never run.
+    const alreadyExisted = attempts === 1 && data.alreadyExisted === true;
+    return { executionId: data.executionId, alreadyExisted };
   } catch (error) {
     logger.warn(
       `[Phantom] Failed to pre-create execution for ${workflowId}: ${formatError(error)}`,
     );
-    return {};
+    return { alreadyExisted: false };
   }
 }
 
@@ -111,7 +208,7 @@ export async function failPhantomExecution(
     errorCode,
   });
   try {
-    const response = await fetch(url, {
+    const { response } = await fetchWithRetry(url, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -226,7 +226,12 @@ export class EventListener {
 
       const args = extractEventArgs(parsed, this.opts.rawEventsAbi);
       const payload = buildEventPayload(log, parsed, args);
-      await this.sendToSqs(payload);
+      // One key per (workflow, chain, transaction, log): two matching logs in
+      // one transaction are two distinct runs. This is the guard that holds
+      // across a reconnect replay, a reorg re-emit and a crash between the
+      // send and the mark below; the Redis dedup is best-effort and per tx.
+      const dispatchKey = `event:${this.opts.workflowId}:${this.opts.chainId}:${txHash}:${log.index}`;
+      await this.sendToSqs(payload, dispatchKey);
 
       // Mark after the send, and after a refusal too: a refused event is
       // settled, and leaving it unmarked only buys another admission
@@ -248,20 +253,36 @@ export class EventListener {
     }
   }
 
-  private async sendToSqs(payload: unknown): Promise<void> {
+  private async sendToSqs(
+    payload: unknown,
+    dispatchKey: string,
+  ): Promise<void> {
     // KEEP-693: pre-create a phantom row (best-effort) so the run is visible
     // even if it never reaches the executor, and carry its id so the executor
     // upgrades that row instead of inserting.
-    const { executionId, refused } = await createPhantomExecution(
-      this.opts.workflowId,
-      this.opts.userId,
-    );
+    const { executionId, alreadyExisted, refused } =
+      await createPhantomExecution(
+        this.opts.workflowId,
+        this.opts.userId,
+        dispatchKey,
+      );
 
     // Refused on plan grounds: the executor would refuse the same run, and a
     // busy contract would otherwise pay for that round-trip on every match.
     if (refused) {
       logger.log(
         `[EventListener:${this.opts.workflowId}] skipping refused dispatch (${refused})`,
+      );
+      return;
+    }
+
+    // An earlier delivery of this log already created and enqueued the row
+    // (the Redis dedup missed it, or a crash landed between the send and the
+    // mark). Enqueueing again would run it twice; returning lets the caller
+    // mark the event processed.
+    if (alreadyExisted) {
+      logger.log(
+        `[EventListener:${this.opts.workflowId}] skipping duplicate dispatch for ${dispatchKey} (already enqueued)`,
       );
       return;
     }

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -18,7 +18,7 @@ import {
 } from "../../src/listener/event-listener";
 
 // KEEP-693: stub the phantom helpers so the listener does not call the internal
-// API. Default (undefined) keeps existing SQS-path tests on the id-less path.
+// API. Default (no id) keeps existing SQS-path tests on the id-less path.
 const { createPhantomExecution, failPhantomExecution } = vi.hoisted(() => ({
   createPhantomExecution: vi.fn(),
   failPhantomExecution: vi.fn(),
@@ -156,7 +156,7 @@ describe("EventListener", () => {
   beforeEach(() => {
     clearInterfaceCache();
     createPhantomExecution.mockReset();
-    createPhantomExecution.mockResolvedValue({});
+    createPhantomExecution.mockResolvedValue({ alreadyExisted: false });
     failPhantomExecution.mockReset();
   });
 
@@ -251,9 +251,14 @@ describe("EventListener", () => {
       expect(sqs.send).toHaveBeenCalledTimes(1);
     });
 
-    // KEEP-693: phantom pre-creation wiring.
-    it("pre-creates a phantom and carries its id on the event message", async () => {
-      createPhantomExecution.mockResolvedValue({ executionId: "exec_ph" });
+    // KEEP-693: phantom pre-creation wiring. The dispatch key is per log
+    // (workflow, chain, tx, log index), so two matching logs in one transaction
+    // are two distinct runs.
+    it("pre-creates a phantom keyed per log and carries its id on the event message", async () => {
+      createPhantomExecution.mockResolvedValue({
+        executionId: "exec_ph",
+        alreadyExisted: false,
+      });
       const providerMock = makeProviderManagerMock();
       const sqs = makeSqsMock();
       const listener = new EventListener(
@@ -265,19 +270,54 @@ describe("EventListener", () => {
       );
       await listener.start();
 
+      const txHash = `0x${"a".repeat(64)}`;
+      await providerMock.capturedHandler!(
+        makeLog({ txHash, sender: SENDER, value: 7n }),
+      );
+
+      expect(createPhantomExecution).toHaveBeenCalledWith(
+        WORKFLOW_ID,
+        USER_ID,
+        `event:${WORKFLOW_ID}:31337:${txHash}:0`,
+      );
+      const command = sqs.send.mock.calls[0][0] as {
+        input: { MessageBody: string };
+      };
+      expect(JSON.parse(command.input.MessageBody).executionId).toBe("exec_ph");
+    });
+
+    // A replayed log whose Redis dedup entry was missed (or never written, when
+    // the process died between the send and the mark) collides on the dispatch
+    // key: the row was already enqueued once, so it must not be enqueued again.
+    it("skips the enqueue when the dispatch key already exists (dedup)", async () => {
+      createPhantomExecution.mockResolvedValue({
+        executionId: "exec_existing",
+        alreadyExisted: true,
+      });
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      const dedup = makeDedupMock();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          dedup,
+          sqs,
+        }),
+      );
+      await listener.start();
+
       await providerMock.capturedHandler!(
         makeLog({
-          txHash: `0x${"a".repeat(64)}`,
+          txHash: `0x${"d".repeat(64)}`,
           sender: SENDER,
           value: 7n,
         }),
       );
 
-      expect(createPhantomExecution).toHaveBeenCalledWith(WORKFLOW_ID, USER_ID);
-      const command = sqs.send.mock.calls[0][0] as {
-        input: { MessageBody: string };
-      };
-      expect(JSON.parse(command.input.MessageBody).executionId).toBe("exec_ph");
+      expect(sqs.send).not.toHaveBeenCalled();
+      expect(failPhantomExecution).not.toHaveBeenCalled();
+      // The event is settled, so it is marked like any delivered one.
+      expect(dedup.markProcessed).toHaveBeenCalledTimes(1);
     });
 
     it("skips the enqueue entirely when the dispatch is refused", async () => {
@@ -310,7 +350,10 @@ describe("EventListener", () => {
     });
 
     it("marks the phantom failed with ES-0001 when the enqueue fails", async () => {
-      createPhantomExecution.mockResolvedValue({ executionId: "exec_ph" });
+      createPhantomExecution.mockResolvedValue({
+        executionId: "exec_ph",
+        alreadyExisted: false,
+      });
       const providerMock = makeProviderManagerMock();
       const sqs = makeSqsMock();
       sqs.send.mockRejectedValueOnce(new Error("SQS down"));

--- a/keeperhub-events/solana-tracker/lib/phantom.ts
+++ b/keeperhub-events/solana-tracker/lib/phantom.ts
@@ -5,6 +5,12 @@
  * to 'pending' on dequeue. If the enqueue fails, the phantom is resolved to a
  * coded failure. Both calls are best-effort and must never fail a real trigger.
  *
+ * The create carries a per-fire dispatch key. The row's unique index on that
+ * key turns a second create for the same fire (a re-processed block, a crash
+ * between the SQS send and the Redis mark) into a no-op that reports
+ * `alreadyExisted`, so the caller skips its enqueue instead of starting a
+ * second run. The Redis dedup in front of this is best-effort; the key holds.
+ *
  * Serves both trigger kinds: event triggers sign as caller "events" with
  * triggerSource "event"; block triggers sign as "scheduler" with source "block".
  */
@@ -25,6 +31,12 @@ export type PhantomCreateResult = {
   /** Id of the phantom row, or undefined when the call failed. */
   executionId?: string;
   /**
+   * True when a row already existed for this dispatch key, i.e. an earlier
+   * pass over the same block already created and enqueued it. The caller must
+   * then skip its own enqueue to avoid a duplicate SQS message and run.
+   */
+  alreadyExisted: boolean;
+  /**
    * Set when the platform refused this dispatch on plan grounds. The caller
    * must skip its enqueue: the executor would refuse the same run. Distinct
    * from an undefined `executionId` with no refusal, which is a transport
@@ -33,15 +45,95 @@ export type PhantomCreateResult = {
   refused?: PhantomRefusalReason;
 };
 
+/**
+ * Per-attempt budget and retry schedule for the internal API calls below. A
+ * transport failure (connection refused or reset, DNS, the timeout) or a 5xx
+ * reply is retried on the schedule; a 4xx is a definitive answer and is not.
+ * Retrying the create is only safe because the dispatch key makes it
+ * idempotent; the PATCH is idempotent through its status compare-and-set.
+ *
+ * Keep in sync with keeperhub-scheduler/lib/http-client.ts and
+ * keeperhub-events/event-tracker/lib/phantom.ts (this package cannot import
+ * either).
+ */
+const REQUEST_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS: readonly number[] = [500, 1_000];
+const MAX_ATTEMPTS = RETRY_DELAYS_MS.length + 1;
+
+type FetchResult = {
+  response: Response;
+  /** 1 when the first attempt was answered; higher when a retry was. */
+  attempts: number;
+};
+
 function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Fetch with a per-attempt timeout, retrying transport failures and 5xx replies
+ * on the schedule above. Resolves with the first non-5xx response (or the last
+ * 5xx once the schedule is exhausted) and the attempt that produced it; rejects
+ * with the last transport error when every attempt failed to get a response.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+): Promise<FetchResult> {
+  for (let attempt = 1; ; attempt++) {
+    const isLast = attempt === MAX_ATTEMPTS;
+    let failure: string;
+    try {
+      const response = await fetchWithTimeout(url, init);
+      const serverError = !response.ok && response.status >= 500;
+      if (!serverError || isLast) {
+        return { response, attempts: attempt };
+      }
+      failure = `HTTP ${response.status}`;
+    } catch (error) {
+      if (isLast) {
+        throw error;
+      }
+      failure = formatError(error);
+    }
+    const delayMs = RETRY_DELAYS_MS[attempt - 1];
+    logger.warn(
+      `[Phantom] ${init.method ?? "GET"} ${url} attempt ${attempt}/${MAX_ATTEMPTS} failed (${failure}); retrying in ${delayMs}ms`,
+    );
+    await sleep(delayMs);
+  }
+}
+
+/**
+ * Pre-create a phantom execution row for one fire, keyed by `dispatchKey`.
+ * Returns its id and whether a row already existed for that key, a refusal
+ * when the platform declined the dispatch on plan grounds, or neither when the
+ * call fails (the caller then enqueues without an id and the executor inserts
+ * its own row).
+ */
 export async function createPhantomExecution(
   workflowId: string,
   userId: string,
   source: PhantomTriggerSource,
   caller: HmacCaller,
+  dispatchKey: string,
 ): Promise<PhantomCreateResult> {
   const url = `${KEEPERHUB_API_URL}/api/internal/executions`;
   const body = JSON.stringify({
@@ -49,9 +141,10 @@ export async function createPhantomExecution(
     userId,
     status: "phantom",
     triggerSource: source,
+    dispatchKey,
   });
   try {
-    const response = await fetch(url, {
+    const { response, attempts } = await fetchWithRetry(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -64,6 +157,7 @@ export async function createPhantomExecution(
     }
     const data = (await response.json()) as {
       executionId?: string;
+      alreadyExisted?: boolean;
       refused?: boolean;
       reason?: PhantomRefusalReason;
       error?: string;
@@ -73,14 +167,22 @@ export async function createPhantomExecution(
       logger.log(
         `[Phantom] Dispatch refused for ${workflowId} (${reason}): ${data.error ?? ""}`,
       );
-      return { refused: reason };
+      return { alreadyExisted: false, refused: reason };
     }
-    return { executionId: data.executionId };
+    // A dedup hit is only trustworthy on the first attempt. After a retry the
+    // existing row may be this ingestor's own, created by an attempt whose
+    // reply was lost, so nobody has enqueued it yet: report it as fresh and let
+    // the caller enqueue. If an earlier pass did enqueue it, the second message
+    // is harmless (the executor's status CAS drops the duplicate delivery);
+    // skipping instead would strand the phantom until the reaper marks it
+    // P-0005 and the fire would never run.
+    const alreadyExisted = attempts === 1 && data.alreadyExisted === true;
+    return { executionId: data.executionId, alreadyExisted };
   } catch (error) {
     logger.warn(
       `[Phantom] Failed to pre-create execution for ${workflowId}: ${formatError(error)}`,
     );
-    return {};
+    return { alreadyExisted: false };
   }
 }
 
@@ -97,7 +199,7 @@ export async function failPhantomExecution(
     errorCode,
   });
   try {
-    const response = await fetch(url, {
+    const { response } = await fetchWithRetry(url, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",

--- a/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
+++ b/keeperhub-events/solana-tracker/src/ingest/block-ingestor.ts
@@ -210,12 +210,17 @@ export class BlockIngestor {
     if (alreadyProcessed) {
       return;
     }
-    const { executionId, refused } = await createPhantomExecution(
-      fire.workflowId,
-      fire.userId,
-      "event",
-      "events",
-    );
+    // The matcher fires a workflow at most once per transaction, so the
+    // signature identifies the fire; there is no per-event index to add.
+    const dispatchKey = `event:${fire.workflowId}:${this.registration.chainId}:${fire.signature}`;
+    const { executionId, alreadyExisted, refused } =
+      await createPhantomExecution(
+        fire.workflowId,
+        fire.userId,
+        "event",
+        "events",
+        dispatchKey,
+      );
     // Refused on plan grounds: the executor would refuse the same run, so skip
     // the enqueue instead of paying for the round-trip on every match. The
     // event is still marked: it is settled, and leaving it unmarked only buys
@@ -223,6 +228,16 @@ export class BlockIngestor {
     if (refused) {
       logger.log(
         `[ingestor] skipping refused event dispatch for ${fire.workflowId} (${refused})`,
+      );
+      await this.markProcessed(fire.workflowId, fire.signature);
+      return;
+    }
+    // An earlier pass over this block already created and enqueued the row
+    // (the Redis dedup missed it). Enqueueing again would run it twice; the
+    // fire is settled, so mark it like a refusal.
+    if (alreadyExisted) {
+      logger.log(
+        `[ingestor] skipping duplicate event dispatch for ${dispatchKey} (already enqueued)`,
       );
       await this.markProcessed(fire.workflowId, fire.signature);
       return;
@@ -271,15 +286,25 @@ export class BlockIngestor {
     if (alreadyProcessed) {
       return;
     }
-    const { executionId, refused } = await createPhantomExecution(
-      fire.workflowId,
-      fire.userId,
-      "block",
-      "scheduler",
-    );
+    const dispatchKey = `block:${fire.workflowId}:${this.registration.chainId}:${fire.payload.slot}`;
+    const { executionId, alreadyExisted, refused } =
+      await createPhantomExecution(
+        fire.workflowId,
+        fire.userId,
+        "block",
+        "scheduler",
+        dispatchKey,
+      );
     if (refused) {
       logger.log(
         `[ingestor] skipping refused block dispatch for ${fire.workflowId} (${refused})`,
+      );
+      await this.markProcessed(fire.workflowId, dedupKey);
+      return;
+    }
+    if (alreadyExisted) {
+      logger.log(
+        `[ingestor] skipping duplicate block dispatch for ${dispatchKey} (already enqueued)`,
       );
       await this.markProcessed(fire.workflowId, dedupKey);
       return;

--- a/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
+++ b/keeperhub-events/solana-tracker/tests/integration/block-ingestor.test.ts
@@ -142,6 +142,23 @@ describe("BlockIngestor end-to-end fan-out", () => {
     expect(mocks.enqueueBlock).toHaveBeenCalledTimes(1);
     expect(dedup.markProcessed).toHaveBeenCalledWith("wf-event", "sig-1");
 
+    // The phantom for each fire carries its dispatch key: the tx signature for
+    // an event (the matcher fires once per tx), the slot for a block.
+    expect(mocks.createPhantom).toHaveBeenCalledWith(
+      "wf-event",
+      "user-1",
+      "event",
+      "events",
+      "event:wf-event:101:sig-1",
+    );
+    expect(mocks.createPhantom).toHaveBeenCalledWith(
+      "wf-block",
+      "user-1",
+      "block",
+      "scheduler",
+      "block:wf-block:101:100",
+    );
+
     const eventArg = mocks.enqueueEvent.mock.calls[0][2] as {
       workflowId: string;
       triggerData: { chainType: string; programId: string };
@@ -163,6 +180,25 @@ describe("BlockIngestor end-to-end fan-out", () => {
     // A refusal is settled, so it is marked: re-processing the block would
     // otherwise pay for the admission round-trip again and reach the same
     // answer.
+    expect(dedup.markProcessed).toHaveBeenCalledWith("wf-event", "sig-1");
+    expect(dedup.markProcessed).toHaveBeenCalledWith("wf-block", "block:10");
+  });
+
+  // A re-processed block whose Redis dedup entries were missed collides on the
+  // dispatch keys: both rows were already enqueued once and must not be again.
+  it("skips both enqueues when the dispatch keys already exist, and marks them settled", async () => {
+    mocks.createPhantom.mockResolvedValue({
+      executionId: "exec-existing",
+      alreadyExisted: true,
+    });
+    const dedup = fakeDedup(false);
+    await startIngestor(dedup);
+
+    await mocks.onBlock?.(block());
+
+    expect(mocks.enqueueEvent).not.toHaveBeenCalled();
+    expect(mocks.enqueueBlock).not.toHaveBeenCalled();
+    expect(mocks.failPhantom).not.toHaveBeenCalled();
     expect(dedup.markProcessed).toHaveBeenCalledWith("wf-event", "sig-1");
     expect(dedup.markProcessed).toHaveBeenCalledWith("wf-block", "block:10");
   });

--- a/keeperhub-events/solana-tracker/tests/unit/phantom.test.ts
+++ b/keeperhub-events/solana-tracker/tests/unit/phantom.test.ts
@@ -6,11 +6,15 @@ vi.mock("../../lib/utils/logger", () => ({
 
 // HMAC signing reads INTERNAL_SERVICE_HMAC_SECRET and parses the request URL;
 // stub it so the unit test asserts the request shape without a real base
-// URL/secret.
+// URL/secret. The caller is echoed so the test can see which one was signed.
 vi.mock("../../lib/utils/fetch-utils", () => ({
-  // Plain function (not vi.fn) so restoreAllMocks in beforeEach can't neutralise it.
-  signHmacHeaders: () => ({
-    "X-KH-Caller": "events",
+  signHmacHeaders: (
+    _method: string,
+    _url: string,
+    _body: string,
+    caller: string,
+  ) => ({
+    "X-KH-Caller": caller,
     "X-KH-Timestamp": "1",
     "X-KH-Signature": "sig",
   }),
@@ -21,7 +25,8 @@ import {
   failPhantomExecution,
 } from "../../lib/phantom";
 
-const KEY = `event:wf_1:1:0x${"a".repeat(64)}:0`;
+const EVENT_KEY = "event:wf_1:101:sig_1";
+const BLOCK_KEY = "block:wf_1:101:4242";
 
 function reply(status: number, body: unknown) {
   return {
@@ -31,20 +36,7 @@ function reply(status: number, body: unknown) {
   };
 }
 
-/** A fetch that never answers until the client's own timeout aborts it. */
-function hangUntilAborted(): (
-  url: string,
-  init: RequestInit,
-) => Promise<never> {
-  return (_url, init) =>
-    new Promise((_resolve, reject) => {
-      init.signal?.addEventListener("abort", () =>
-        reject(new Error("aborted")),
-      );
-    });
-}
-
-describe("createPhantomExecution (event-tracker)", () => {
+describe("createPhantomExecution (solana-tracker)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -53,7 +45,7 @@ describe("createPhantomExecution (event-tracker)", () => {
     vi.useRealTimers();
   });
 
-  it("POSTs a phantom row keyed by the dispatch key and returns the execution id", async () => {
+  it("POSTs an event phantom keyed by the dispatch key as caller events", async () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValue(
@@ -61,7 +53,13 @@ describe("createPhantomExecution (event-tracker)", () => {
       );
     vi.stubGlobal("fetch", fetchMock);
 
-    const result = await createPhantomExecution("wf_1", "owner_1", KEY);
+    const result = await createPhantomExecution(
+      "wf_1",
+      "owner_1",
+      "event",
+      "events",
+      EVENT_KEY,
+    );
 
     expect(result).toEqual({ executionId: "exec_evt", alreadyExisted: false });
     const [url, init] = fetchMock.mock.calls[0];
@@ -74,7 +72,29 @@ describe("createPhantomExecution (event-tracker)", () => {
       userId: "owner_1",
       status: "phantom",
       triggerSource: "event",
-      dispatchKey: KEY,
+      dispatchKey: EVENT_KEY,
+    });
+  });
+
+  it("POSTs a block phantom as caller scheduler with source block", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(reply(201, { executionId: "exec_blk" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createPhantomExecution(
+      "wf_1",
+      "owner_1",
+      "block",
+      "scheduler",
+      BLOCK_KEY,
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers["X-KH-Caller"]).toBe("scheduler");
+    expect(JSON.parse(init.body)).toMatchObject({
+      triggerSource: "block",
+      dispatchKey: BLOCK_KEY,
     });
   });
 
@@ -89,11 +109,11 @@ describe("createPhantomExecution (event-tracker)", () => {
     );
 
     await expect(
-      createPhantomExecution("wf_1", "owner_1", KEY),
+      createPhantomExecution("wf_1", "owner_1", "event", "events", EVENT_KEY),
     ).resolves.toEqual({ executionId: "exec_existing", alreadyExisted: true });
   });
 
-  // After a retry the existing row may be this listener's own, created by an
+  // After a retry the existing row may be this ingestor's own, created by an
   // attempt whose reply was lost and therefore never enqueued. Reporting it as
   // fresh makes the caller enqueue; the executor's claim CAS absorbs the rare
   // genuine duplicate, whereas a skip would strand the phantom for the reaper.
@@ -101,13 +121,19 @@ describe("createPhantomExecution (event-tracker)", () => {
     vi.useFakeTimers();
     const fetchMock = vi
       .fn()
-      .mockRejectedValueOnce(new Error("socket hang up"))
+      .mockResolvedValueOnce(reply(502, {}))
       .mockResolvedValueOnce(
         reply(200, { executionId: "exec_mine", alreadyExisted: true }),
       );
     vi.stubGlobal("fetch", fetchMock);
 
-    const pending = createPhantomExecution("wf_1", "owner_1", KEY);
+    const pending = createPhantomExecution(
+      "wf_1",
+      "owner_1",
+      "event",
+      "events",
+      EVENT_KEY,
+    );
     await vi.advanceTimersByTimeAsync(500);
 
     await expect(pending).resolves.toEqual({
@@ -124,7 +150,7 @@ describe("createPhantomExecution (event-tracker)", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(
-      createPhantomExecution("wf_1", "owner_1", KEY),
+      createPhantomExecution("wf_1", "owner_1", "event", "events", EVENT_KEY),
     ).resolves.toEqual({ alreadyExisted: false });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -134,14 +160,18 @@ describe("createPhantomExecution (event-tracker)", () => {
     const fetchMock = vi.fn().mockResolvedValue(reply(503, {}));
     vi.stubGlobal("fetch", fetchMock);
 
-    const pending = createPhantomExecution("wf_1", "owner_1", KEY);
+    const pending = createPhantomExecution(
+      "wf_1",
+      "owner_1",
+      "block",
+      "scheduler",
+      BLOCK_KEY,
+    );
     await vi.advanceTimersByTimeAsync(499);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(999);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(1_000);
 
     await expect(pending).resolves.toEqual({ alreadyExisted: false });
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -152,32 +182,17 @@ describe("createPhantomExecution (event-tracker)", () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
     vi.stubGlobal("fetch", fetchMock);
 
-    const pending = createPhantomExecution("wf_1", "owner_1", KEY);
+    const pending = createPhantomExecution(
+      "wf_1",
+      "owner_1",
+      "event",
+      "events",
+      EVENT_KEY,
+    );
     await vi.advanceTimersByTimeAsync(1_500);
 
     await expect(pending).resolves.toEqual({ alreadyExisted: false });
     expect(fetchMock).toHaveBeenCalledTimes(3);
-  });
-
-  it("aborts an attempt that exceeds 5s and retries it", async () => {
-    vi.useFakeTimers();
-    const fetchMock = vi
-      .fn()
-      .mockImplementationOnce(hangUntilAborted())
-      .mockResolvedValueOnce(reply(201, { executionId: "exec_late" }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    const pending = createPhantomExecution("wf_1", "owner_1", KEY);
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    // The abort fires at 5s; the retry follows after the 500ms backoff.
-    await vi.advanceTimersByTimeAsync(1 + 500);
-
-    await expect(pending).resolves.toEqual({
-      executionId: "exec_late",
-      alreadyExisted: false,
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   // A transport failure and a refusal must stay distinguishable: the first
@@ -188,19 +203,19 @@ describe("createPhantomExecution (event-tracker)", () => {
       vi.fn().mockResolvedValue(
         reply(200, {
           refused: true,
-          reason: "execution_limit",
-          error: "limit reached",
+          reason: "plan_feature",
+          error: "gated action",
         }),
       ),
     );
 
     await expect(
-      createPhantomExecution("wf_1", "owner_1", KEY),
-    ).resolves.toEqual({ alreadyExisted: false, refused: "execution_limit" });
+      createPhantomExecution("wf_1", "owner_1", "event", "events", EVENT_KEY),
+    ).resolves.toEqual({ alreadyExisted: false, refused: "plan_feature" });
   });
 });
 
-describe("failPhantomExecution (event-tracker)", () => {
+describe("failPhantomExecution (solana-tracker)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
@@ -209,20 +224,26 @@ describe("failPhantomExecution (event-tracker)", () => {
     vi.useRealTimers();
   });
 
-  it("PATCHes the phantom row to a coded error", async () => {
+  it("PATCHes the phantom row to a coded error under the given caller", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", fetchMock);
 
-    await failPhantomExecution("exec_evt", "ES-0001", "dispatch failed");
+    await failPhantomExecution(
+      "exec_blk",
+      "BS-0001",
+      "dispatch failed",
+      "scheduler",
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
-    expect(String(url)).toMatch(/\/api\/internal\/executions\/exec_evt$/);
+    expect(String(url)).toMatch(/\/api\/internal\/executions\/exec_blk$/);
     expect(init.method).toBe("PATCH");
+    expect(init.headers["X-KH-Caller"]).toBe("scheduler");
     expect(JSON.parse(init.body)).toEqual({
       status: "system_error",
       error: "dispatch failed",
-      errorCode: "ES-0001",
+      errorCode: "BS-0001",
     });
   });
 
@@ -231,7 +252,7 @@ describe("failPhantomExecution (event-tracker)", () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
     vi.stubGlobal("fetch", fetchMock);
 
-    const pending = failPhantomExecution("exec_evt", "ES-0001", "x");
+    const pending = failPhantomExecution("exec_evt", "ES-0001", "x", "events");
     await vi.advanceTimersByTimeAsync(1_500);
 
     await expect(pending).resolves.toBeUndefined();

--- a/keeperhub-executor/index.ts
+++ b/keeperhub-executor/index.ts
@@ -49,6 +49,7 @@ import { verifySqsMessageSignature } from "../lib/sqs-message-auth";
 import { generateId } from "../lib/utils/id";
 import { checkConcurrencyLimit } from "../lib/workflow/concurrency";
 import { hashWorkflowDefinition } from "../lib/workflow/content-hash";
+import { SHUTDOWN_TIMEOUT_MS } from "../lib/workflow/executor/runner-constants";
 import { loadWorkflowForExecution } from "../lib/workflow/load-for-execution";
 import type { WorkflowNode } from "../lib/workflow/store";
 import { chargePaygExecution } from "../lib/billing/payg/charge";
@@ -67,6 +68,7 @@ import {
   failExecutionAsSystemError,
   resolveToSkipped,
 } from "./lib/db-helpers";
+import { InFlightTracker } from "./lib/in-flight";
 import { applyCounterDeltas, isIngestPayload } from "./lib/metrics-shipping";
 import { recordSkippedSample } from "./lib/terminal-counters";
 import { toJsonSafe } from "./lib/serialize";
@@ -373,14 +375,20 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
   });
   if (loaded.status === "not_found") {
     console.error(`[Executor] Workflow not found: ${workflowId}`);
-    await discardPhantomRow(db, message.executionId);
+    await discardPhantomRow(db, message.executionId, {
+      reason: "not_found",
+      error: "Execution skipped: workflow not found.",
+    });
     return;
   }
   if (loaded.status === "not_executable") {
     console.log(
       `[Executor] Workflow not executable (${loaded.reason}), skipping: ${workflowId}`
     );
-    await discardPhantomRow(db, message.executionId);
+    await discardPhantomRow(db, message.executionId, {
+      reason: loaded.reason,
+      error: `Execution skipped: workflow is not executable (${loaded.reason}).`,
+    });
     return;
   }
   const { workflow } = loaded;
@@ -390,7 +398,10 @@ async function processExecutorMessage(message: ExecutorMessage): Promise<void> {
       (message as ScheduleMessage).scheduleId
     );
     if (!valid) {
-      await discardPhantomRow(db, message.executionId);
+      await discardPhantomRow(db, message.executionId, {
+        reason: "schedule_invalid",
+        error: "Execution skipped: schedule is disabled or no longer exists.",
+      });
       return;
     }
   }
@@ -1024,17 +1035,43 @@ async function listen(): Promise<void> {
     );
   });
 
-  const shutdown = async (): Promise<void> => {
-    console.log("\n[Executor] Shutting down...");
+  // Graceful shutdown: stop receiving, let in-flight handlers finish within the
+  // pod's grace period, then close the DB. Exiting with work mid-processMessage
+  // leaves the claimed row for the reaper and redelivers the message after the
+  // visibility timeout - dropped by the claim CAS when it carries an id, run a
+  // second time when it does not (the id-less fallback path).
+  const inFlight = new InFlightTracker();
+  const receiveAbort = new AbortController();
+  let shuttingDown = false;
+
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown) {
+      console.log(`[Executor] Already shutting down, ignoring ${signal}`);
+      return;
+    }
+    shuttingDown = true;
+    console.log(
+      `\n[Executor] Received ${signal}, draining ${inFlight.size} in-flight message(s) (up to ${SHUTDOWN_TIMEOUT_MS}ms)...`
+    );
     healthServer.close();
+    // Cut the long poll short so the loop exits instead of handing back a
+    // batch the drain could not cover.
+    receiveAbort.abort();
+
+    const drained = await inFlight.drain(SHUTDOWN_TIMEOUT_MS);
+    if (!drained) {
+      console.error(
+        `[Executor] Drain timed out with ${inFlight.size} message(s) still in flight; their rows are left for the reaper and the messages redeliver after the visibility timeout`
+      );
+    }
     await queryClient.end();
     console.log("[Executor] Shutdown complete");
-    process.exit(0);
+    process.exit(drained ? 0 : 1);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
-  process.on("SIGHUP", shutdown);
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGHUP", () => shutdown("SIGHUP"));
   process.on("SIGUSR1", () => {
     console.warn(
       "[Security] SIGUSR1 received; inspector activation suppressed"
@@ -1042,7 +1079,7 @@ async function listen(): Promise<void> {
   });
 
   // SQS polling loop
-  while (true) {
+  while (!shuttingDown) {
     try {
       const response = await sqs.send(
         new ReceiveMessageCommand({
@@ -1051,16 +1088,29 @@ async function listen(): Promise<void> {
           WaitTimeSeconds: CONFIG.waitTimeSeconds,
           VisibilityTimeout: CONFIG.visibilityTimeout,
           MessageAttributeNames: ["All"],
-        })
+        }),
+        { abortSignal: receiveAbort.signal }
       );
 
       const messages = response.Messages || [];
+
+      if (shuttingDown) {
+        // A batch that landed as the abort fired. It is already invisible on
+        // the queue, so leave it to redeliver after the visibility timeout
+        // rather than start work the drain cannot see through.
+        if (messages.length > 0) {
+          console.warn(
+            `[Executor] Ignoring ${messages.length} message(s) received during shutdown; they redeliver after the visibility timeout`
+          );
+        }
+        break;
+      }
 
       if (messages.length > 0) {
         console.log(`[Executor] Received ${messages.length} messages`);
 
         const results = await Promise.allSettled(
-          messages.map((msg) => processMessage(msg))
+          messages.map((msg) => inFlight.track(processMessage(msg)))
         );
 
         for (const [idx, result] of results.entries()) {
@@ -1070,6 +1120,10 @@ async function listen(): Promise<void> {
         }
       }
     } catch (error) {
+      if (shuttingDown) {
+        // The aborted long poll rejects; that is the loop's exit, not a fault.
+        break;
+      }
       console.error("[Executor] Error receiving messages:", error);
       await new Promise((r) => setTimeout(r, 5000));
     }

--- a/keeperhub-executor/lib/db-helpers.test.ts
+++ b/keeperhub-executor/lib/db-helpers.test.ts
@@ -10,17 +10,22 @@ vi.mock("server-only", () => ({}));
 // the DB for the org slug. Stub it so these tests stay a focused unit on the
 // row write; a separate assertion checks it is invoked with the persisted
 // classification.
-const { recordTerminalSampleMock } = vi.hoisted(() => ({
-  recordTerminalSampleMock: vi.fn(),
-}));
+const { recordTerminalSampleMock, recordSkippedSampleMock } = vi.hoisted(
+  () => ({
+    recordTerminalSampleMock: vi.fn(),
+    recordSkippedSampleMock: vi.fn(),
+  })
+);
 vi.mock("./terminal-counters", () => ({
   recordTerminalSample: recordTerminalSampleMock,
+  recordSkippedSample: recordSkippedSampleMock,
 }));
 
 import type { DbSchema } from "./db-helpers";
 import {
   claimPendingForExecution,
   claimPhantomForExecution,
+  discardPhantomRow,
   updateExecutionStatus,
 } from "./db-helpers";
 
@@ -251,5 +256,55 @@ describe("execution-claim CAS retry", () => {
 
     await expect(claimPendingForExecution(db, "e1")).resolves.toBe("not_found");
     expect(updateCalls()).toBe(1);
+  });
+});
+
+describe("discardPhantomRow", () => {
+  const discard = {
+    reason: "disabled" as const,
+    error: "Execution skipped: workflow is not executable (disabled).",
+  };
+
+  beforeEach(() => {
+    recordSkippedSampleMock.mockReset();
+  });
+
+  // The row is resolved, not deleted: a delete would release its dispatch key
+  // and let a later dispatcher create a second row for the same occurrence.
+  it("resolves the row to a non-billable skipped state with the reason", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await discardPhantomRow(db, "e1", discard);
+
+    expect(captured.setData).toMatchObject({
+      status: "skipped",
+      billable: false,
+      error: discard.error,
+      errorCategory: "configuration",
+      errorType: "user",
+    });
+    expect(captured.setData?.completedAt).toBeInstanceOf(Date);
+    expect(recordSkippedSampleMock).toHaveBeenCalledWith(db, {
+      workflowId: "wf1",
+      reason: "disabled",
+    });
+  });
+
+  it("does not count a skip when the row already advanced past phantom/pending", async () => {
+    const { db, captured } = makeDb([]);
+
+    await discardPhantomRow(db, "e1", discard);
+
+    expect(captured.setData?.status).toBe("skipped");
+    expect(recordSkippedSampleMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for an id-less message", async () => {
+    const { db, captured } = makeDb([{ workflowId: "wf1" }]);
+
+    await discardPhantomRow(db, undefined, discard);
+
+    expect(captured.setData).toBeNull();
+    expect(recordSkippedSampleMock).not.toHaveBeenCalled();
   });
 });

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -441,31 +441,46 @@ export async function claimPendingForExecution(
 }
 
 /**
- * KEEP-693: delete a pre-created phantom or pending row when the executor
+ * Why the executor intentionally did not run a trigger it was handed. The
+ * workflow lifecycle values mirror loadWorkflowForExecution's reasons; the
+ * schedule value covers a schedule row that is disabled or gone.
+ */
+export type DiscardReason =
+  | "not_found"
+  | "deleted"
+  | "deactivated"
+  | "org_deactivated"
+  | "disabled"
+  | "schedule_invalid";
+
+/**
+ * KEEP-693: resolve a pre-created phantom or pending row when the executor
  * intentionally skips the trigger (workflow not found / not executable /
  * schedule invalid). The trigger correctly did not run, so there is no failure
  * to surface and the reaper must not later age the orphan to a system P-code.
- * The compare-and-set on status IN ('phantom', 'pending') makes it a no-op
- * when there is no id or the row already advanced past these states.
+ *
+ * The row is kept, as 'skipped' and non-billable, rather than deleted. A
+ * delete would release its dispatch key, and the next dispatcher to compute the
+ * same key (an overlapping leader, a catch-up window, a replayed log) could then
+ * create and enqueue a second row for the same occurrence; keeping the row
+ * reserves the key for good and also tells the author why the trigger did not
+ * fire. The compare-and-set on status IN ('phantom', 'pending') makes it a
+ * no-op when there is no id or the row already advanced past these states.
  *
  * Matches 'pending' in addition to 'phantom' because manual-trigger executions
  * are pre-created by the API as 'pending' before being enqueued.
  */
 export async function discardPhantomRow(
   db: PostgresJsDatabase<DbSchema>,
-  executionId: string | undefined
+  executionId: string | undefined,
+  discard: { reason: DiscardReason; error: string }
 ): Promise<void> {
-  if (!executionId) {
-    return;
-  }
-  await db
-    .delete(workflowExecutions)
-    .where(
-      and(
-        eq(workflowExecutions.id, executionId),
-        inArray(workflowExecutions.status, ["phantom", "pending"])
-      )
-    );
+  await resolveToSkipped(db, executionId, {
+    error: discard.error,
+    errorCategory: "configuration",
+    errorType: "user",
+    reason: discard.reason,
+  });
 }
 
 /**
@@ -478,7 +493,8 @@ export async function discardPhantomRow(
  * it never executed, and counting it as a failure skews the success-rate SLI
  * (in a sampled window, refusals read as a 21% error rate against a real 3%).
  * The reason is still recorded on the row so its author sees why it did not
- * fire.
+ * fire. Serves both the billing refusals and, via discardPhantomRow, the
+ * lifecycle skips (workflow or schedule not runnable).
  *
  * Matches 'pending' in addition to 'phantom' because manual-trigger executions
  * are pre-created by the API as 'pending' (not 'phantom') before being enqueued.
@@ -488,7 +504,7 @@ export async function resolveToSkipped(
   executionId: string | undefined,
   fields: {
     error: string;
-    errorCategory: "billing";
+    errorCategory: "billing" | "configuration";
     errorType: "user";
     reason: string;
   }

--- a/keeperhub-executor/lib/in-flight.test.ts
+++ b/keeperhub-executor/lib/in-flight.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InFlightTracker } from "./in-flight";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve: () => void = () => undefined;
+  let reject: (reason: unknown) => void = () => undefined;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("InFlightTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drains immediately when nothing is in flight", async () => {
+    await expect(new InFlightTracker().drain(25_000)).resolves.toBe(true);
+  });
+
+  it("returns the tracked promise unchanged and forgets it once it settles", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+
+    const tracked = tracker.track(work.promise);
+
+    expect(tracked).toBe(work.promise);
+    expect(tracker.size).toBe(1);
+    work.resolve();
+    await tracked;
+    expect(tracker.size).toBe(0);
+  });
+
+  it("forgets a rejected promise too, without adding a rejection of its own", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+    const tracked = tracker.track(work.promise);
+
+    work.reject(new Error("boom"));
+
+    await expect(tracked).rejects.toThrow("boom");
+    expect(tracker.size).toBe(0);
+  });
+
+  it("waits for every in-flight handler and reports a clean drain", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const second = deferred();
+    tracker.track(first.promise);
+    tracker.track(second.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+    expect(tracker.size).toBe(1);
+
+    second.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+
+  it("gives up once the bound elapses while work is still running", async () => {
+    const tracker = new InFlightTracker();
+    const stuck = deferred();
+    tracker.track(stuck.promise);
+
+    const drained = tracker.drain(25_000);
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(tracker.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(drained).resolves.toBe(false);
+    // The handler is still running; the caller exits knowing it was cut off.
+    expect(tracker.size).toBe(1);
+    stuck.resolve();
+  });
+
+  it("also waits for a handler tracked after the drain began", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const late = deferred();
+    tracker.track(first.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+    tracker.track(late.promise);
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+
+    late.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+});

--- a/keeperhub-executor/lib/in-flight.ts
+++ b/keeperhub-executor/lib/in-flight.ts
@@ -1,0 +1,46 @@
+/**
+ * Tracks the executor's in-flight message handlers so shutdown can wait for
+ * them. Without a drain, SIGTERM exits mid-processMessage: the claimed row is
+ * left pending/running for the reaper, and the SQS message redelivers after the
+ * visibility timeout - dropped by the claim CAS when it carries an execution
+ * id, run a second time when it does not.
+ */
+export class InFlightTracker {
+  private readonly pending = new Set<Promise<unknown>>();
+
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /** Register a handler promise; it leaves the set once it settles either way. */
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.pending.add(promise);
+    const remove = (): void => {
+      this.pending.delete(promise);
+    };
+    promise.then(remove, remove);
+    return promise;
+  }
+
+  /**
+   * Resolve true once every tracked promise has settled, including any tracked
+   * while waiting, or false when timeoutMs elapses first (work is still running
+   * and will be cut off by the exit that follows).
+   */
+  drain(timeoutMs: number): Promise<boolean> {
+    if (this.pending.size === 0) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      const settleAll = async (): Promise<void> => {
+        while (this.pending.size > 0) {
+          await Promise.allSettled([...this.pending]);
+        }
+        clearTimeout(timer);
+        resolve(true);
+      };
+      settleAll();
+    });
+  }
+}

--- a/keeperhub-scheduler/lib/http-client.ts
+++ b/keeperhub-scheduler/lib/http-client.ts
@@ -3,6 +3,33 @@ import { KEEPERHUB_URL } from "./config.js";
 
 const HMAC_CALLER = "scheduler";
 
+/**
+ * Per-attempt budget and retry schedule for internal API calls. A transport
+ * failure (connection refused or reset, DNS, the timeout below) or a 5xx reply
+ * is retried on the schedule; a 4xx is a definitive answer and is not. Every
+ * call this client makes is idempotent, which is what makes a retry safe: the
+ * GETs by nature, the phantom POST through its dispatch key, the PATCH through
+ * its terminal-status compare-and-set.
+ *
+ * Keep in sync with the copies in keeperhub-events/event-tracker/lib/phantom.ts
+ * and keeperhub-events/solana-tracker/lib/phantom.ts (those packages cannot
+ * import this one).
+ */
+const REQUEST_TIMEOUT_MS = 5_000;
+const RETRY_DELAYS_MS: readonly number[] = [500, 1_000];
+const MAX_ATTEMPTS = RETRY_DELAYS_MS.length + 1;
+
+export interface ApiResponse<T> {
+  data: T;
+  /** 1 when the first attempt was answered; higher when a retry was. */
+  attempts: number;
+}
+
+type AttemptOutcome<T> =
+  | { kind: "ok"; data: T }
+  | { kind: "retry"; error: unknown }
+  | { kind: "fail"; error: Error };
+
 function signHmacHeaders(
   method: string,
   url: string,
@@ -23,30 +50,91 @@ function signHmacHeaders(
   };
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function attemptRequest<T>(
+  url: string,
+  init: RequestInit,
+  label: string,
+): Promise<AttemptOutcome<T>> {
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(url, init);
+  } catch (error) {
+    return { kind: "retry", error };
+  }
+  if (response.ok) {
+    return { kind: "ok", data: (await response.json()) as T };
+  }
+  const text = await response.text();
+  const error = new Error(`API ${label} failed: ${response.status} ${text}`);
+  return { kind: response.status >= 500 ? "retry" : "fail", error };
+}
+
+/**
+ * Like apiRequest, but also reports how many attempts the call took. A caller
+ * whose reply semantics assume its request was the first to reach the server
+ * needs this: after a retry, the reply may be answering for this caller's own
+ * earlier attempt whose response was lost, not for another caller's request.
+ */
+export async function apiRequestWithAttempts<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<ApiResponse<T>> {
+  const url = `${KEEPERHUB_URL}${path}`;
+  const method = (options.method ?? "GET").toUpperCase();
+  const body = typeof options.body === "string" ? options.body : "";
+  const label = `${options.method || "GET"} ${path}`;
+  // Signed once for every attempt: the server accepts a timestamp within
+  // 300 s, far beyond the whole retry schedule.
+  const init: RequestInit = {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...signHmacHeaders(method, url, body),
+      ...options.headers,
+    },
+  };
+
+  for (let attempt = 1; ; attempt++) {
+    const outcome = await attemptRequest<T>(url, init, label);
+    if (outcome.kind === "ok") {
+      return { data: outcome.data, attempts: attempt };
+    }
+    if (outcome.kind === "fail" || attempt === MAX_ATTEMPTS) {
+      throw outcome.error;
+    }
+    const delayMs = RETRY_DELAYS_MS[attempt - 1];
+    console.warn(
+      `[ApiClient] ${label} attempt ${attempt}/${MAX_ATTEMPTS} failed (${describeError(outcome.error)}); retrying in ${delayMs}ms`,
+    );
+    await sleep(delayMs);
+  }
+}
+
 export async function apiRequest<T>(
   path: string,
   options: RequestInit = {},
 ): Promise<T> {
-  const url = `${KEEPERHUB_URL}${path}`;
-  const method = (options.method ?? "GET").toUpperCase();
-  const body = typeof options.body === "string" ? options.body : "";
-  const hmacHeaders = signHmacHeaders(method, url, body);
-
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...hmacHeaders,
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(
-      `API ${options.method || "GET"} ${path} failed: ${response.status} ${text}`,
-    );
-  }
-
-  return response.json() as Promise<T>;
+  const { data } = await apiRequestWithAttempts<T>(path, options);
+  return data;
 }

--- a/keeperhub-scheduler/lib/phantom.ts
+++ b/keeperhub-scheduler/lib/phantom.ts
@@ -14,7 +14,7 @@
  * must ever block or fail a real trigger.
  */
 
-import { apiRequest } from "./http-client.js";
+import { apiRequest, apiRequestWithAttempts } from "./http-client.js";
 
 /** Trigger sources the scheduler reports for phantom attribution. */
 export type PhantomTriggerSource = "schedule" | "block";
@@ -63,7 +63,7 @@ export async function createPhantomExecution(
   dispatchKey?: string,
 ): Promise<PhantomCreateResult> {
   try {
-    const result = await apiRequest<{
+    const { data: result, attempts } = await apiRequestWithAttempts<{
       executionId?: string;
       alreadyExisted?: boolean;
       refused?: boolean;
@@ -86,10 +86,15 @@ export async function createPhantomExecution(
       );
       return { alreadyExisted: false, refused: reason };
     }
-    return {
-      executionId: result.executionId,
-      alreadyExisted: result.alreadyExisted ?? false,
-    };
+    // A dedup hit is only trustworthy on the first attempt. After a retry the
+    // existing row may be this dispatcher's own, created by an attempt whose
+    // reply was lost, so nobody has enqueued it yet: report it as fresh and let
+    // the caller enqueue. If another dispatcher did enqueue it, the second
+    // message is harmless (the executor's status CAS drops the duplicate
+    // delivery); skipping instead would strand the phantom until the reaper
+    // marks it P-0005 and the occurrence would never run.
+    const alreadyExisted = attempts === 1 && result.alreadyExisted === true;
+    return { executionId: result.executionId, alreadyExisted };
   } catch (error) {
     console.warn(
       `[Phantom] Failed to pre-create execution for workflow ${workflowId}:`,

--- a/keeperhub-scheduler/tests/unit/http-client.test.ts
+++ b/keeperhub-scheduler/tests/unit/http-client.test.ts
@@ -1,0 +1,142 @@
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { apiRequest, apiRequestWithAttempts } from "../../lib/http-client.js";
+
+function reply(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+/** A fetch that never answers until the client's own timeout aborts it. */
+function hangUntilAborted(): (
+  url: string,
+  init: RequestInit,
+) => Promise<never> {
+  return (_url, init) =>
+    new Promise((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () =>
+        reject(new Error("aborted")),
+      );
+    });
+}
+
+// The phantom POST is only safe to retry because its dispatch key makes a
+// repeat a no-op on the server, so the schedule here (one attempt, then 500ms
+// and 1s backoffs, 5s per attempt, 5xx and transport failures only) is part of
+// the exactly-once contract and is pinned as such.
+describe("apiRequest retry policy", () => {
+  let warnSpy: MockInstance;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    warnSpy.mockRestore();
+  });
+
+  it("answers from the first attempt when the API replies 2xx", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(reply(200, { schedules: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      apiRequestWithAttempts("/api/internal/schedules"),
+    ).resolves.toEqual({ data: { schedules: [] }, attempts: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("retries a 5xx after 500ms and reports the attempt that was answered", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(reply(503, "unavailable"))
+      .mockResolvedValueOnce(reply(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = apiRequestWithAttempts("/api/internal/executions", {
+      method: "POST",
+      body: "{}",
+    });
+    await vi.advanceTimersByTimeAsync(499);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(pending).resolves.toEqual({ data: { ok: true }, attempts: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits 1s before the third and final attempt, then rethrows the last error", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const rejection = expect(apiRequest("/x")).rejects.toThrow("ECONNREFUSED");
+    await vi.advanceTimersByTimeAsync(500);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry a 4xx", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(reply(404, { error: "Workflow not found" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      apiRequest("/api/internal/executions", { method: "POST", body: "{}" }),
+    ).rejects.toThrow(/API POST \/api\/internal\/executions failed: 404/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("aborts an attempt that exceeds 5s and retries it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(hangUntilAborted())
+      .mockResolvedValueOnce(reply(200, { ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pending = apiRequestWithAttempts("/x");
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The abort fires at 5s; the retry follows after the 500ms backoff.
+    await vi.advanceTimersByTimeAsync(1 + 500);
+    await expect(pending).resolves.toEqual({ data: { ok: true }, attempts: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("signs every request with the scheduler's HMAC headers", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(reply(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await apiRequest("/api/internal/schedules");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["X-KH-Caller"]).toBe("scheduler");
+    expect(headers["X-KH-Timestamp"]).toMatch(/^\d+$/);
+    expect(headers["X-KH-Signature"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/keeperhub-scheduler/tests/unit/phantom.test.ts
+++ b/keeperhub-scheduler/tests/unit/phantom.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiRequest = vi.fn();
+const apiRequestWithAttempts = vi.fn();
 vi.mock("../../lib/http-client.js", () => ({
   apiRequest: (...args: unknown[]) => apiRequest(...args),
+  apiRequestWithAttempts: (...args: unknown[]) =>
+    apiRequestWithAttempts(...args),
 }));
 
 import {
@@ -10,18 +13,25 @@ import {
   failPhantomExecution,
 } from "../../lib/phantom.js";
 
+/** The API reply as apiRequestWithAttempts reports it: answered on attempt 1. */
+function firstAttempt(data: unknown): { data: unknown; attempts: number } {
+  return { data, attempts: 1 };
+}
+
 describe("createPhantomExecution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("POSTs a phantom row and returns the new execution id", async () => {
-    apiRequest.mockResolvedValue({ executionId: "exec_123" });
+    apiRequestWithAttempts.mockResolvedValue(
+      firstAttempt({ executionId: "exec_123" }),
+    );
 
     const result = await createPhantomExecution("wf_1", "schedule");
 
     expect(result).toEqual({ executionId: "exec_123", alreadyExisted: false });
-    const [path, options] = apiRequest.mock.calls[0];
+    const [path, options] = apiRequestWithAttempts.mock.calls[0];
     expect(path).toBe("/api/internal/executions");
     expect(options.method).toBe("POST");
     expect(JSON.parse(options.body)).toEqual({
@@ -32,21 +42,22 @@ describe("createPhantomExecution", () => {
   });
 
   it("forwards userId and dispatchKey when provided (block path)", async () => {
-    apiRequest.mockResolvedValue({ executionId: "exec_456" });
+    apiRequestWithAttempts.mockResolvedValue(
+      firstAttempt({ executionId: "exec_456" }),
+    );
 
     await createPhantomExecution("wf_1", "block", "owner_1", "block:wf_1:1:99");
 
-    const body = JSON.parse(apiRequest.mock.calls[0][1].body);
+    const body = JSON.parse(apiRequestWithAttempts.mock.calls[0][1].body);
     expect(body.userId).toBe("owner_1");
     expect(body.triggerSource).toBe("block");
     expect(body.dispatchKey).toBe("block:wf_1:1:99");
   });
 
   it("reports alreadyExisted when the API returns it (dedup hit)", async () => {
-    apiRequest.mockResolvedValue({
-      executionId: "exec_existing",
-      alreadyExisted: true,
-    });
+    apiRequestWithAttempts.mockResolvedValue(
+      firstAttempt({ executionId: "exec_existing", alreadyExisted: true }),
+    );
 
     const result = await createPhantomExecution(
       "wf_1",
@@ -61,8 +72,28 @@ describe("createPhantomExecution", () => {
     });
   });
 
+  // After a retry the existing row may be this dispatcher's own, created by an
+  // attempt whose reply was lost and therefore never enqueued. Reporting it as
+  // fresh makes the caller enqueue; the executor's claim CAS absorbs the rare
+  // genuine duplicate, whereas a skip would strand the phantom for the reaper.
+  it("does not trust alreadyExisted from a retried attempt", async () => {
+    apiRequestWithAttempts.mockResolvedValue({
+      data: { executionId: "exec_mine", alreadyExisted: true },
+      attempts: 2,
+    });
+
+    const result = await createPhantomExecution(
+      "wf_1",
+      "schedule",
+      undefined,
+      "schedule:s1:2026-01-01T00:00:00.000Z",
+    );
+
+    expect(result).toEqual({ executionId: "exec_mine", alreadyExisted: false });
+  });
+
   it("returns no id and alreadyExisted=false when the API call fails", async () => {
-    apiRequest.mockRejectedValue(new Error("api down"));
+    apiRequestWithAttempts.mockRejectedValue(new Error("api down"));
 
     const result = await createPhantomExecution("wf_1", "schedule");
 
@@ -72,11 +103,13 @@ describe("createPhantomExecution", () => {
   // A transport failure and a refusal must stay distinguishable: the first
   // still falls back to the id-less enqueue, the second must not enqueue.
   it("reports a refusal when the platform declines the dispatch", async () => {
-    apiRequest.mockResolvedValue({
-      refused: true,
-      reason: "plan_feature",
-      error: "gated action",
-    });
+    apiRequestWithAttempts.mockResolvedValue(
+      firstAttempt({
+        refused: true,
+        reason: "plan_feature",
+        error: "gated action",
+      }),
+    );
 
     const result = await createPhantomExecution("wf_1", "schedule");
 
@@ -85,7 +118,7 @@ describe("createPhantomExecution", () => {
   });
 
   it("defaults an unlabelled refusal to execution_limit", async () => {
-    apiRequest.mockResolvedValue({ refused: true });
+    apiRequestWithAttempts.mockResolvedValue(firstAttempt({ refused: true }));
 
     const result = await createPhantomExecution("wf_1", "schedule");
 

--- a/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
+++ b/keeperhub-scheduler/tests/unit/schedule-dispatcher.test.ts
@@ -338,31 +338,46 @@ describe("fetchSchedules", () => {
     await expect(fetchSchedules()).resolves.toEqual([]);
   });
 
-  it("throws including the status and body on a non-2xx response", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 503,
-        text: async () => "service unavailable",
-      }),
-    );
-
-    await expect(fetchSchedules()).rejects.toThrow(
-      /API GET \/api\/internal\/schedules failed: 503 service unavailable/,
-    );
+  // A 5xx is retried on the client's backoff schedule (fake timers skip the
+  // waits), so the error only reaches the caller once every attempt failed.
+  it("throws including the status and body once a 5xx exhausts its retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => "service unavailable",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+    try {
+      const rejection = expect(fetchSchedules()).rejects.toThrow(
+        /API GET \/api\/internal\/schedules failed: 503 service unavailable/,
+      );
+      await vi.runAllTimersAsync();
+      await rejection;
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("propagates fetch network errors to the caller", async () => {
     // fetch itself rejecting (DNS failure, TLS error, socket reset) is a
     // distinct branch from the non-2xx path -- no `response` object exists
-    // to inspect, so the error reaches the caller unwrapped.
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
-    );
-
-    await expect(fetchSchedules()).rejects.toThrow("ECONNREFUSED");
+    // to inspect, so the error reaches the caller unwrapped once the retry
+    // schedule is exhausted.
+    const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+    try {
+      const rejection = expect(fetchSchedules()).rejects.toThrow(
+        "ECONNREFUSED",
+      );
+      await vi.runAllTimersAsync();
+      await rejection;
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("calls fetch with the schedules path and HMAC headers", async () => {
@@ -666,9 +681,13 @@ describe("dispatch", () => {
       }),
     );
 
-    await expect(dispatch()).rejects.toThrow(
+    // The 500 is retried on the client's backoff schedule; this describe runs
+    // on fake timers, so drive the waits before awaiting the rejection.
+    const rejection = expect(dispatch()).rejects.toThrow(
       /API GET \/api\/internal\/schedules failed: 500/,
     );
+    await vi.runAllTimersAsync();
+    await rejection;
     expect(mockedSqsSend).not.toHaveBeenCalled();
   });
 

--- a/lib/metrics/collectors/prometheus.ts
+++ b/lib/metrics/collectors/prometheus.ts
@@ -1058,7 +1058,7 @@ export function recordWorkflowExecutionFinished(labels: {
 const workflowExecutionsSkipped = getOrCreateCounter(
   apiRegistry,
   "keeperhub_workflow_executions_skipped_total",
-  "Workflow executions refused before starting, by org_slug and reason (execution_limit, plan_feature, payg_unpaid). Not failures: these runs never executed.",
+  "Workflow executions skipped before starting, by org_slug and reason: plan refusals (execution_limit, plan_feature, payg_unpaid) and lifecycle skips the executor resolves (not_found, deleted, deactivated, org_deactivated, disabled, schedule_invalid). Not failures: these runs never executed.",
   ["org_slug", "reason"]
 );
 

--- a/tests/e2e/vitest/phantom-upgrade.test.ts
+++ b/tests/e2e/vitest/phantom-upgrade.test.ts
@@ -302,20 +302,34 @@ describe.skipIf(SKIP)("consume-path claim helpers", () => {
     ).toBe("not_found");
   });
 
-  it("discardPhantomRow deletes a phantom row (intentional skip)", async () => {
+  // Kept rather than deleted: the row reserves its dispatch key, so a later
+  // dispatcher recomputing the same occurrence cannot create a second run.
+  it("discardPhantomRow resolves a phantom row to skipped (intentional skip)", async () => {
     const id = `${PREFIX}discard`;
     await seedExecution(id, "phantom");
 
-    await discardPhantomRow(execDb, id);
+    await discardPhantomRow(execDb, id, {
+      reason: "disabled",
+      error: "Execution skipped: workflow is not executable (disabled).",
+    });
 
-    expect(await readExecution(id)).toBeUndefined();
+    const row = await readExecution(id);
+    expect(row?.status).toBe("skipped");
+    expect(row?.billable).toBe(false);
+    expect(row?.error).toBe(
+      "Execution skipped: workflow is not executable (disabled)."
+    );
+    expect(row?.completedAt).toBeInstanceOf(Date);
   });
 
   it("discardPhantomRow leaves a non-phantom row intact", async () => {
     const id = `${PREFIX}discard_running`;
     await seedExecution(id, "running");
 
-    await discardPhantomRow(execDb, id);
+    await discardPhantomRow(execDb, id, {
+      reason: "disabled",
+      error: "Execution skipped: workflow is not executable (disabled).",
+    });
 
     expect((await readExecution(id))?.status).toBe("running");
   });


### PR DESCRIPTION
## Failure mode

KeeperHub dedups triggers with two mechanisms: a unique `dispatch_key` on the phantom execution row created before the enqueue, and a status compare-and-set when the executor claims that row. The key covered schedule (`schedule:<id>:<ISO occurrence>`) and EVM block (`block:<workflow>:<chain>:<height>`) triggers only. Four gaps followed:

1. Event triggers, EVM and Solana, created their phantom with no key at all. Every duplicate delivery of the same log (a WSS reconnect replaying it, a reorg re-emitting it, a crash between the SQS send and the Redis mark) created a fresh row and ran the workflow again. The Redis dedup in front of it is documented as deliberately non-atomic and defers to "the downstream executor as the idempotency authority", which is not true without a key.
2. The phantom call had no timeout and no retry, so any non-2xx dropped the dispatcher to an id-less enqueue. An id-less message cannot be deduplicated at all: the queue is standard, no producer sets a deduplication id, and the executor inserts its own row. An HMAC secret drift or an app rollout gap makes every trigger id-less at once.
3. The executor's shutdown handler called `process.exit(0)` with no drain, so every rollout redelivered whatever was mid-`processMessage` after the visibility timeout. Id-bearing messages are absorbed by the claim CAS; id-less ones run a second time.
4. `discardPhantomRow` deleted the row, which released its dispatch key.

## Changes

**Event dispatch keys.** EVM events key on `event:<workflow>:<chain>:<txHash>:<logIndex>`, so two matching logs in one transaction are two runs (the Redis key is per transaction and would have collapsed them). Solana events key on the signature, which is what its matcher fires on, and Solana block ingests on the slot. On `alreadyExisted` the caller skips its enqueue and marks the event processed, exactly as the schedule dispatcher does.

One subtlety worth review: `alreadyExisted` is only trusted on the first attempt. After a retry the existing row may be this listener's own, created by an attempt whose reply was lost, in which case nobody has enqueued it yet. Reporting it as fresh and enqueueing is the safe direction: a genuinely duplicated message is dropped by the executor's claim CAS, whereas skipping would strand the phantom until the reaper marks it never-picked-up and the event would never run.

**Bounded retry on the phantom call.** A 5s per-attempt timeout and two retries (500ms, 1s) for transport failures and 5xx, never for 4xx, in the scheduler's shared client and in both trackers' own copies (these packages cannot import each other). Retrying the create is only safe because the dispatch key makes it idempotent; the PATCH is idempotent through its status compare-and-set.

**Executor drain.** In-flight handlers are tracked and awaited on SIGTERM/SIGINT within the pod's grace budget, and the long poll is aborted so the loop stops taking new batches. A drain that times out logs what is still running and exits non-zero.

**`discardPhantomRow` keeps the row.** It now resolves to `skipped` and non-billable with a reason (`not_found`, `deleted`, `deactivated`, `org_deactivated`, `disabled`, `schedule_invalid`) instead of deleting. That reserves the key permanently and tells the author why the trigger did not fire. This is a visible behaviour change: a trigger for a deleted or disabled workflow now leaves a `skipped` row in the run history where it previously left nothing. Flagging it explicitly since it is a product-visible call, not just an internal one. The counter description for `keeperhub_workflow_executions_skipped_total` is updated to name the new reasons; no query or aggregate changed, so the metrics gate is a path match only.

## Verification

The main checkout's `node_modules` was three months stale and missing five declared packages, because `pnpm install` hits an interactive "the modules directories will be removed and reinstalled, proceed?" prompt and silently no-ops when answered non-interactively. It was reinstalled with `--config.confirm-modules-purge=false` first, so these results are against a tree that matches the lockfile. Baseline `tsc` on `staging` is clean at zero errors.

- `tsc --noEmit`: clean
- `tsc -p keeperhub-executor --noEmit`: clean
- `vitest run keeperhub-executor`: 13 files, 121 tests passed
- scheduler `vitest run`: 9 files, 151 tests passed
- solana-tracker `vitest run`: 15 files, 105 tests passed
- event-tracker `vitest run`: 12 files, 202 tests passed. Three integration files (`event-to-sqs-inproc`, `-config-change`, `-multi`) fail offline with "JsonRpcProvider failed to detect network": they need the anvil, localstack and redis services CI starts, and none of them reference the changed code. Zero individual test failures.
- `biome check` on the changed root files: clean (root biome excludes the three service packages)
