### PR TITLE
fix: stop analytics run filters saturating postgres and crash-looping the block dispatcher

### DIFF
--- a/components/analytics/runs-table.tsx
+++ b/components/analytics/runs-table.tsx
@@ -771,6 +771,36 @@ export function RunsTable(): ReactNode {
     ]
   );
 
+  // A changed filter set restarts the listing at page 1 - useAnalytics refetches
+  // without a page - so a ?page= left in the URL outlives the result it
+  // described, and the restore below would replay it against a filter set that
+  // never produced it. Dropping it keeps the URL and the rendered page in step.
+  const filterKey = JSON.stringify([
+    range,
+    statuses,
+    sources,
+    networks,
+    gas,
+    duration,
+    search,
+    projectId,
+    customStart,
+    customEnd,
+  ]);
+  const lastFilterKey = useRef(filterKey);
+  useEffect(() => {
+    if (lastFilterKey.current === filterKey) {
+      return;
+    }
+    lastFilterKey.current = filterKey;
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has("page")) {
+      return;
+    }
+    url.searchParams.delete("page");
+    router.replace(url.pathname + url.search, { scroll: false });
+  }, [filterKey, router]);
+
   // Restore page from URL ?page= param once after initial data load
   const urlPage = Number(searchParams.get("page")) || 1;
   const hasRestoredPage = useRef(false);

--- a/keeperhub-scheduler/block-dispatcher/health.ts
+++ b/keeperhub-scheduler/block-dispatcher/health.ts
@@ -1,0 +1,39 @@
+/**
+ * Aggregation behind `/health`, kept pure so the policy can be tested without
+ * booting the dispatcher.
+ */
+
+export type MonitorLiveness = { alive: boolean };
+
+export type HealthStatus = "ok" | "degraded" | "down";
+
+/**
+ * A stalled upstream on one chain is not a reason to kill a process still
+ * serving the other seventeen.
+ *
+ * `/health` backs both the liveness and the readiness probe, so requiring every
+ * monitor to be alive turned a single dead chain into a SIGKILL *and* an
+ * endpoint removal that stopped Alloy scraping /metrics. Neither restores an
+ * upstream: the restart drops the healthy subscriptions too and hands
+ * leadership to a peer that inherits the same condition, which is how one stuck
+ * chain became a crash loop across both replicas.
+ *
+ * Partial failure is therefore reported as degraded-but-serving. It stays
+ * visible without kubelet intervening: the reconciler already recreates a dead
+ * monitor (MONITOR_RECREATE_TIMEOUT_MS) and per-chain aliveness is exported as
+ * keeperhub_block_dispatcher_is_alive. Only a total outage - monitors running,
+ * none of them alive - is worth a restart.
+ */
+export function buildHealthStatus(monitors: readonly MonitorLiveness[]): {
+  healthy: boolean;
+  status: HealthStatus;
+} {
+  const alive = monitors.filter((m) => m.alive).length;
+  if (monitors.length === 0 || alive === monitors.length) {
+    return { healthy: true, status: "ok" };
+  }
+  if (alive > 0) {
+    return { healthy: true, status: "degraded" };
+  }
+  return { healthy: false, status: "down" };
+}

--- a/keeperhub-scheduler/block-dispatcher/index.ts
+++ b/keeperhub-scheduler/block-dispatcher/index.ts
@@ -34,6 +34,7 @@ import { metrics, registry } from "../lib/metrics.js";
 import type { BlockWorkflow, ChainConfig } from "../lib/types.js";
 import { fetchBlockWorkflows } from "./api-client.js";
 import { ChainMonitor } from "./chain-monitor.js";
+import { type HealthStatus, buildHealthStatus } from "./health.js";
 
 class BlockMonitorService {
   private readonly monitors: Map<number, ChainMonitor> = new Map();
@@ -89,11 +90,11 @@ class BlockMonitorService {
 
   getHealth(): {
     healthy: boolean;
+    status: HealthStatus;
     monitors: ReturnType<ChainMonitor["getStatus"]>[];
   } {
     const monitors = [...this.monitors.values()].map((m) => m.getStatus());
-    const healthy = monitors.length === 0 || monitors.every((m) => m.alive);
-    return { healthy, monitors };
+    return { ...buildHealthStatus(monitors), monitors };
   }
 
   private async reconcile(): Promise<void> {
@@ -284,7 +285,7 @@ async function main(): Promise<void> {
     const health = service.getHealth();
     const statusCode = health.healthy ? 200 : 503;
     res.status(statusCode).json({
-      status: health.healthy ? "ok" : "degraded",
+      status: health.status,
       service: "block-dispatcher",
       leader: election.isLeader(),
       timestamp: new Date().toISOString(),

--- a/keeperhub-scheduler/tests/unit/block-health.test.ts
+++ b/keeperhub-scheduler/tests/unit/block-health.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildHealthStatus } from "../../block-dispatcher/health.js";
+
+const alive = { alive: true };
+const dead = { alive: false };
+
+describe("buildHealthStatus", () => {
+  it("is ok before any monitor is registered", () => {
+    expect(buildHealthStatus([])).toEqual({ healthy: true, status: "ok" });
+  });
+
+  it("is ok when every monitor is alive", () => {
+    expect(buildHealthStatus([alive, alive, alive])).toEqual({
+      healthy: true,
+      status: "ok",
+    });
+  });
+
+  it("stays serving when a single chain of many is dead", () => {
+    // The regression this guards: `every` here returned 503, and because
+    // /health backs the liveness probe that killed a process still monitoring
+    // seventeen other chains.
+    const monitors = [dead, ...Array.from({ length: 17 }, () => alive)];
+    expect(buildHealthStatus(monitors)).toEqual({
+      healthy: true,
+      status: "degraded",
+    });
+  });
+
+  it("still reports degraded when only one chain survives", () => {
+    const monitors = [alive, ...Array.from({ length: 17 }, () => dead)];
+    expect(buildHealthStatus(monitors)).toEqual({
+      healthy: true,
+      status: "degraded",
+    });
+  });
+
+  it("fails only on a total outage", () => {
+    expect(buildHealthStatus([dead, dead])).toEqual({
+      healthy: false,
+      status: "down",
+    });
+  });
+});

--- a/lib/analytics/like-pattern.ts
+++ b/lib/analytics/like-pattern.ts
@@ -1,0 +1,13 @@
+/**
+ * `%` and `_` are LIKE wildcards, so a search term carrying either silently
+ * widens the match: `my_workflow` would also match `myXworkflow`, and `100%`
+ * would match every row. The term is bound as a parameter either way, so this
+ * is a correctness fix rather than an injection one.
+ *
+ * Postgres already defaults LIKE's escape character to a backslash, but the
+ * callers spell `ESCAPE '\'` out so a pattern built here does not silently
+ * depend on that default.
+ */
+export function likePattern(term: string): string {
+  return `%${term.replace(/[\\%_]/g, "\\$&")}%`;
+}

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -38,6 +38,7 @@ import {
 import { redactAllUrls, redactSecretUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { executionLogNotDeleted } from "@/lib/workflow/soft-delete";
 import { analyticsCacheKey, cachedAnalytics } from "./cache";
+import { likePattern } from "./like-pattern";
 import {
   getBucketInterval,
   getPreviousPeriodStart,
@@ -200,24 +201,24 @@ function workflowNetworkCondition(networks: string[]): SQL {
 // The name match gets its own alias because both callers already have
 // `workflows` in scope, one through a join and one through a scoping subquery.
 function workflowSearchCondition(term: string): SQL {
-  const pattern = `%${term}%`;
+  const pattern = likePattern(term);
   return sql`(
-    ${workflowExecutions.id} ILIKE ${pattern}
+    ${workflowExecutions.id} ILIKE ${pattern} ESCAPE '\\'
     OR EXISTS (
       SELECT 1
         FROM ${workflows} AS search_wf
        WHERE search_wf.id = ${workflowExecutions.workflowId}
-         AND search_wf.name ILIKE ${pattern}
+         AND search_wf.name ILIKE ${pattern} ESCAPE '\\'
     )
   )`;
 }
 
 function directSearchCondition(term: string): SQL {
-  const pattern = `%${term}%`;
+  const pattern = likePattern(term);
   return sql`(
-    ${directExecutions.id} ILIKE ${pattern}
-    OR ${directExecutions.type} ILIKE ${pattern}
-    OR ${directExecutions.network} ILIKE ${pattern}
+    ${directExecutions.id} ILIKE ${pattern} ESCAPE '\\'
+    OR ${directExecutions.type} ILIKE ${pattern} ESCAPE '\\'
+    OR ${directExecutions.network} ILIKE ${pattern} ESCAPE '\\'
   )`;
 }
 

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -186,11 +186,11 @@ function directStatusesCondition(statuses: NormalizedStatus[]): SQL {
  * same COALESCE(column, JSONB) the listing reads them through. EXISTS keeps a
  * run that touched any selected chain without multiplying it per matching step.
  */
-function workflowNetworkCondition(networks: string[]): SQL {
-  return sql`EXISTS (
-    SELECT 1
+function workflowNetworkCondition(networks: string[], logsFrom: Date): SQL {
+  return sql`${workflowExecutions.id} IN (
+    SELECT ${workflowExecutionLogs.executionId}
       FROM ${workflowExecutionLogs}
-     WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
+     WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
        AND COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")}) IN (${sql.join(
          networks.map((network) => sql`${network}`),
          sql`, `
@@ -227,67 +227,103 @@ function directSearchCondition(term: string): SQL {
 // asking for "runs over 30s" means.
 const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
 
-// Wei the run's steps burned, and the slice of it gas credit covered. The step
-// rollup is the total, not the unsponsored remainder, so the wallet's share is
-// the difference rather than the whole.
-const workflowStepGasWei = sql`COALESCE((
-  SELECT SUM(COALESCE(
-           ${workflowExecutionLogs.gasUsedWei},
-           CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
-         ))
-    FROM ${workflowExecutionLogs}
-   WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
-), 0)`;
+// Per-step gas and the sponsorship marker, each read as COALESCE(denormalised
+// column, JSONB extract) so rows written before migration 0117 - and rows the
+// backfill has not reached - still classify correctly.
+const filterStepGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC))`;
+const filterStepSponsored = sql`${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'`;
 
-const workflowSponsoredGasWei = sql`COALESCE((
-  SELECT SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC))
+/**
+ * Gas facts per execution, aggregated once over the window.
+ *
+ * These were correlated subqueries on workflow_executions.id, so the planner
+ * re-ran them - up to four, each decoding JSONB - for every candidate row in
+ * the range. Selecting a gas filter over a wide range therefore walked
+ * workflow_execution_logs once per execution, which is what pinned prod on
+ * 2026-09-02: the listing and its count both paid it and neither ever
+ * finished. Uncorrelated, it is evaluated once and hash-semi-joined instead.
+ *
+ * The lower bound is the only bound, and it is safe in both directions: a step
+ * cannot start before the run that owns it, so every log of an execution
+ * inside the window has started_at >= the window start; and a step may finish
+ * after the window closes, so there is no upper bound to apply.
+ */
+function workflowGasTotals(logsFrom: Date): SQL {
+  return sql`(
+    SELECT ${workflowExecutionLogs.executionId} AS execution_id,
+           COALESCE(SUM(${filterStepGasWei}), 0) AS step_gas_wei,
+           COALESCE(BOOL_OR(${filterStepSponsored}), false) AS sponsored_step,
+           COALESCE(BOOL_OR(
+             ${filterStepGasWei} > 0
+             AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
+           ), false) AS unsponsored_gas_step
+      FROM ${workflowExecutionLogs}
+     WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
+     GROUP BY ${workflowExecutionLogs.executionId}
+  )`;
+}
+
+/**
+ * The sponsored slice from the gas-credit ledger, per execution. Its
+ * execution_id is nullable, and a NULL reaching a NOT IN below would make the
+ * whole predicate answer NULL, so the rows are dropped here at the source.
+ */
+const workflowLedgerTotals = sql`(
+  SELECT ${gasCreditUsage.executionId} AS execution_id,
+         COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0) AS sponsored_gas_wei
     FROM ${gasCreditUsage}
-   WHERE ${gasCreditUsage.executionId} = ${workflowExecutions.id}
-), 0)`;
-
-// The same marker the sponsored chip on a run reads: a web3 step core writes
-// `sponsored: true` into its output when the gas station covered the gas. Taken
-// alongside the ledger rather than instead of it, so a run is still sponsored
-// if only one of the two recorded it.
-const workflowSponsoredStep = sql`EXISTS (
-  SELECT 1
-    FROM ${workflowExecutionLogs}
-   WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
-     AND ${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'
+   WHERE ${gasCreditUsage.executionId} IS NOT NULL
+   GROUP BY ${gasCreditUsage.executionId}
 )`;
 
 /**
  * One predicate per gas category. Sponsored is "gas credit covered a leg";
  * wallet is "the run burned more than credit covered", which is what makes a
- * part-sponsored run answer to both.
+ * part-sponsored run answer to both. Free is the complement of the two, so a
+ * run with no step rows at all - absent from the aggregate rather than present
+ * with a zero - still reads as free.
  */
-function workflowGasCondition(value: GasSpend): SQL {
+function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
   if (value === "sponsored") {
-    return sql`(${workflowSponsoredStep} OR ${workflowSponsoredGasWei} > 0)`;
+    // Only the marker decides this one, so it reads output_raw directly rather
+    // than paying for the gas rollup - and its JSONB decode - that the other
+    // two branches genuinely need.
+    return sql`(
+      ${workflowExecutions.id} IN (
+        SELECT ${workflowExecutionLogs.executionId}
+          FROM ${workflowExecutionLogs}
+         WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
+           AND ${filterStepSponsored}
+      )
+      OR ${workflowExecutions.id} IN (
+        SELECT s.execution_id FROM ${workflowLedgerTotals} AS s
+         WHERE s.sponsored_gas_wei > 0
+      )
+    )`;
   }
+  const totals = workflowGasTotals(logsFrom);
   if (value === "wallet") {
     // Both signals have to agree there is an unsponsored share: a step that
     // burned gas without the sponsored marker, and a total the ledger did not
     // fully cover. Either alone misfiles a run that only one of the two
     // recorded.
-    return sql`(
-      EXISTS (
-        SELECT 1
-          FROM ${workflowExecutionLogs}
-         WHERE ${workflowExecutionLogs.executionId} = ${workflowExecutions.id}
-           AND COALESCE(
-                 ${workflowExecutionLogs.gasUsedWei},
-                 CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC)
-               ) > 0
-           AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
-      )
-      AND ${workflowStepGasWei} > ${workflowSponsoredGasWei}
+    return sql`${workflowExecutions.id} IN (
+      SELECT g.execution_id
+        FROM ${totals} AS g
+        LEFT JOIN ${workflowLedgerTotals} AS s ON s.execution_id = g.execution_id
+       WHERE g.unsponsored_gas_step
+         AND g.step_gas_wei > COALESCE(s.sponsored_gas_wei, 0)
     )`;
   }
   return sql`(
-    ${workflowStepGasWei} = 0
-    AND ${workflowSponsoredGasWei} = 0
-    AND NOT ${workflowSponsoredStep}
+    ${workflowExecutions.id} NOT IN (
+      SELECT g.execution_id FROM ${totals} AS g
+       WHERE g.step_gas_wei > 0 OR g.sponsored_step
+    )
+    AND ${workflowExecutions.id} NOT IN (
+      SELECT s.execution_id FROM ${workflowLedgerTotals} AS s
+       WHERE s.sponsored_gas_wei > 0
+    )
   )`;
 }
 
@@ -327,6 +363,7 @@ function gasCondition(
  */
 function workflowFilterConditions(
   filters: RunQueryFilters,
+  rangeStart: Date,
   skipStatuses = false
 ): SQL[] {
   const conditions: SQL[] = [];
@@ -336,7 +373,7 @@ function workflowFilterConditions(
   }
   const networks = filters.networks ?? [];
   if (networks.length > 0) {
-    conditions.push(workflowNetworkCondition(networks));
+    conditions.push(workflowNetworkCondition(networks, rangeStart));
   }
   if (filters.durationMinMs !== undefined) {
     conditions.push(
@@ -352,7 +389,9 @@ function workflowFilterConditions(
   if (search) {
     conditions.push(workflowSearchCondition(search));
   }
-  const gas = gasCondition(filters.gas ?? [], workflowGasCondition);
+  const gas = gasCondition(filters.gas ?? [], (value) =>
+    workflowGasCondition(value, rangeStart)
+  );
   if (gas) {
     conditions.push(gas);
   }
@@ -1257,7 +1296,7 @@ async function fetchWorkflowRuns(
     isNull(workflowExecutions.deletedAt),
   ];
 
-  conditions.push(...workflowFilterConditions(filters));
+  conditions.push(...workflowFilterConditions(filters, rangeStart));
 
   if (cursor) {
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
@@ -1534,7 +1573,7 @@ async function getWorkflowRunsTotal(
   if (projectId) {
     conditions.push(eq(workflows.projectId, projectId));
   }
-  conditions.push(...workflowFilterConditions(filters));
+  conditions.push(...workflowFilterConditions(filters, rangeStart));
   const result = await db
     .select({ count: count() })
     .from(workflowExecutions)
@@ -1652,7 +1691,7 @@ async function computeStatusFacets(
             gte(workflowExecutions.startedAt, rangeStart),
             lt(workflowExecutions.startedAt, rangeEnd),
             isNull(workflowExecutions.deletedAt),
-            ...workflowFilterConditions(filters, true)
+            ...workflowFilterConditions(filters, rangeStart, true)
           )
         )
         // Group by the select ordinal: the CASE carries a bound parameter, and

--- a/tests/unit/analytics-like-pattern.test.ts
+++ b/tests/unit/analytics-like-pattern.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { likePattern } from "@/lib/analytics/like-pattern";
+
+describe("likePattern", () => {
+  it("wraps a plain term in wildcards", () => {
+    expect(likePattern("swap")).toBe("%swap%");
+  });
+
+  it("escapes an underscore so it matches a literal underscore", () => {
+    // Unescaped, `my_workflow` also matched `myXworkflow`.
+    expect(likePattern("my_workflow")).toBe("%my\\_workflow%");
+  });
+
+  it("escapes a percent so it does not match every row", () => {
+    expect(likePattern("100%")).toBe("%100\\%%");
+  });
+
+  it("escapes a backslash before it can escape something else", () => {
+    expect(likePattern("a\\b")).toBe("%a\\\\b%");
+  });
+
+  it("leaves a term with no metacharacters untouched", () => {
+    expect(likePattern("wrun_01M1")).toBe("%wrun\\_01M1%");
+  });
+});


### PR DESCRIPTION
## What happened

On 2026-09-02 the analytics page stopped loading and the block dispatcher
entered a crash loop. Both had one cause.

The gas and network run filters, added in the release that shipped at
00:15Z, are correlated subqueries on `workflow_executions.id`. The planner
re-ran them - up to four per row, each decoding JSONB - for every candidate
execution in the selected range. They only fire when a reader selects a gas
or network filter, which is why prod ran clean for six hours and fell over
at 06:57Z when someone first used them.

From there:

- The analytics page hung. The query never returned, so it never threw, so
  nothing reached the logs or Sentry - the page just span.
- Aborting a request client-side does not cancel a Postgres query, and
  `statement_timeout` was `0`, so every filter change stacked another one.
- With the database saturated the block dispatcher stopped advancing block
  height, its monitors were marked dead, and `/health` - which requires
  *every* monitor alive and backs both probes - returned 503. Kubelet killed
  a process still serving seventeen healthy chains, leadership flipped to the
  peer, and the peer inherited the same condition.

## Changes

**`perf(analytics)`** - the filters are evaluated once and hash-semi-joined
instead of per row. The log scan takes a lower bound of the window start,
safe in both directions: a step cannot start before the run that owns it,
and a step may finish after the window closes so there is no upper bound to
apply. The sponsored branch reads `output_raw` alone rather than pulling the
gas rollup it does not need.

**`fix(block-dispatcher)`** - partial failure is reported as
degraded-but-serving; only a total outage (monitors running, none alive)
fails the probe. This also fixes a readiness side effect: failing readiness
removed the pod from the service, so Alloy stopped scraping `/metrics`
exactly when the per-chain detail mattered. The reconciler already recreates
dead monitors and `keeperhub_block_dispatcher_is_alive` already exports
per-chain state, so nothing loses visibility. The aggregation moved to a pure
module so the policy is testable without booting the dispatcher, following
the `solana-tracker` precedent.

**`fix(analytics)`** - the run search built its ILIKE pattern as
`%${term}%`, so `_` and `%` acted as wildcards: `my_workflow` also matched
`myXworkflow` and `100%` matched every row. The term was always bound as a
parameter, so this is a correctness fix, not an injection one. Also drops a
stale `?page=` when the filter set changes.

## Measured against production

`EXPLAIN`, and counts compared against the old predicates over a 24h window
on an org with real sponsored runs:

| | old | new |
|---|---|---|
| planner cost, 30d wallet filter | 254,045,556 | 2,855,208 |
| sponsored (164 = 164) | 26,540ms | 1,288ms |
| free (7726 = 7726) | 23,300ms | 1,371ms |
| network (3387 = 3387) | 250ms | 296ms |

`sponsored + free = 7890` matches the execution total for the window. The
network win scales with range; at 24h it is already index-friendly.

## Not verified - please treat as the review gate

- **The `wallet` branch returned 0 in every window available on prod**, so
  its equivalence is unexercised on discriminating data.
  `tests/e2e/vitest/analytics-run-filters.db.test.ts` covers these filters
  with seeded data and is the real gate here.
- Type-check, biome and the unit suites have not been run locally (the
  worktree has no `node_modules`). A function signature changed across three
  call sites, which is exactly what `tsc` should confirm.

## Operational notes

- `statement_timeout` is now `120s` on the `keeperhub` role as a backstop.
  It applies to new sessions only, so pooled connections keep `0` until they
  recycle.
- The block-dispatcher fix only takes effect when that image ships.
