### PR TITLE
ci: KEEP-1307 stop telling contributors to re-run the gate by hand

### DIFF
--- a/.github/workflows/pr-issue-link.yml
+++ b/.github/workflows/pr-issue-link.yml
@@ -161,9 +161,8 @@ jobs:
             if [ -n "$awaiting" ]; then
               md+="**Nothing to do on your side.** The issue is filed and is waiting for a "
               md+="maintainer to triage it and apply the \`$ACCEPTED_LABEL\` label; that step "
-              md+="is ours, not yours. This check reruns when the pull request is pushed or "
-              md+="edited, not when the issue is labelled, so once \`$ACCEPTED_LABEL\` lands, "
-              md+="re-run the job or edit the title to retrigger it."
+              md+="is ours, not yours. Once \`$ACCEPTED_LABEL\` lands this check re-runs on "
+              md+="its own and turns green; there is nothing to re-trigger by hand."
             else
               md+="**Outside contributions** start with an issue. Open one, wait for a "
               md+="maintainer to apply the \`$ACCEPTED_LABEL\` label, then put \`#N\` in the "
@@ -171,8 +170,8 @@ jobs:
               md+="No issue is needed for typos, broken links, formatting, or docs corrected to "
               md+="match existing behaviour; retitle with one of: \`$EXEMPT_TYPES\`. Full policy: "
               md+="[ISSUES.md](https://github.com/$REPO/blob/staging/ISSUES.md)."$'\n\n'
-              md+="This check reruns on every push and edit, but not when the issue changes; "
-              md+="re-run the job or edit the title to retrigger it."
+              md+="This check reruns on every push and edit, and again on its own once a "
+              md+="referenced issue is labelled \`$ACCEPTED_LABEL\`."
             fi
 
             echo "----------------------------------------------"


### PR DESCRIPTION
## Issue

No GitHub issue. Team change, tracked as KEEP-1307, in the branch name and the commit.

## What this changes

The `check-issue-link` failure comment instructed contributors to work around a bug that no longer exists:

> This check reruns when the pull request is pushed or edited, not when the issue is labelled, so once `accepted` lands, re-run the job or edit the title to retrigger it.

Since KEEP-1296, `recheck-issue-link` does exactly that on its own, in about nine seconds. The instruction appeared twice, and the worse of the two is in the branch shown to an outside contributor who is waiting on our triage - told to perform a manual step for a step that was never theirs.

Both occurrences now say the check re-runs by itself once a referenced issue is labelled `accepted`.

## Scope

One file, comment copy only. No control flow, no trigger, no permission changes.

## How it was verified

No TypeScript or JavaScript changed. YAML parses; the extracted `run:` body passes `sh -n`; the stale phrase now appears zero times in the file.

## Screenshots

Renders nothing.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [ ] `pnpm check` and `pnpm type-check` pass - not run; one YAML file, no TypeScript
- [x] No secrets, `.env` files, or credentials committed
