### PR TITLE
fix: KEEP-1302 keep backticks paired so executeWorkflow is compiled as a workflow

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -1037,7 +1037,13 @@ function computeCommentRanges(code: string): [number, number][] {
       i++;
       continue;
     }
-    if (c === '"' || c === "'" || c === "`") {
+    // "\u0060" is a backtick, written as an escape on purpose. A raw backtick
+    // here is unpaired within this file, and @workflow/builders' directive
+    // detector pairs backticks with a regex that ignores string context. One
+    // unpaired tick desynchronizes it for the rest of the file and blanks the
+    // "use workflow" directive in executeWorkflow below, so the function ships
+    // untransformed and start() rejects it at runtime. See KEEP-1302.
+    if (c === '"' || c === "'" || c === "\u0060") {
       stringDelim = c;
       i++;
       continue;

--- a/tests/unit/workflow-directive-detection.test.ts
+++ b/tests/unit/workflow-directive-detection.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Guards the build-time contract that makes `start(executeWorkflow)` work.
+ *
+ * A "use workflow" function is only compiled into a real workflow if
+ * @workflow/builders' `detectWorkflowPatterns` finds its directive - that is
+ * what gates the Next.js loader, and an undetected file ships as a plain
+ * function whose `workflowId` is undefined. `start()` then throws
+ * "'start' received an invalid workflow function" at runtime, in production,
+ * with nothing failing at build time.
+ *
+ * KEEP-1302 was exactly that. The detector blanks template literals with a
+ * regex that pairs backticks positionally, ignoring string context, so a
+ * single backtick inside an ordinary quoted string left the file's ticks
+ * unpaired, desynchronized the matcher for everything after it, and blanked
+ * the directive itself.
+ *
+ * Entrypoints are discovered rather than listed, so a new *.workflow.ts is
+ * covered the day it lands instead of the day someone remembers this file.
+ */
+import { readFileSync } from "node:fs";
+import { glob } from "node:fs/promises";
+import { join } from "node:path";
+// `@workflow/builders` is a transitive dependency, resolvable here only
+// because .npmrc public-hoists `@workflow/*`. That is deliberate (see the
+// comment on public-hoist-pattern), and if it ever stops resolving this test
+// goes red rather than quietly passing, which is the safe direction.
+import { detectWorkflowPatterns } from "@workflow/builders";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+
+/**
+ * Files the Next.js loader must transform. The `*.workflow.ts` suffix is the
+ * repo's convention for a workflow entrypoint; codegen templates that merely
+ * emit a directive inside a template string do not use it, and must not be
+ * asserted on - the detector is right to skip those.
+ */
+let entrypoints: string[] = [];
+
+beforeAll(async () => {
+  const found: string[] = [];
+  for await (const path of glob("**/*.workflow.ts", {
+    cwd: repoRoot,
+    exclude: (name) => name === "node_modules" || name === ".next",
+  })) {
+    found.push(path);
+  }
+  entrypoints = found.sort();
+});
+
+describe("workflow directive detection", () => {
+  it("finds at least one workflow entrypoint to check", () => {
+    // Guards the discovery itself: a glob that silently matches nothing would
+    // make every assertion below vacuous.
+    expect(entrypoints.length).toBeGreaterThan(0);
+  });
+
+  it("sees every entrypoint as a workflow", () => {
+    const undetected = entrypoints.filter(
+      (path) =>
+        !detectWorkflowPatterns(readFileSync(join(repoRoot, path), "utf8"))
+          .hasUseWorkflow
+    );
+
+    expect(undetected).toEqual([]);
+  });
+
+  it("keeps entrypoint backticks paired, which the detector's regex requires", () => {
+    // An odd count means some backtick sits in a comment or a quoted string.
+    // The detector pairs them positionally, so one stray tick silently blanks
+    // real code - including the directive - from there to end of file.
+    const unpaired = entrypoints.filter((path) => {
+      const source = readFileSync(join(repoRoot, path), "utf8");
+      return (source.match(/`/g) ?? []).length % 2 !== 0;
+    });
+
+    expect(unpaired).toEqual([]);
+  });
+});


### PR DESCRIPTION
Unblocks staging. Every protocol-coverage suite has failed since #2203 with `'start' received an invalid workflow function`, and `e2e-gate` has kept `deploy` skipped since 02:57 UTC.

## Root cause

`start()` identifies a workflow by reading a field the build attaches:

```js
// @workflow/core/dist/runtime/start.js
const workflowName = workflow?.workflowId;   // added by the client transform
if (!workflowName) throw new WorkflowRuntimeError("'start' received an invalid workflow function...");
```

Whether that transform runs is gated on `@workflow/builders`' `detectWorkflowPatterns` finding the directive. #2203 changed that function:

```js
// 4.0.1-beta.67 - one regex over the raw source
const hasUseWorkflow = useWorkflowPattern.test(source);

// 4.1.10 - blanks template literals and comments first
const sourceForDirectives = source.replace(templateLiteralPattern, blank)
                                  .replace(commentPattern, blank);
const hasUseWorkflow = source.includes("use workflow") &&
                       hasDirective(sourceForDirectives, "use workflow");
```

The rewrite is sound in intent - `lib/workflow/codegen/templates/*.ts` emit `"use workflow"` inside `export default \`...\`` strings and correctly must not be treated as workflows.

But `templateLiteralPattern` pairs backticks positionally, with no string context. `executor.workflow.ts:1040` compared a character against a raw backtick:

```js
if (c === '"' || c === "'" || c === "`") {
```

One tick inside a double-quoted string left the file at **403 backticks - odd**. From there the matcher is off by one, the span holding `executeWorkflow`'s directive at line 2091 is mistaken for a template literal and blanked, `hasUseWorkflow` goes false, `shouldTransformFile` returns false, the loader skips the file, and `executeWorkflow` ships as a plain function.

Nothing fails at build time. It surfaces only when `start()` runs - which is why #2203 was green and the app broke after merge.

## Evidence

Ran the real detector against the real file rather than inferring:

```
{"file":"lib/workflow/executor/executor.workflow.ts","hasUseWorkflow":false,"hasDirective":false}
```

Then traced why - after blanking, line 2091 comes back as whitespace:

```
raw   [2090]: "  \"use workflow\";"
blank [2090]: "                 "
```

With the escape applied, the same detector returns `hasUseWorkflow: true`.

## Change

Two files.

`executor.workflow.ts` - that one backtick written as `"`"`, with a comment saying why it must stay escaped. Identical string, unchanged comparison; it only restores the parity the detector's regex assumes.

`tests/unit/workflow-directive-detection.test.ts` - the regression guard. It **discovers** `*.workflow.ts` entrypoints rather than listing them, so a new workflow is covered when it lands rather than when someone remembers this file, and asserts three things: that discovery matched something (a glob matching nothing would make the rest vacuous), that the builder's own detector sees every entrypoint, and that entrypoint backticks stay paired.

Verified the guard fails on the unpatched file, naming it in the assertion diff:

```
× sees every entrypoint as a workflow
+   "lib/workflow/executor/executor.workflow.ts",
```

## Verification

- `tsc --noEmit` exits 0
- `biome check` clean on both files
- the 135 tests covering `computeCommentRanges` and template resolution still pass, so the escape is behaviour-neutral
- swept every `*.workflow.ts` in the repo - this was the only genuine casualty; the codegen templates flagged by a naive scan are string templates the detector is right to skip

## Scope

This fixes our side of an upstream defect. The durable fix is `@workflow/builders` scanning with string context instead of a positional regex, which I would like to report upstream with the minimal reproduction - happy to draft that separately rather than hold this PR.

Worth noting for whoever reviews: the pre-bump detector did not "work" because it was correct, it worked because it was permissive. Any file here with an unpaired backtick is exposed to the same failure, which is what the discovery-based guard is for.

Related: KEEP-1297 (#2256), the other regression from #2203, which masked this one until it was fixed.
