### PR TITLE
fix: KEEP-1297 call world-postgres bootstrap instead of the retired setup bin

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -172,7 +172,7 @@ app:
             set -e
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec workflow-postgres-setup
+            pnpm exec bootstrap
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/keeperhub-stack/self-hosted/values.yaml
+++ b/deploy/keeperhub-stack/self-hosted/values.yaml
@@ -283,12 +283,12 @@ app:
           - |
             set -e
             echo "Setting up workflow postgres tables..."
-            # Same line staging runs. workflow-postgres-setup parses the URL
+            # Same line staging runs. The bootstrap command parses the URL
             # itself and does not tolerate unencoded characters in the userinfo
             # component, while drizzle goes through getDatabaseUrl and is already
             # safe. A generated password is where that difference shows up.
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec workflow-postgres-setup
+            pnpm exec bootstrap
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -121,7 +121,7 @@ app:
             set -e
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec workflow-postgres-setup
+            pnpm exec bootstrap
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -66,7 +66,7 @@ deployment:
         - |
           set -e
           echo "Setting up workflow postgres tables..."
-          pnpm exec workflow-postgres-setup
+          pnpm exec bootstrap
           echo "Running database migrations..."
           pnpm db:migrate
           echo "Seeding chains and tokens..."

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev:login": "tsx scripts/dev-login.ts",
     "dev:totp": "tsx scripts/dev-totp.ts",
     "db:setup": "pnpm db:migrate && pnpm db:setup-workflow && pnpm db:seed",
-    "db:setup-workflow": "workflow-postgres-setup",
+    "db:setup-workflow": "bootstrap",
     "discover-plugins": "tsx scripts/discover-plugins.ts",
     "pin-agent-card": "tsx scripts/pin-agent-card.ts",
     "update-agent-uri": "tsx scripts/update-agent-uri.ts",

--- a/scripts/encode-pg-url.ts
+++ b/scripts/encode-pg-url.ts
@@ -8,7 +8,7 @@
  * characters (base64 +/= from CNPG, etc.) don't break URL parsing, and
  * prints the result to stdout.
  *
- * Used by Helm init containers before running workflow-postgres-setup and
+ * Used by Helm init containers before running world-postgres bootstrap and
  * drizzle-kit migrations. The same logic lives in instrumentation.ts for
  * runtime use -- keep both in sync.
  *

--- a/tests/e2e/postgres-world.test.ts
+++ b/tests/e2e/postgres-world.test.ts
@@ -2,7 +2,7 @@
  * E2E Tests for Workflow Postgres World
  *
  * Verifies that the @workflow/world-postgres integration works:
- * 1. workflow-postgres-setup creates the workflow schema tables
+ * 1. world-postgres bootstrap creates the workflow schema tables
  * 2. world.start() creates pg-boss schema tables
  * 3. Workflow executions flow through pg-boss and persist in workflow.workflow_runs
  * 4. Steps are recorded in workflow.workflow_steps
@@ -10,7 +10,7 @@
  * Prerequisites:
  * - Docker compose dev profile running with WORKFLOW_TARGET_WORLD=@workflow/world-postgres
  * - WORKFLOW_POSTGRES_URL or DATABASE_URL pointing to the database
- * - workflow-postgres-setup already run against the database
+ * - world-postgres bootstrap already run against the database
  * - App running at KEEPERHUB_URL (default: http://localhost:3000)
  * - INTERNAL_SERVICE_HMAC_SECRET set to the same value seeded into the running
  *   app's internal_service_hmac_secrets store under caller "*shared*" (see
@@ -150,7 +150,7 @@ describe.skipIf(shouldSkip || !hasPgboss)("Postgres World E2E", () => {
   });
 
   describe("Schema Setup", () => {
-    it("should have workflow schema tables from workflow-postgres-setup", async () => {
+    it("should have workflow schema tables from world-postgres bootstrap", async () => {
       const result = await client<{ table_name: string }[]>`
         SELECT table_name
         FROM information_schema.tables


### PR DESCRIPTION
## Problem

Staging CI has been red and undeployable since #2203 merged at 02:57 UTC on 2026-09-02.

`@workflow/world-postgres` went from `4.1.0-beta.51` to `4.3.5` in that dependabot bump, and the package renamed its bin:

| version | bin map |
|---|---|
| 4.1.0-beta.51 | `workflow-postgres-setup` -> `bin/setup.js` |
| 4.3.5 | `bootstrap` -> `bin/setup.js`, `workflow-postgres-setup` -> `bin/setup-deprecated.js` |

`bin/setup-deprecated.js` is a nine-line stub that prints "The workflow-postgres-setup command has moved." and calls `process.exit(1)`. The entrypoint behind the new name is byte-identical, so this is purely a rename, not a migration.

`db:setup-workflow` is the first step of `.github/actions/setup-e2e-db`, so all seven ephemeral e2e jobs (four protocol-coverage shards, playwright, vitest, and the gate) die there. `e2e-gate` fails, and `deploy`, `release`, `pin-agent-card` and `docs-sync` are skipped.

The same dead bin is the DB bootstrap step in four deploy configs. They have not failed yet only because the gate is keeping deploys from running at all; fixing `package.json` alone would just move the failure into the staging deploy's migration init container.

## Why CI did not catch this on #2203

Two gates both abstained, which is the more durable finding here:

- `e2e-tests-ephemeral.yml`'s `should-run` only runs e2e for a `pull_request` when the `run-e2e-tests-ephemeral` label is present. The dependabot PR had no label, so every e2e job reported `skipping`.
- `pr-checks.yml`'s migration job does call `db:setup-workflow`, but is gated on changed files matching `^(drizzle/|lib/db/schema)`. A lockfile bump matches neither.

Nothing on that PR ever executed the script the bump broke. A dependency bump can change a bin name, a CLI contract, or a runtime and reach staging entirely unexercised. Worth a follow-up; deliberately not in this PR, which stays a pure rename so it can go in fast.

## Change

Five call sites move from `workflow-postgres-setup` to `bootstrap`:

- `package.json` `db:setup-workflow`
- `deploy/keeperhub-stack/staging/values.yaml`
- `deploy/keeperhub-stack/prod/values.yaml`
- `deploy/keeperhub-stack/self-hosted/values.yaml`
- `deploy/pr-environment/values.template.yaml`

Plus three comments and one test title that named the retired command.

## Verification

Ran the changed script against a throwaway postgres:16, with `node_modules` from the current lockfile:

```
Setting up database schema...
Running migrations from: .../@workflow/world-postgres/src/drizzle/migrations
Bootstrapping graphile-worker schema...
Database schema created successfully!
EXIT=0
```

Resulting schema, which is what `tests/e2e/postgres-world.test.ts` asserts on:

```
workflow.workflow_events        workflow.workflow_runs
workflow.workflow_hooks         workflow.workflow_steps
workflow.workflow_stream_chunks workflow.workflow_waits
workflow_drizzle.workflow_migrations
graphile_worker.* (6 tables)
```

## Reviewer note

`bootstrap` is upstream's chosen name and is what their deprecation message documents, but it is a generic bin name and `pnpm exec bootstrap` does not tell a reader which package provides it. Exactly one package in the current tree declares that bin, so there is no collision today. The alternative is `node node_modules/@workflow/world-postgres/bin/setup.js`, which is collision-proof and self-documenting at the cost of reaching into a package's internal layout. Happy to switch if you prefer that trade.
