### PR TITLE
fix: bind the analytics log window through gte, not a raw template value

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -190,7 +190,7 @@ function workflowNetworkCondition(networks: string[], logsFrom: Date): SQL {
   return sql`${workflowExecutions.id} IN (
     SELECT ${workflowExecutionLogs.executionId}
       FROM ${workflowExecutionLogs}
-     WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
+     WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
        AND COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")}) IN (${sql.join(
          networks.map((network) => sql`${network}`),
          sql`, `
@@ -258,7 +258,7 @@ function workflowGasTotals(logsFrom: Date): SQL {
              AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
            ), false) AS unsponsored_gas_step
       FROM ${workflowExecutionLogs}
-     WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
+     WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
      GROUP BY ${workflowExecutionLogs.executionId}
   )`;
 }
@@ -292,7 +292,7 @@ function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
       ${workflowExecutions.id} IN (
         SELECT ${workflowExecutionLogs.executionId}
           FROM ${workflowExecutionLogs}
-         WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
+         WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
            AND ${filterStepSponsored}
       )
       OR ${workflowExecutions.id} IN (


### PR DESCRIPTION
Follow-up to #2260, which merged before this fix was pushed.

## The regression now in staging

The windowed filter subqueries added in #2260 interpolate a JS `Date`
straight into the `sql` template:

```
WHERE ${workflowExecutionLogs.startedAt} >= ${logsFrom}
```

Drizzle binds a raw template value as a parameter without the column's type
mapper, so the driver is handed a `Date` it cannot serialise. Every analytics
query carrying a gas or network filter fails with:

```
ERR_INVALID_ARG_TYPE: The "string" argument must be of type string or an
instance of Buffer or ArrayBuffer. Received an instance of Date
```

`gte()` applies the timestamp mapper, which is why every surrounding
condition was unaffected. Three call sites, three lines.

## Blast radius

Both predicates are only built when a filter is selected -
`workflowNetworkCondition` when `networks.length > 0`, and `gasCondition`
returns `undefined` for zero or all three categories. So the analytics page
loads normally and only the gas and network filters are broken. It fails
fast, so unlike the incident that prompted #2260 it does not hold database
connections.

## How it was caught, and why the earlier checks missed it

`tests/e2e/vitest/analytics-run-filters.db.test.ts` failed 4 tests on #2260
(219 passed): the three filter cases plus the facet count.

The equivalence and `EXPLAIN` checks run against production for #2260 used
hand-written SQL through node-postgres, which serialises a `Date` itself.
They confirmed the predicates were semantically identical and ~89x cheaper,
but never exercised drizzle's binding path - which is the path that broke.

## Verification

This PR carries `run-e2e-tests-ephemeral` so the same db suite that caught it
runs against the fix.

Note the playwright job on #2260 also failed, in `signIn` before any test
body, identically for all four personas across every retry - the org switcher
never appears after login. That touches no code in either PR and looks
environmental, but it was not green before #2260 either, so it is unproven
and worth watching on this run.
