### PR TITLE
ci: KEEP-1300 pass release PR JSON through a file, not the environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,11 @@ jobs:
             echo "has_prs=true" >> "$GITHUB_OUTPUT"
           fi
 
-          # Save PR JSON for subsequent steps
-          echo "PR_JSON<<PRJSONEOF" >> "$GITHUB_ENV"
-          echo "$PR_JSON" >> "$GITHUB_ENV"
-          echo "PRJSONEOF" >> "$GITHUB_ENV"
+          # Save PR JSON to a file, not GITHUB_ENV. A PR body is capped at
+          # 65535 chars, so two dependabot PRs alone push this past the kernel's
+          # 128 KB limit on a single environment variable, and every later step
+          # then fails at exec with "Argument list too long".
+          printf '%s\n' "$PR_JSON" > "$RUNNER_TEMP/merged-prs.json"
 
       - name: Skip release if no PRs found
         if: steps.discover_prs.outputs.has_prs == 'false'
@@ -147,7 +148,7 @@ jobs:
             else
               OTHER_PRS="${OTHER_PRS}${ENTRY}"$'\n'
             fi
-          done < <(echo "$PR_JSON" | jq -c '.[]')
+          done < <(jq -c '.[]' "$RUNNER_TEMP/merged-prs.json")
 
           # Determine bump type
           if [ "$HAS_BREAKING" = true ]; then


### PR DESCRIPTION
Fixes KEEP-1300.

## What breaks today

The `release` job fails about 9 seconds in, at process start rather than inside any script:

```
An error occurred trying to start process '/usr/bin/bash' ... Argument list too long
An error occurred trying to start process '.../node24/bin/node' ... Argument list too long
```

`Discover merged PRs since last release` succeeds, then `Determine version bump and classify PRs`, the post-checkout step and the post-job step all fail. First seen in run 33574589080 on 2026-09-02; the releases on 08-28, 08-30 and 09-01 all succeeded.

## Why

The discovery step exported the full merged-PR JSON, bodies included, into `GITHUB_ENV`. Anything written there becomes a real environment variable for every later step, and Linux caps a single environment string at `MAX_ARG_STRLEN` = 131072 bytes. Once the payload crosses that, every subsequent `exec` in the job fails with E2BIG, which is why the failures land at process start and hit bash, node and the runner's own cleanup alike.

That window held 16 PRs, not the 200 the `--limit` allows, totalling 231039 bytes. Two dependabot PRs, #2200 and #2201, carried bodies of exactly 65535 bytes each, which is GitHub's PR body cap, so those two alone are 131070 bytes. The other 14 come to 45 KB combined. Stripped of bodies the same 16 PRs serialise to 4415 bytes, so the bodies are the entire problem.

The condition does not clear on its own. `PREV_TAG` comes from `git describe`, and no tag was cut because the job failed, so `v2.101.0` stays put at 2026-09-01T00:16:19Z and every later prod push recomputes the window from it, keeps those two PRs inside, and fails again with a window that grows each time.

This landed whole in 955367b59 (#294, 2026-02-10). `body` was in the `--json` field list and the `GITHUB_ENV` heredoc were both in that first commit; 67605488b only reordered the field list and 78b76d98c only fixed timezones. It has been latent for roughly seven months and fired the first time a merge window happened to hold enough body text.

## The change

`PR_JSON` has exactly one consumer, the classify loop, and `body` is read for exactly one thing, the `BREAKING CHANGE` grep. Both steps run in the same job on the same runner, so the JSON is handed over as a file on `$RUNNER_TEMP` instead of through the environment. That is bounded regardless of PR count or body size.

The alternative of pre-computing a `breaking` boolean and deleting `body` before the `GITHUB_ENV` write shrinks the payload about 50x, but only moves the ceiling: 200 PRs at the observed ~276 bytes each is ~55 KB, within a factor of 2.4 of the limit. Worth doing as well, not instead, so it is left out here.

Tradeoff: this couples the two steps to one job. That holds today. If the classify step ever moves to a separate job it would need `actions/upload-artifact` instead.

## Verification

- The mechanism was reproduced directly: exporting the real 231039-byte payload and exec-ing bash reproduces `Argument list too long`, exit 126, matching the runner annotation.
- The patched classify step was extracted and replayed against that same payload with `RUNNER_TEMP` pointed at it. Exit 0, all 16 PRs classified, bump `minor`, `new_tag=v2.102.0`, and release notes generated with both dependabot PRs present. The existing tag-collision guard passed.
- `actionlint` reports no findings on the workflow.

## Out of scope

`scripts/test-release.sh` mirrors this logic and also builds a `PR_JSON`, but never exports it and runs in a single process, so the value never enters a child's environment. It is unaffected and untouched. It is worth noting that this also means the local dry-run harness could not have caught this failure mode.

The missed 2026-09-02 release is not addressed here. Once this merges and promotes, the next prod push cuts a single tag spanning the widened window and folds both days into one set of release notes. A separate tag at the 09-02 commit would have to be cut by hand.
