### PR TITLE
ci: KEEP-1303 gate on decision-needed, the label that exists

### DIFF
--- a/.github/workflows/decision-label-check.yml
+++ b/.github/workflows/decision-label-check.yml
@@ -1,8 +1,8 @@
 name: Decision Label Check
 
-# Blocks merge while the `decision` label is present.
+# Blocks merge while the `decision-needed` label is present.
 #
-# `decision` means the PR is waiting on a maintainer, not on the contributor:
+# `decision-needed` means the PR is waiting on a maintainer, not on the contributor:
 # an API shape that becomes a contract, a new dependency, a behaviour change to
 # an existing default, anything touching pricing, limits, auth or permissions,
 # or a product judgement the diff alone cannot settle.
@@ -13,7 +13,7 @@ name: Decision Label Check
 # default rather than on purpose. This turns that into a red check.
 #
 # Workflow:
-#   1. Reviewer raises a needs-decision finding and adds `decision`.
+#   1. Reviewer raises a needs-decision finding and adds `decision-needed`.
 #   2. This check fails, so the PR cannot merge.
 #   3. A maintainer answers the question in a comment on the PR, so the
 #      reasoning is on the record and not just in someone's head.
@@ -37,15 +37,21 @@ jobs:
   decision-label-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail while the decision label is present
+      - name: Fail while the decision-needed label is present
         env:
+          # The label name lives here, once. This gate shipped reading
+          # `decision`; the label was renamed to `decision-needed` the next day
+          # and the workflow was missed, so it passed on every pull request it
+          # existed to stop. Keep this in step with DECISION_LABEL in the
+          # babysit-prs sweep, which is what applies it.
+          LABEL: decision-needed
           LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          if printf '%s' "$LABELS_JSON" | jq -e 'any(. == "decision")' >/dev/null; then
-            echo "::error::This PR carries the 'decision' label: it is blocked on a maintainer decision, not on the contributor."
-            echo "::error::Answer the open question in a comment on this PR, then remove the 'decision' label. This check re-runs on unlabeled."
+          if printf '%s' "$LABELS_JSON" | jq -e --arg L "$LABEL" 'any(. == $L)' >/dev/null; then
+            echo "::error::This PR carries the '$LABEL' label: it is blocked on a maintainer decision, not on the contributor."
+            echo "::error::Answer the open question in a comment on this PR, then remove the '$LABEL' label. This check re-runs on unlabeled."
             echo "::error::Removing the label without answering defeats the gate - the decision then gets made by default at merge time."
             exit 1
           fi
-          echo "No 'decision' label; nothing is blocked on a maintainer."
+          echo "No '$LABEL' label; nothing is blocked on a maintainer."


### PR DESCRIPTION
## Issue

No GitHub issue. Team change, tracked as KEEP-1303, which is in the branch name and the commit.

## What this changes

`decision-label-check` blocked merge while a label named `decision` was present. Neither repository has a label by that name.

The workflow shipped on **4 August** (`858d572f`). The label was renamed `decision` to `decision-needed` on **5 August**; `babysit-prs/queue.sh` records that rename in its alias list, and the workflow was missed. A GitHub search confirms no pull request has ever carried the bare `decision` label, so this gate has passed on every pull request it existed to stop, since the day after it shipped.

Six open pull requests carry `decision-needed` today - #2188, #2197, #2213, #2215, #2228, #2229 - and the check is green on all six.

The label name moves into a `LABEL` env var so there is one place to change it, matching the shape `metrics-db-review-gate` already uses, and points at `decision-needed`.

## Scope

One change, one file. The label name is the only behavioural edit; the rest is the env var and the prose that quoted the old name.

Worth knowing: `decision-label-check` is not in the required status checks on `staging`, so this makes the gate correct rather than blocking. Adding it to the ruleset is separate and needs an organisation owner.

## How it was verified

No TypeScript or JavaScript changed. What I ran:

- Both branches of the comparison, against the real check body extracted from the YAML: labels `["changes-requested","decision-needed"]` blocks, labels `["changes-requested"]` passes.
- YAML parses; the extracted `run:` body passes `sh -n`.
- Confirmed against the live API that no `decision` label exists in either repository, and that the six pull requests above carry `decision-needed`.

## Screenshots

Renders nothing.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [ ] `pnpm check` and `pnpm type-check` pass - not run; this diff touches one YAML file and no TypeScript
- [x] No secrets, `.env` files, or credentials committed
