### PR TITLE
fix: KEEP-1299 call world-postgres setup by path so a hoisted bin cannot shadow it

### DIFF
--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -172,7 +172,10 @@ app:
             set -e
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec bootstrap
+            # Called by path, not through the `bootstrap` bin: .npmrc public-hoists
+            # @workflow/* and hoisted packages land bins in the root .bin, so a sibling
+            # gaining that generic name would silently shadow this (KEEP-1299).
+            node node_modules/@workflow/world-postgres/bin/setup.js
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/keeperhub-stack/self-hosted/values.yaml
+++ b/deploy/keeperhub-stack/self-hosted/values.yaml
@@ -283,12 +283,13 @@ app:
           - |
             set -e
             echo "Setting up workflow postgres tables..."
-            # Same line staging runs. The bootstrap command parses the URL
-            # itself and does not tolerate unencoded characters in the userinfo
-            # component, while drizzle goes through getDatabaseUrl and is already
-            # safe. A generated password is where that difference shows up.
+            # Same line staging runs, called by path for the reason noted
+            # there. The setup entrypoint parses the URL itself and does not
+            # tolerate unencoded characters in the userinfo component, while
+            # drizzle goes through getDatabaseUrl and is already safe. A
+            # generated password is where that difference shows up.
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec bootstrap
+            node node_modules/@workflow/world-postgres/bin/setup.js
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -121,7 +121,10 @@ app:
             set -e
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
-            pnpm exec bootstrap
+            # Called by path, not through the `bootstrap` bin: .npmrc public-hoists
+            # @workflow/* and hoisted packages land bins in the root .bin, so a sibling
+            # gaining that generic name would silently shadow this (KEEP-1299).
+            node node_modules/@workflow/world-postgres/bin/setup.js
             echo "Running database migrations..."
             pnpm db:migrate
             echo "Seeding chains..."

--- a/deploy/pr-environment/values.template.yaml
+++ b/deploy/pr-environment/values.template.yaml
@@ -66,7 +66,10 @@ deployment:
         - |
           set -e
           echo "Setting up workflow postgres tables..."
-          pnpm exec bootstrap
+          # Called by path, not through the `bootstrap` bin: .npmrc public-hoists
+          # @workflow/* and hoisted packages land bins in the root .bin, so a sibling
+          # gaining that generic name would silently shadow this (KEEP-1299).
+          node node_modules/@workflow/world-postgres/bin/setup.js
           echo "Running database migrations..."
           pnpm db:migrate
           echo "Seeding chains and tokens..."

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dev:login": "tsx scripts/dev-login.ts",
     "dev:totp": "tsx scripts/dev-totp.ts",
     "db:setup": "pnpm db:migrate && pnpm db:setup-workflow && pnpm db:seed",
-    "db:setup-workflow": "bootstrap",
+    "db:setup-workflow": "node node_modules/@workflow/world-postgres/bin/setup.js",
     "discover-plugins": "tsx scripts/discover-plugins.ts",
     "pin-agent-card": "tsx scripts/pin-agent-card.ts",
     "update-agent-uri": "tsx scripts/update-agent-uri.ts",


### PR DESCRIPTION
Follow-up to KEEP-1297 (#2256), deferred from that PR's review so the staging fix could land first.

## Why

#2256 repointed five call sites at `@workflow/world-postgres`'s renamed bin, `bootstrap`. That name is upstream's and is correct, but it is generic, and the root `node_modules/.bin` is not limited to direct dependencies.

`.npmrc:80` sets `public-hoist-pattern[]=@workflow/*`, and public-hoisted transitive packages do get their bins linked into the root `.bin`. Verified in the current tree:

| bin in root `.bin` | direct dependency? |
|---|---|
| `graphile-worker` | no |
| `js-yaml` | no |
| `semver` | no |

Two sibling world implementations are already installed under that same wildcard - `@workflow/world-local` 4.4.0 and `@workflow/world-vercel` 4.7.1. Neither declares a bin today, so nothing is shadowed right now. But upstream chose a generic name for a setup entrypoint, and a routine dependabot bump is all it would take for `node_modules/.bin/bootstrap` to become ambiguous.

## Why that is worse than an ordinary name clash

The four Helm `db-migration` init containers run this under `set -e`:

```
node_modules/.bin/bootstrap   # wrong program, exits 0
pnpm db:migrate               # proceeds anyway
```

`set -e` only catches a non-zero exit. A shadowing program that exits 0 lets the migration continue and the app start against a database with no `workflow.*` or `graphile_worker.*` schema. That is the KEEP-1297 failure again, except silent, and in prod.

## Change

The same five sites move from `bootstrap` to `node node_modules/@workflow/world-postgres/bin/setup.js`, plus a three-line comment at each deploy site so the next reader does not shorten it back. The self-hosted file already carried a comment there, so its wording was corrected rather than duplicated.

## This is not a fragile path

- `bin` is in the package's published `files` array (`["dist", "bin", "src/drizzle/migrations"]`), so `bin/setup.js` is an advertised target, not a private internal.
- It adds no new resolution risk. `node_modules/.bin/bootstrap` is a shim whose last line is `exec node "$basedir/../@workflow/world-postgres/bin/setup.js"` - the explicit form is what the shim already does, minus the name lookup, and both traverse the same pnpm symlink.
- The migrator image supports it: `Dockerfile:155` `FROM node:24-alpine AS migrator`, `WORKDIR /app`, `COPY --from=deps /app/node_modules ./node_modules`. Same working directory the neighbouring `tsx scripts/encode-pg-url.ts` and `pnpm db:migrate` lines rely on.

## Verification

Ran the changed `db:setup-workflow` against a throwaway postgres:16 on this branch's base, with `node_modules` from the current lockfile. Exit 0, and the identical 13-table result #2256 produced:

```
workflow.workflow_events         workflow.workflow_runs
workflow.workflow_hooks          workflow.workflow_steps
workflow.workflow_stream_chunks  workflow.workflow_waits
workflow_drizzle.workflow_migrations
graphile_worker.* (6 tables)
```

Labelling this `deploy-pr-environment` would exercise the `deploy/pr-environment/values.template.yaml` line in a real init container, as it did on #2256.

## Reviewer note

There is a DRY alternative I did not take: have the deploy configs call `pnpm db:setup-workflow` instead, leaving the path in `package.json` alone. That is one site instead of five, and the neighbouring `pnpm db:migrate` line proves `pnpm run` works in that image. I kept the shape KEEP-1299 specified and stayed consistent with how these init containers invoke the tool directly today, but if you would rather have the single source of truth, it is a small change and I am happy to make it.
