### PR TITLE
feat(web3): add a fail-on-error toggle to the web3 read actions

### DIFF
--- a/plugins/field-fragments.ts
+++ b/plugins/field-fragments.ts
@@ -87,7 +87,7 @@ export function readFailOnErrorField(): ActionConfigField {
   return {
     defaultValue: "true",
     helpTip:
-      "When off, a failed read (RPC error, or a call the chain rejects) passes a soft error to the next node instead of failing the run, so one bad item in a For Each loop does not abort it. Config problems (bad address, unknown network, unresolved RPC) always fail the run regardless of this setting.",
+      "When off, a failed read passes a soft error to the next node instead of failing the run, so one bad item in a For Each loop does not abort it. This covers the call itself and the ABI, function and arguments you send. Only problems that leave the step with nowhere to call - an invalid address, an unknown network, or unresolved RPC config - still fail the run, matching HTTP Request, which softens every response but refuses to soften an unusable URL.",
     key: "failOnError",
     label: "Fail workflow on error",
     type: "fail-on-error-switch",

--- a/plugins/field-fragments.ts
+++ b/plugins/field-fragments.ts
@@ -76,6 +76,24 @@ export function contractAddressField(): ActionConfigField {
   };
 }
 
+/**
+ * The "Fail workflow on error" toggle shared by the web3 read actions. When
+ * off, a failed on-chain read hands the next node a soft error instead of
+ * failing the run, so one bad item inside a For Each loop does not abort it.
+ * See softenReadFailure in plugins/web3/steps/read-fail-on-error-core.ts for
+ * which failures qualify.
+ */
+export function readFailOnErrorField(): ActionConfigField {
+  return {
+    defaultValue: "true",
+    helpTip:
+      "When off, a failed read (RPC error, or a call the chain rejects) passes a soft error to the next node instead of failing the run, so one bad item in a For Each loop does not abort it. Config problems (bad address, unknown network, unresolved RPC) always fail the run regardless of this setting.",
+    key: "failOnError",
+    label: "Fail workflow on error",
+    type: "fail-on-error-switch",
+  };
+}
+
 export function transactionLinkOutput(): OutputField {
   return {
     description: "Explorer link to view the transaction",
@@ -85,7 +103,8 @@ export function transactionLinkOutput(): OutputField {
 
 export function checkErrorOutput(): OutputField {
   return {
-    description: "Error message if the check failed",
+    description:
+      "Error message if the check failed. Also set when failOnError is off and a failed read was softened into success=true.",
     field: "error",
   };
 }
@@ -120,7 +139,8 @@ export function tempoChainIdOutput(): OutputField {
 
 export function balanceCheckSuccessOutput(): OutputField {
   return {
-    description: "Whether the balance check succeeded",
+    description:
+      "Whether the balance check succeeded. Also true when failOnError is off and a failed read was softened; the balance fields are null and `error` is set.",
     field: "success",
   };
 }

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -10,8 +10,7 @@ import {
   executedCallContractAddressOutput,
   executedCallRevertedOutput,
   executedCallSponsoredOutput,
-  queryErrorOutput,
-  querySuccessOutput,
+  readFailOnErrorField,
   receiptChainIdOutput,
   solanaNetworkField,
   tokenConfigField,
@@ -90,6 +89,7 @@ const web3Plugin: IntegrationPlugin = {
           example: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -150,6 +150,7 @@ const web3Plugin: IntegrationPlugin = {
           required: true,
         },
         tokenConfigField(),
+        readFailOnErrorField(),
       ],
     },
     {
@@ -218,6 +219,7 @@ const web3Plugin: IntegrationPlugin = {
             '{"mode":"custom","customToken":{"address":"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","symbol":"USDC"}}',
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -582,11 +584,13 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the read succeeded",
+          description:
+            "Whether the read succeeded. Also true when failOnError is off and a failed read was softened; `exists` is null and `error` is set.",
         },
         {
           field: "exists",
-          description: "Whether the account exists on-chain",
+          description:
+            "Whether the account exists on-chain. Null on a soft-failed (failOnError=false) read, where the answer is unknown -- test for null before treating it as absent.",
         },
         {
           field: "owner",
@@ -618,7 +622,8 @@ const web3Plugin: IntegrationPlugin = {
         },
         {
           field: "error",
-          description: "Error message if the read failed",
+          description:
+            "Error message if the read failed. Also set when failOnError is off and a failed read was softened into success=true.",
         },
       ],
       configFields: [
@@ -631,6 +636,7 @@ const web3Plugin: IntegrationPlugin = {
           example: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -644,7 +650,8 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the read succeeded",
+          description:
+            "Whether the read succeeded. Also true when failOnError is off and a failed read was softened; `result` is null and `error` is set.",
         },
         {
           field: "result",
@@ -664,7 +671,8 @@ const web3Plugin: IntegrationPlugin = {
         },
         {
           field: "error",
-          description: "Error message if the read or decode failed",
+          description:
+            "Error message if the read or decode failed. Also set when failOnError is off and a failed read was softened into success=true.",
         },
       ],
       configFields: [
@@ -707,6 +715,7 @@ const web3Plugin: IntegrationPlugin = {
             "The name of the account type to decode as, exactly as it appears in the IDL's accounts array.",
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -718,7 +727,11 @@ const web3Plugin: IntegrationPlugin = {
       stepFunction: "querySolanaProgramEventsStep",
       stepImportPath: "query-solana-program-events",
       outputFields: [
-        querySuccessOutput(),
+        {
+          field: "success",
+          description:
+            "Whether the query succeeded. Also true when failOnError is off and a failed query was softened; the data fields are null and `error` is set.",
+        },
         {
           field: "events",
           description:
@@ -760,7 +773,11 @@ const web3Plugin: IntegrationPlugin = {
           description:
             "When eventName is set, the distinct names of other decoded events that were filtered out - empty if nothing else was seen, useful for catching an eventName typo",
         },
-        queryErrorOutput(),
+        {
+          field: "error",
+          description:
+            "Error message if the query failed. Also set when failOnError is off and a failed query was softened into success=true.",
+        },
       ],
       configFields: [
         solanaNetworkField(),
@@ -820,6 +837,7 @@ const web3Plugin: IntegrationPlugin = {
             },
           ],
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -874,14 +892,7 @@ const web3Plugin: IntegrationPlugin = {
           abiField: "abi",
           abiFunctionField: "abiFunction",
         },
-        {
-          key: "failOnError",
-          label: "Fail workflow on error",
-          type: "fail-on-error-switch",
-          defaultValue: "true",
-          helpTip:
-            "When off, a failed read (RPC error or a reverting call) passes a soft error to the next node instead of failing the run, so one bad item in a For Each loop does not abort it. Config/validation problems (bad ABI, missing function, unresolved RPC) always fail the run regardless of this setting.",
-        },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -895,7 +906,8 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the transaction was found",
+          description:
+            "Whether the transaction was found. Also true when failOnError is off and a failed lookup (RPC error, or no such transaction) was softened; every detail field is null and `error` is set.",
         },
         {
           field: "hash",
@@ -949,7 +961,8 @@ const web3Plugin: IntegrationPlugin = {
         },
         {
           field: "error",
-          description: "Error message if the lookup failed",
+          description:
+            "Error message if the lookup failed. Also set when failOnError is off and a failed lookup was softened into success=true.",
         },
       ],
       configFields: [
@@ -970,6 +983,7 @@ const web3Plugin: IntegrationPlugin = {
             "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -1141,7 +1155,11 @@ const web3Plugin: IntegrationPlugin = {
       stepFunction: "queryEventsStep",
       stepImportPath: "query-events",
       outputFields: [
-        querySuccessOutput(),
+        {
+          field: "success",
+          description:
+            "Whether the query succeeded. Also true when failOnError is off and a failed query was softened; the data fields are null and `error` is set.",
+        },
         {
           field: "events",
           description:
@@ -1159,7 +1177,11 @@ const web3Plugin: IntegrationPlugin = {
           field: "eventCount",
           description: "Number of events returned",
         },
-        queryErrorOutput(),
+        {
+          field: "error",
+          description:
+            "Error message if the query failed. Also set when failOnError is off and a failed query was softened into success=true.",
+        },
       ],
       configFields: [
         evmNetworkField(),
@@ -1213,6 +1235,7 @@ const web3Plugin: IntegrationPlugin = {
             },
           ],
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -1224,7 +1247,11 @@ const web3Plugin: IntegrationPlugin = {
       stepFunction: "queryTransactionsStep",
       stepImportPath: "query-transactions",
       outputFields: [
-        querySuccessOutput(),
+        {
+          field: "success",
+          description:
+            "Whether the query succeeded. Also true when failOnError is off and a failed query was softened; the data fields are null and `error` is set.",
+        },
         {
           field: "transactions",
           description:
@@ -1252,7 +1279,11 @@ const web3Plugin: IntegrationPlugin = {
           field: "contractAddressLink",
           description: "Block explorer link for the contract",
         },
-        queryErrorOutput(),
+        {
+          field: "error",
+          description:
+            "Error message if the query failed. Also set when failOnError is off and a failed query was softened into success=true.",
+        },
       ],
       configFields: [
         evmNetworkField(),
@@ -1315,6 +1346,7 @@ const web3Plugin: IntegrationPlugin = {
             },
           ],
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -1328,12 +1360,13 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the batch call succeeded",
+          description:
+            "Whether the batch call succeeded. Also true when failOnError is off and a failed batch was softened; `results` is null and `error` is set. A single call reverting is reported in its own `results` entry and is unaffected by that setting.",
         },
         {
           field: "results",
           description:
-            "Array of results in call order, each with { success, result, error? }",
+            "Array of results in call order, each with { success, result, error? }. Null on a soft-failed (failOnError=false) batch.",
         },
         {
           field: "totalCalls",
@@ -1341,7 +1374,8 @@ const web3Plugin: IntegrationPlugin = {
         },
         {
           field: "error",
-          description: "Error message if the entire batch failed",
+          description:
+            "Error message if the entire batch failed. Also set when failOnError is off and a failed batch was softened into success=true.",
         },
       ],
       configFields: [
@@ -1441,6 +1475,7 @@ const web3Plugin: IntegrationPlugin = {
             },
           ],
         },
+        readFailOnErrorField(),
       ],
     },
     {
@@ -1650,7 +1685,8 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the allowance check succeeded",
+          description:
+            "Whether the allowance check succeeded. Also true when failOnError is off and a failed read was softened; the allowance fields are null and `error` is set.",
         },
         {
           field: "allowance",
@@ -1682,6 +1718,7 @@ const web3Plugin: IntegrationPlugin = {
           example: "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45",
           required: true,
         },
+        readFailOnErrorField(),
       ],
     },
     {

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -832,16 +832,18 @@ const web3Plugin: IntegrationPlugin = {
       outputFields: [
         {
           field: "success",
-          description: "Whether the contract call succeeded",
+          description:
+            "Whether the contract call succeeded. Also true when failOnError is off and a failed read (RPC error or revert) was softened; check `error` to tell them apart.",
         },
         {
           field: "result",
           description:
-            "The contract function return value (structured based on ABI outputs)",
+            "The contract function return value (structured based on ABI outputs). Null on a soft-failed (failOnError=false) read.",
         },
         {
           field: "error",
-          description: "Error message if the call failed",
+          description:
+            "Error message if the call failed. Also set when failOnError is off and a failed read was softened into success=true. Match this string in a downstream Condition node (contains/matchesRegex) to filter known errors from ones that should alert.",
         },
       ],
       configFields: [
@@ -871,6 +873,14 @@ const web3Plugin: IntegrationPlugin = {
           type: "abi-function-args",
           abiField: "abi",
           abiFunctionField: "abiFunction",
+        },
+        {
+          key: "failOnError",
+          label: "Fail workflow on error",
+          type: "fail-on-error-switch",
+          defaultValue: "true",
+          helpTip:
+            "When off, a failed read (RPC error or a reverting call) passes a soft error to the next node instead of failing the run, so one bad item in a For Each loop does not abort it. Config/validation problems (bad ABI, missing function, unresolved RPC) always fail the run regardless of this setting.",
         },
       ],
     },

--- a/plugins/web3/steps/batch-read-contract.ts
+++ b/plugins/web3/steps/batch-read-contract.ts
@@ -10,8 +10,9 @@ import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "@/plugins/web3/steps/read-fail-on-error-core";
 import {
   type AbiOutputParam,
@@ -41,7 +42,7 @@ type BatchReadContractResult =
       totalCalls: number | null;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 export type BatchReadContractCoreInput = ReadFailOnErrorInput & {
   network?: string;
@@ -639,7 +640,7 @@ async function executeUniformMode(
 
   const chainRpc = await resolveChainRpc(network, userId);
   if (chainRpc.error !== undefined) {
-    return { success: false, error: chainRpc.error };
+    return { success: false, destinationError: true, error: chainRpc.error };
   }
 
   const { results, error: batchError } = await executeMulticallBatches(
@@ -650,10 +651,6 @@ async function executeUniformMode(
   );
 
   if (batchError) {
-    const soft = softenReadFailure(input.failOnError, batchError);
-    if (soft) {
-      return { ...soft, results: null, totalCalls: null };
-    }
     return { success: false, error: batchError };
   }
 
@@ -725,10 +722,7 @@ async function executeMixedMode(
     results: CallResult[];
     group: IndexedEncodedCall[];
   };
-  // `soft` marks a failure of the multicall execution itself, the only kind
-  // the failOnError toggle may soften. An unresolved network or RPC config is
-  // a config problem and always hard-fails.
-  type GroupFailure = { ok: false; error: string; soft?: boolean };
+  type GroupFailure = { ok: false; error: string };
   type GroupOutcome = GroupSuccess | GroupFailure;
 
   // Execute all network groups in parallel
@@ -749,7 +743,7 @@ async function executeMixedMode(
         chainRpc.chainId
       );
       if (batchResult.error !== undefined) {
-        return { ok: false, error: batchResult.error, soft: true };
+        return { ok: false, error: batchResult.error };
       }
 
       return { ok: true, results: batchResult.results, group };
@@ -758,12 +752,6 @@ async function executeMixedMode(
 
   for (const outcome of groupOutcomes) {
     if (!outcome.ok) {
-      const soft = outcome.soft
-        ? softenReadFailure(input.failOnError, outcome.error)
-        : undefined;
-      if (soft) {
-        return { ...soft, results: null, totalCalls: null };
-      }
       return { success: false, error: outcome.error };
     }
     for (const [resultIdx, groupCall] of outcome.group.entries()) {
@@ -802,7 +790,11 @@ export async function batchReadContractStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "batch-read-contract" },
     input,
-    stepHandler
+    async (i) =>
+      applyReadFailOnError(await stepHandler(i), i.failOnError, {
+        results: null,
+        totalCalls: null,
+      })
   );
 }
 

--- a/plugins/web3/steps/batch-read-contract.ts
+++ b/plugins/web3/steps/batch-read-contract.ts
@@ -722,7 +722,7 @@ async function executeMixedMode(
     results: CallResult[];
     group: IndexedEncodedCall[];
   };
-  type GroupFailure = { ok: false; error: string };
+  type GroupFailure = { ok: false; error: string; destinationError?: true };
   type GroupOutcome = GroupSuccess | GroupFailure;
 
   // Execute all network groups in parallel
@@ -733,7 +733,7 @@ async function executeMixedMode(
     groupEntries.map(async ([networkKey, group]): Promise<GroupOutcome> => {
       const chainRpc = await resolveChainRpc(networkKey, userId);
       if (chainRpc.error !== undefined) {
-        return { ok: false, error: chainRpc.error };
+        return { ok: false, error: chainRpc.error, destinationError: true };
       }
 
       const batchResult = await executeMulticallBatches(
@@ -752,7 +752,9 @@ async function executeMixedMode(
 
   for (const outcome of groupOutcomes) {
     if (!outcome.ok) {
-      return { success: false, error: outcome.error };
+      return outcome.destinationError
+        ? { success: false, destinationError: true, error: outcome.error }
+        : { success: false, error: outcome.error };
     }
     for (const [resultIdx, groupCall] of outcome.group.entries()) {
       allResults[groupCall.originalIndex] = outcome.results[resultIdx];

--- a/plugins/web3/steps/batch-read-contract.ts
+++ b/plugins/web3/steps/batch-read-contract.ts
@@ -10,6 +10,10 @@ import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "@/plugins/web3/steps/read-fail-on-error-core";
+import {
   type AbiOutputParam,
   structureAbiOutputs,
 } from "@/plugins/web3/steps/structure-abi-result";
@@ -26,10 +30,20 @@ type CallResult = {
 };
 
 type BatchReadContractResult =
-  | { success: true; results: CallResult[]; totalCalls: number }
+  | {
+      success: true;
+      // Null when failOnError=false softened a failed batch into a success
+      // value so the workflow continues; `error` carries the reason. Null
+      // rather than an empty list so a downstream node cannot read a failed
+      // batch as "every call returned nothing". A single call reverting is
+      // already isolated into its own `results` entry and is unaffected.
+      results: CallResult[] | null;
+      totalCalls: number | null;
+      error?: string;
+    }
   | { success: false; error: string };
 
-export type BatchReadContractCoreInput = {
+export type BatchReadContractCoreInput = ReadFailOnErrorInput & {
   network?: string;
   abi?: string;
   inputMode?: string;
@@ -636,6 +650,10 @@ async function executeUniformMode(
   );
 
   if (batchError) {
+    const soft = softenReadFailure(input.failOnError, batchError);
+    if (soft) {
+      return { ...soft, results: null, totalCalls: null };
+    }
     return { success: false, error: batchError };
   }
 
@@ -707,7 +725,10 @@ async function executeMixedMode(
     results: CallResult[];
     group: IndexedEncodedCall[];
   };
-  type GroupFailure = { ok: false; error: string };
+  // `soft` marks a failure of the multicall execution itself, the only kind
+  // the failOnError toggle may soften. An unresolved network or RPC config is
+  // a config problem and always hard-fails.
+  type GroupFailure = { ok: false; error: string; soft?: boolean };
   type GroupOutcome = GroupSuccess | GroupFailure;
 
   // Execute all network groups in parallel
@@ -728,7 +749,7 @@ async function executeMixedMode(
         chainRpc.chainId
       );
       if (batchResult.error !== undefined) {
-        return { ok: false, error: batchResult.error };
+        return { ok: false, error: batchResult.error, soft: true };
       }
 
       return { ok: true, results: batchResult.results, group };
@@ -737,6 +758,12 @@ async function executeMixedMode(
 
   for (const outcome of groupOutcomes) {
     if (!outcome.ok) {
+      const soft = outcome.soft
+        ? softenReadFailure(input.failOnError, outcome.error)
+        : undefined;
+      if (soft) {
+        return { ...soft, results: null, totalCalls: null };
+      }
       return { success: false, error: outcome.error };
     }
     for (const [resultIdx, groupCall] of outcome.group.entries()) {

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -11,8 +11,9 @@ import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-ha
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 import { parseTokenAddress } from "./transfer-token-core";
 
@@ -36,7 +37,7 @@ type CheckAllowanceResult =
       symbol: string | null;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 async function stepHandler(
   input: CheckAllowanceInput
@@ -54,7 +55,8 @@ async function stepHandler(
       error,
       { plugin_name: "web3", action_name: "check-allowance" }
     );
-    return { success: false, error: getErrorMessage(error) };
+    return { success: false,
+      destinationError: true, error: getErrorMessage(error) };
   }
 
   // Parse token address from config
@@ -103,7 +105,8 @@ async function stepHandler(
         chain_id: String(chainId),
       }
     );
-    return { success: false, error: getErrorMessage(error) };
+    return { success: false,
+      destinationError: true, error: getErrorMessage(error) };
   }
 
   const adapter = getChainAdapter(chainId);
@@ -162,10 +165,6 @@ async function stepHandler(
       }
     );
     const message = `Failed to check allowance: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return { ...soft, allowance: null, allowanceRaw: null, symbol: null };
-    }
     return { success: false, error: message };
   }
 }
@@ -174,13 +173,18 @@ async function stepHandler(
  * Check Allowance Step
  * Reads ERC20 allowance(owner, spender) to check the current spending approval
  */
-// biome-ignore lint/suspicious/useAwait: "use step" directive requires async
 export async function checkAllowanceStep(
   input: CheckAllowanceInput
 ): Promise<CheckAllowanceResult> {
   "use step";
 
-  return withStepLogging(input, () => stepHandler(input));
+  return withStepLogging(input, async () =>
+    applyReadFailOnError(await stepHandler(input), input.failOnError, {
+      allowance: null,
+      allowanceRaw: null,
+      symbol: null,
+    })
+  );
 }
 
 checkAllowanceStep.maxRetries = 0;

--- a/plugins/web3/steps/check-allowance.ts
+++ b/plugins/web3/steps/check-allowance.ts
@@ -10,9 +10,13 @@ import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { type StepInput, withStepLogging } from "@/lib/workflow/executor/step-handler";
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 import { parseTokenAddress } from "./transfer-token-core";
 
-export type CheckAllowanceCoreInput = {
+export type CheckAllowanceCoreInput = ReadFailOnErrorInput & {
   network: string;
   tokenConfig: string | Record<string, unknown>;
   ownerAddress: string;
@@ -25,9 +29,12 @@ export type CheckAllowanceInput = StepInput & CheckAllowanceCoreInput;
 type CheckAllowanceResult =
   | {
       success: true;
-      allowance: string;
-      allowanceRaw: string;
-      symbol: string;
+      // Null when failOnError=false softened a failed read into a success
+      // value so the workflow continues; `error` carries the reason.
+      allowance: string | null;
+      allowanceRaw: string | null;
+      symbol: string | null;
+      error?: string;
     }
   | { success: false; error: string };
 
@@ -154,10 +161,12 @@ async function stepHandler(
         chain_id: String(chainId),
       }
     );
-    return {
-      success: false,
-      error: `Failed to check allowance: ${getErrorMessage(error)}`,
-    };
+    const message = `Failed to check allowance: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return { ...soft, allowance: null, allowanceRaw: null, symbol: null };
+    }
+    return { success: false, error: message };
   }
 }
 

--- a/plugins/web3/steps/check-balance.ts
+++ b/plugins/web3/steps/check-balance.ts
@@ -13,18 +13,25 @@ import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-hand
 import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
 type CheckBalanceResult =
   | {
       success: true;
-      balance: string;
-      balanceWei: string;
+      // Null when failOnError=false softened a failed read into a success
+      // value so the workflow continues; `error` carries the reason.
+      balance: string | null;
+      balanceWei: string | null;
       address: string;
       addressLink: string;
+      error?: string;
     }
   | { success: false; error: string };
 
-export type CheckBalanceCoreInput = {
+export type CheckBalanceCoreInput = ReadFailOnErrorInput & {
   network: string;
   address: string;
 };
@@ -147,10 +154,18 @@ async function stepHandler(
         chain_id: String(chainId),
       }
     );
-    return {
-      success: false,
-      error: `Failed to check balance: ${getErrorMessage(error)}`,
-    };
+    const message = `Failed to check balance: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return {
+        ...soft,
+        balance: null,
+        balanceWei: null,
+        address,
+        addressLink: await adapter.getAddressUrl(address),
+      };
+    }
+    return { success: false, error: message };
   }
 }
 

--- a/plugins/web3/steps/check-balance.ts
+++ b/plugins/web3/steps/check-balance.ts
@@ -14,8 +14,9 @@ import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 type CheckBalanceResult =
@@ -29,7 +30,7 @@ type CheckBalanceResult =
       addressLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 export type CheckBalanceCoreInput = ReadFailOnErrorInput & {
   network: string;
@@ -79,6 +80,7 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }
@@ -97,6 +99,7 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: isSolana
         ? `Invalid Solana address: ${address}`
         : `Invalid Ethereum address: ${address}`,
@@ -122,6 +125,7 @@ async function stepHandler(
       );
       return {
         success: false,
+      destinationError: true,
         error: getErrorMessage(error),
       };
     }
@@ -155,16 +159,6 @@ async function stepHandler(
       }
     );
     const message = `Failed to check balance: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return {
-        ...soft,
-        balance: null,
-        balanceWei: null,
-        address,
-        addressLink: await adapter.getAddressUrl(address),
-      };
-    }
     return { success: false, error: message };
   }
 }
@@ -186,7 +180,13 @@ export async function checkBalanceStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "check-balance" },
     enrichedInput,
-    () => stepHandler(input)
+    async () =>
+      applyReadFailOnError(await stepHandler(input), input.failOnError, {
+        balance: null,
+        balanceWei: null,
+        address: input.address,
+        addressLink: "",
+      })
   );
 }
 

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -13,6 +13,10 @@ import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
+import {
   getTokenAddress,
   parseTokenConfig,
   type TokenBalanceInfo,
@@ -22,16 +26,20 @@ import {
 type CheckTokenBalanceResult =
   | {
       success: true;
-      balance: TokenBalanceInfo;
+      // Null when failOnError=false softened a failed read into a success
+      // value so the workflow continues; `error` carries the reason.
+      balance: TokenBalanceInfo | null;
       address: string;
       addressLink: string;
+      error?: string;
     }
   | { success: false; error: string };
 
-export type CheckTokenBalanceCoreInput = TokenConfigSource & {
-  network: string;
-  address: string;
-};
+export type CheckTokenBalanceCoreInput = TokenConfigSource &
+  ReadFailOnErrorInput & {
+    network: string;
+    address: string;
+  };
 
 export type CheckTokenBalanceInput = StepInput & CheckTokenBalanceCoreInput;
 
@@ -108,7 +116,8 @@ async function checkEvmTokenBalance(
   address: string,
   tokenAddress: string,
   chainId: number,
-  userId: string | undefined
+  userId: string | undefined,
+  failOnError: unknown
 ): Promise<CheckTokenBalanceResult> {
   let rpcManager: RpcProviderManager;
   try {
@@ -161,10 +170,17 @@ async function checkEvmTokenBalance(
         chain_id: String(chainId),
       }
     );
-    return {
-      success: false,
-      error: `Failed to check token balance: ${getErrorMessage(error)}`,
-    };
+    const message = `Failed to check token balance: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(failOnError, message);
+    if (soft) {
+      return {
+        ...soft,
+        balance: null,
+        address,
+        addressLink: await adapter.getAddressUrl(address),
+      };
+    }
+    return { success: false, error: message };
   }
 }
 
@@ -270,7 +286,13 @@ async function stepHandler(
     };
   }
 
-  return checkEvmTokenBalance(address, tokenAddress, chainId, userId);
+  return checkEvmTokenBalance(
+    address,
+    tokenAddress,
+    chainId,
+    userId,
+    input.failOnError
+  );
 }
 
 /**

--- a/plugins/web3/steps/check-token-balance.ts
+++ b/plugins/web3/steps/check-token-balance.ts
@@ -13,8 +13,9 @@ import { getErrorMessage } from "@/lib/utils";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 import {
   getTokenAddress,
@@ -33,7 +34,7 @@ type CheckTokenBalanceResult =
       addressLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 export type CheckTokenBalanceCoreInput = TokenConfigSource &
   ReadFailOnErrorInput & {
@@ -116,8 +117,7 @@ async function checkEvmTokenBalance(
   address: string,
   tokenAddress: string,
   chainId: number,
-  userId: string | undefined,
-  failOnError: unknown
+  userId: string | undefined
 ): Promise<CheckTokenBalanceResult> {
   let rpcManager: RpcProviderManager;
   try {
@@ -135,6 +135,7 @@ async function checkEvmTokenBalance(
     );
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }
@@ -171,15 +172,6 @@ async function checkEvmTokenBalance(
       }
     );
     const message = `Failed to check token balance: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(failOnError, message);
-    if (soft) {
-      return {
-        ...soft,
-        balance: null,
-        address,
-        addressLink: await adapter.getAddressUrl(address),
-      };
-    }
     return { success: false, error: message };
   }
 }
@@ -225,6 +217,7 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }
@@ -232,6 +225,7 @@ async function stepHandler(
   if (isSolanaChain(chainId)) {
     return {
       success: false,
+      destinationError: true,
       error:
         "Solana chains are not supported by this action. Use the Get SPL Token Balance action for SPL tokens.",
     };
@@ -250,6 +244,7 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: `Invalid wallet address: ${address}`,
     };
   }
@@ -282,24 +277,18 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: `Invalid token address: ${tokenAddress}`,
     };
   }
 
-  return checkEvmTokenBalance(
-    address,
-    tokenAddress,
-    chainId,
-    userId,
-    input.failOnError
-  );
+  return checkEvmTokenBalance(address, tokenAddress, chainId, userId);
 }
 
 /**
  * Check Token Balance Step
  * Checks the ERC20 token balance of an address for a single token
  */
-// biome-ignore lint/suspicious/useAwait: "use step" directive requires async
 export async function checkTokenBalanceStep(
   input: CheckTokenBalanceInput
 ): Promise<CheckTokenBalanceResult> {
@@ -308,7 +297,12 @@ export async function checkTokenBalanceStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "check-token-balance" },
     input,
-    stepHandler
+    async (i) =>
+      applyReadFailOnError(await stepHandler(i), i.failOnError, {
+        balance: null,
+        address: i.address,
+        addressLink: "",
+      })
   );
 }
 

--- a/plugins/web3/steps/get-spl-token-balance.ts
+++ b/plugins/web3/steps/get-spl-token-balance.ts
@@ -21,6 +21,10 @@ import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
+import {
   getTokenAddress,
   parseTokenConfig,
   type TokenBalanceInfo,
@@ -45,19 +49,23 @@ const MAX_METADATA_SYMBOL_LENGTH = 10;
 const DISALLOWED_METADATA_CHARS =
   /[\u0000-\u001f\u007f-\u009f\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]/g;
 
-export type GetSplTokenBalanceCoreInput = TokenConfigSource & {
-  network: string;
-  address: string;
-};
+export type GetSplTokenBalanceCoreInput = TokenConfigSource &
+  ReadFailOnErrorInput & {
+    network: string;
+    address: string;
+  };
 
 export type GetSplTokenBalanceInput = StepInput & GetSplTokenBalanceCoreInput;
 
 type GetSplTokenBalanceResult =
   | {
       success: true;
-      balance: TokenBalanceInfo;
+      // Null when failOnError=false softened a failed read into a success
+      // value so the workflow continues; `error` carries the reason.
+      balance: TokenBalanceInfo | null;
       address: string;
       addressLink: string;
+      error?: string;
     }
   | { success: false; error: string };
 
@@ -357,10 +365,17 @@ async function stepHandler(
         chain_id: String(chainId),
       }
     );
-    return {
-      success: false,
-      error: `Failed to check token balance: ${getErrorMessage(error)}`,
-    };
+    const message = `Failed to check token balance: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return {
+        ...soft,
+        balance: null,
+        address,
+        addressLink: await adapter.getAddressUrl(address),
+      };
+    }
+    return { success: false, error: message };
   }
 }
 

--- a/plugins/web3/steps/get-spl-token-balance.ts
+++ b/plugins/web3/steps/get-spl-token-balance.ts
@@ -21,8 +21,9 @@ import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 import { parseSolanaMintAccount } from "@/lib/web3/solana-mint";
 import { validateChainAddress } from "@/lib/web3/validate-chain-address";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 import {
   getTokenAddress,
@@ -67,7 +68,7 @@ type GetSplTokenBalanceResult =
       addressLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 /**
  * Read a borsh string (u32 LE length prefix + utf8 bytes) at offset,
@@ -263,6 +264,7 @@ async function stepHandler(
     );
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }
@@ -366,15 +368,6 @@ async function stepHandler(
       }
     );
     const message = `Failed to check token balance: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return {
-        ...soft,
-        balance: null,
-        address,
-        addressLink: await adapter.getAddressUrl(address),
-      };
-    }
     return { success: false, error: message };
   }
 }
@@ -391,7 +384,12 @@ export async function getSplTokenBalanceStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "get-spl-token-balance" },
     input,
-    stepHandler
+    async (i) =>
+      applyReadFailOnError(await stepHandler(i), i.failOnError, {
+        balance: null,
+        address: i.address,
+        addressLink: "",
+      })
   );
 }
 

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -20,8 +20,9 @@ import { getErrorMessage } from "@/lib/utils";
 import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 /**
@@ -65,7 +66,7 @@ type GetTransactionResult =
       toLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 /** Data fields a softened lookup reports, so a soft failure never looks like a real transaction. */
 const SOFT_TRANSACTION_FIELDS = {
@@ -95,8 +96,7 @@ export type GetTransactionInput = StepInput & GetTransactionCoreInput;
 async function fetchEvmTransaction(
   hash: string,
   chainId: number,
-  userId: string | undefined,
-  failOnError: unknown
+  userId: string | undefined
 ): Promise<GetTransactionResult> {
   let rpcManager: RpcProviderManager;
   try {
@@ -111,10 +111,7 @@ async function fetchEvmTransaction(
 
   if (!tx) {
     const message = `Transaction not found: ${hash}`;
-    const soft = softenReadFailure(failOnError, message);
-    return soft
-      ? { ...soft, ...SOFT_TRANSACTION_FIELDS }
-      : { success: false, error: message };
+    return { success: false, error: message };
   }
 
   const explorerConfig = await db.query.explorerConfigs.findFirst({
@@ -154,8 +151,7 @@ async function fetchEvmTransaction(
 async function fetchSolanaTransaction(
   hash: string,
   chainId: number,
-  userId: string | undefined,
-  failOnError: unknown
+  userId: string | undefined
 ): Promise<GetTransactionResult> {
   const adapter = new SolanaChainAdapter(chainId, () =>
     getSolanaProvider({ chainId, userId })
@@ -169,10 +165,7 @@ async function fetchSolanaTransaction(
 
   if (!tx) {
     const message = `Transaction not found: ${hash}`;
-    const soft = softenReadFailure(failOnError, message);
-    return soft
-      ? { ...soft, ...SOFT_TRANSACTION_FIELDS }
-      : { success: false, error: message };
+    return { success: false, error: message };
   }
 
   const feePayer = getSolanaFeePayer(tx);
@@ -212,7 +205,7 @@ async function fetchSolanaTransaction(
 async function stepHandler(
   input: GetTransactionInput
 ): Promise<GetTransactionResult> {
-  const { network, transactionHash, failOnError, _context } = input;
+  const { network, transactionHash, _context } = input;
 
   if (!transactionHash?.trim()) {
     return {
@@ -238,6 +231,7 @@ async function stepHandler(
   if (!validateChainTxHash(hash, chainId)) {
     return {
       success: false,
+      destinationError: true,
       error: `Invalid transaction hash format: ${hash}`,
     };
   }
@@ -246,14 +240,10 @@ async function stepHandler(
 
   try {
     return isSolanaChain(chainId)
-      ? await fetchSolanaTransaction(hash, chainId, userId, failOnError)
-      : await fetchEvmTransaction(hash, chainId, userId, failOnError);
+      ? await fetchSolanaTransaction(hash, chainId, userId)
+      : await fetchEvmTransaction(hash, chainId, userId);
   } catch (error) {
     const message = `Failed to fetch transaction: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(failOnError, message);
-    if (soft) {
-      return { ...soft, ...SOFT_TRANSACTION_FIELDS };
-    }
     return { success: false, error: message };
   }
 }
@@ -279,7 +269,12 @@ export async function getTransactionStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "get-transaction" },
     enrichedInput,
-    () => stepHandler(input)
+    async () =>
+      applyReadFailOnError(
+        await stepHandler(input),
+        input.failOnError,
+        SOFT_TRANSACTION_FIELDS
+      )
   );
 }
 

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -102,7 +102,11 @@ async function fetchEvmTransaction(
   try {
     rpcManager = await getRpcProvider({ chainId, userId });
   } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+    };
   }
 
   const tx = await rpcManager.executeWithFailover(async (provider) =>
@@ -224,6 +228,7 @@ async function stepHandler(
   } catch (error) {
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }

--- a/plugins/web3/steps/get-transaction.ts
+++ b/plugins/web3/steps/get-transaction.ts
@@ -19,6 +19,10 @@ import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-hand
 import { getErrorMessage } from "@/lib/utils";
 import { SolanaChainAdapter } from "@/lib/web3/chain-adapter/solana";
 import { validateChainTxHash } from "@/lib/web3/validate-chain-address";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
 /**
  * Index 0 of a transaction's account keys is always the fee payer - the
@@ -40,13 +44,16 @@ function getSolanaFeePayer(tx: VersionedTransactionResponse): string {
 type GetTransactionResult =
   | {
       success: true;
-      hash: string;
-      from: string;
+      // Every field below is null when failOnError=false softened a failed
+      // lookup into a success value so the workflow continues; `error`
+      // carries the reason.
+      hash: string | null;
+      from: string | null;
       to: string | null;
-      value: string;
-      input: string;
-      nonce: number;
-      gasLimit: string;
+      value: string | null;
+      input: string | null;
+      nonce: number | null;
+      gasLimit: string | null;
       // Solana only: actual compute units consumed. Not comparable to
       // gasLimit (an EVM ceiling the transaction was allowed to spend, not
       // what it used), so it is reported as its own field rather than
@@ -56,10 +63,26 @@ type GetTransactionResult =
       transactionLink: string;
       fromLink: string;
       toLink: string;
+      error?: string;
     }
   | { success: false; error: string };
 
-export type GetTransactionCoreInput = {
+/** Data fields a softened lookup reports, so a soft failure never looks like a real transaction. */
+const SOFT_TRANSACTION_FIELDS = {
+  hash: null,
+  from: null,
+  to: null,
+  value: null,
+  input: null,
+  nonce: null,
+  gasLimit: null,
+  blockNumber: null,
+  transactionLink: "",
+  fromLink: "",
+  toLink: "",
+} as const;
+
+export type GetTransactionCoreInput = ReadFailOnErrorInput & {
   network: string;
   transactionHash: string;
 };
@@ -72,7 +95,8 @@ export type GetTransactionInput = StepInput & GetTransactionCoreInput;
 async function fetchEvmTransaction(
   hash: string,
   chainId: number,
-  userId: string | undefined
+  userId: string | undefined,
+  failOnError: unknown
 ): Promise<GetTransactionResult> {
   let rpcManager: RpcProviderManager;
   try {
@@ -86,7 +110,11 @@ async function fetchEvmTransaction(
   );
 
   if (!tx) {
-    return { success: false, error: `Transaction not found: ${hash}` };
+    const message = `Transaction not found: ${hash}`;
+    const soft = softenReadFailure(failOnError, message);
+    return soft
+      ? { ...soft, ...SOFT_TRANSACTION_FIELDS }
+      : { success: false, error: message };
   }
 
   const explorerConfig = await db.query.explorerConfigs.findFirst({
@@ -126,7 +154,8 @@ async function fetchEvmTransaction(
 async function fetchSolanaTransaction(
   hash: string,
   chainId: number,
-  userId: string | undefined
+  userId: string | undefined,
+  failOnError: unknown
 ): Promise<GetTransactionResult> {
   const adapter = new SolanaChainAdapter(chainId, () =>
     getSolanaProvider({ chainId, userId })
@@ -139,7 +168,11 @@ async function fetchSolanaTransaction(
   );
 
   if (!tx) {
-    return { success: false, error: `Transaction not found: ${hash}` };
+    const message = `Transaction not found: ${hash}`;
+    const soft = softenReadFailure(failOnError, message);
+    return soft
+      ? { ...soft, ...SOFT_TRANSACTION_FIELDS }
+      : { success: false, error: message };
   }
 
   const feePayer = getSolanaFeePayer(tx);
@@ -179,7 +212,7 @@ async function fetchSolanaTransaction(
 async function stepHandler(
   input: GetTransactionInput
 ): Promise<GetTransactionResult> {
-  const { network, transactionHash, _context } = input;
+  const { network, transactionHash, failOnError, _context } = input;
 
   if (!transactionHash?.trim()) {
     return {
@@ -213,13 +246,15 @@ async function stepHandler(
 
   try {
     return isSolanaChain(chainId)
-      ? await fetchSolanaTransaction(hash, chainId, userId)
-      : await fetchEvmTransaction(hash, chainId, userId);
+      ? await fetchSolanaTransaction(hash, chainId, userId, failOnError)
+      : await fetchEvmTransaction(hash, chainId, userId, failOnError);
   } catch (error) {
-    return {
-      success: false,
-      error: `Failed to fetch transaction: ${getErrorMessage(error)}`,
-    };
+    const message = `Failed to fetch transaction: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(failOnError, message);
+    if (soft) {
+      return { ...soft, ...SOFT_TRANSACTION_FIELDS };
+    }
+    return { success: false, error: message };
   }
 }
 

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -18,6 +18,10 @@ import {
   isNearHeadBatch,
   queryBatchWithRetry,
 } from "./query-events-core";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
 const DEFAULT_BATCH_SIZE = 2000;
 
@@ -31,14 +35,27 @@ type DecodedEvent = {
 type QueryEventsResult =
   | {
       success: true;
-      events: DecodedEvent[];
-      fromBlock: number;
-      toBlock: number;
-      eventCount: number;
+      // Null when failOnError=false softened a failed query into a success
+      // value so the workflow continues; `error` carries the reason. Null
+      // rather than an empty list so a downstream node cannot read a failed
+      // query as "no events in range".
+      events: DecodedEvent[] | null;
+      fromBlock: number | null;
+      toBlock: number | null;
+      eventCount: number | null;
+      error?: string;
     }
   | { success: false; error: string };
 
-export type QueryEventsCoreInput = {
+/** Data fields a softened query reports, so a soft failure never looks like an empty result set. */
+const SOFT_QUERY_FIELDS = {
+  events: null,
+  fromBlock: null,
+  toBlock: null,
+  eventCount: null,
+} as const;
+
+export type QueryEventsCoreInput = ReadFailOnErrorInput & {
   network: string;
   contractAddress: string;
   abi: string;
@@ -234,6 +251,10 @@ async function stepHandler(
       )
   );
   if (!blockRangeResult.success) {
+    const soft = softenReadFailure(input.failOnError, blockRangeResult.error);
+    if (soft) {
+      return { ...soft, ...SOFT_QUERY_FIELDS };
+    }
     return { success: false, error: blockRangeResult.error };
   }
   const { range } = blockRangeResult;
@@ -273,10 +294,12 @@ async function stepHandler(
       eventCount: events.length,
     };
   } catch (error) {
-    return {
-      success: false,
-      error: `Event query failed: ${getErrorMessage(error)}`,
-    };
+    const message = `Event query failed: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return { ...soft, ...SOFT_QUERY_FIELDS };
+    }
+    return { success: false, error: message };
   }
 }
 

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -190,7 +190,11 @@ async function stepHandler(
   try {
     chainId = getChainIdFromNetwork(network);
   } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+    };
   }
 
   // Event querying decodes EVM ABI logs, which have no Solana equivalent
@@ -238,6 +242,7 @@ async function stepHandler(
   } catch (error) {
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }

--- a/plugins/web3/steps/query-events.ts
+++ b/plugins/web3/steps/query-events.ts
@@ -19,8 +19,9 @@ import {
   queryBatchWithRetry,
 } from "./query-events-core";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 const DEFAULT_BATCH_SIZE = 2000;
@@ -45,7 +46,7 @@ type QueryEventsResult =
       eventCount: number | null;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 /** Data fields a softened query reports, so a soft failure never looks like an empty result set. */
 const SOFT_QUERY_FIELDS = {
@@ -202,6 +203,7 @@ async function stepHandler(
   if (!ethers.isAddress(contractAddress)) {
     return {
       success: false,
+      destinationError: true,
       error: `Invalid contract address: ${contractAddress}`,
     };
   }
@@ -251,10 +253,6 @@ async function stepHandler(
       )
   );
   if (!blockRangeResult.success) {
-    const soft = softenReadFailure(input.failOnError, blockRangeResult.error);
-    if (soft) {
-      return { ...soft, ...SOFT_QUERY_FIELDS };
-    }
     return { success: false, error: blockRangeResult.error };
   }
   const { range } = blockRangeResult;
@@ -295,10 +293,6 @@ async function stepHandler(
     };
   } catch (error) {
     const message = `Event query failed: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return { ...soft, ...SOFT_QUERY_FIELDS };
-    }
     return { success: false, error: message };
   }
 }
@@ -318,7 +312,12 @@ export async function queryEventsStep(
   return runPluginStep(
     { pluginName: "web3", actionName: "query-events" },
     enrichedInput,
-    () => stepHandler(input)
+    async () =>
+      applyReadFailOnError(
+        await stepHandler(input),
+        input.failOnError,
+        SOFT_QUERY_FIELDS
+      )
   );
 }
 

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -12,8 +12,9 @@ import { getSolanaProvider } from "@/lib/rpc/provider-factory";
 import type { SolanaProviderManager } from "@/lib/rpc/providers/solana";
 import { getErrorMessage } from "@/lib/utils";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 import {
   type AnchorEventDecoder,
@@ -78,7 +79,7 @@ export type QuerySolanaProgramEventsResult =
       otherEventNamesSeen: string[] | null;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 /** Data fields a softened query reports, so a soft failure never looks like an empty result set. */
 const SOFT_QUERY_FIELDS = {
@@ -164,12 +165,18 @@ type ResolvedQuery = {
 
 function resolveQueryContext(
   input: QuerySolanaProgramEventsCoreInput
-): { success: true; value: ResolvedQuery } | { success: false; error: string } {
+):
+  | { success: true; value: ResolvedQuery }
+  | (ReadDestinationFailure & { success: false; error: string }) {
   let programKey: PublicKey;
   try {
     programKey = new PublicKey(input.programId);
   } catch {
-    return { success: false, error: `Invalid program ID: ${input.programId}` };
+    return {
+      success: false,
+      destinationError: true,
+      error: `Invalid program ID: ${input.programId}`,
+    };
   }
 
   const beforeCheck = validateSignatureCursor(
@@ -426,9 +433,19 @@ async function mapWithConcurrency<T, R>(
 export async function queryProgramEventsCore(
   input: QuerySolanaProgramEventsCoreInput
 ): Promise<QuerySolanaProgramEventsResult> {
+  return applyReadFailOnError(
+    await queryProgramEventsInner(input),
+    input.failOnError,
+    SOFT_QUERY_FIELDS
+  );
+}
+
+async function queryProgramEventsInner(
+  input: QuerySolanaProgramEventsCoreInput
+): Promise<QuerySolanaProgramEventsResult> {
   const resolved = resolveQueryContext(input);
   if (!resolved.success) {
-    return { success: false, error: resolved.error };
+    return resolved;
   }
   const { programKey, decoder, lookback, chainId } = resolved.value;
   const eventName = input.eventName;
@@ -456,10 +473,6 @@ export async function queryProgramEventsCore(
     truncated = page.truncated;
   } catch (error) {
     const message = `Signature lookup failed: ${getErrorMessage(error)}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return { ...soft, ...SOFT_QUERY_FIELDS };
-    }
     return { success: false, error: message };
   }
 

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -12,6 +12,10 @@ import { getSolanaProvider } from "@/lib/rpc/provider-factory";
 import type { SolanaProviderManager } from "@/lib/rpc/providers/solana";
 import { getErrorMessage } from "@/lib/utils";
 import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
+import {
   type AnchorEventDecoder,
   createEventDecoder,
 } from "@/lib/web3/anchor-events";
@@ -34,7 +38,7 @@ export const NULL_TX_RETRY_DELAY_MS = 1000;
 const INTEGER_STRING_RE = /^\d+$/;
 const BASE58_SIGNATURE_RE = /^[1-9A-HJ-NP-Za-km-z]{64,90}$/;
 
-export type QuerySolanaProgramEventsCoreInput = {
+export type QuerySolanaProgramEventsCoreInput = ReadFailOnErrorInput & {
   network: string;
   programId: string;
   idl?: string;
@@ -59,17 +63,35 @@ export type SolanaProgramEvent = {
 export type QuerySolanaProgramEventsResult =
   | {
       success: true;
-      events: SolanaProgramEvent[];
+      // Null when failOnError=false softened a failed query into a success
+      // value so the workflow continues; `error` carries the reason. Null
+      // rather than an empty list so a downstream node cannot read a failed
+      // query as "no events in range".
+      events: SolanaProgramEvent[] | null;
       oldestSignature: string | null;
       newestSignature: string | null;
-      signatureCount: number;
-      eventCount: number;
-      truncated: boolean;
+      signatureCount: number | null;
+      eventCount: number | null;
+      truncated: boolean | null;
       nextBeforeSignature: string | null;
-      failedSignatureCount: number;
-      otherEventNamesSeen: string[];
+      failedSignatureCount: number | null;
+      otherEventNamesSeen: string[] | null;
+      error?: string;
     }
   | { success: false; error: string };
+
+/** Data fields a softened query reports, so a soft failure never looks like an empty result set. */
+const SOFT_QUERY_FIELDS = {
+  events: null,
+  oldestSignature: null,
+  newestSignature: null,
+  signatureCount: null,
+  eventCount: null,
+  truncated: null,
+  nextBeforeSignature: null,
+  failedSignatureCount: null,
+  otherEventNamesSeen: null,
+} as const;
 
 function parseSignatureLookback(
   input: number | string | undefined
@@ -433,10 +455,12 @@ export async function queryProgramEventsCore(
     signatures = page.signatures;
     truncated = page.truncated;
   } catch (error) {
-    return {
-      success: false,
-      error: `Signature lookup failed: ${getErrorMessage(error)}`,
-    };
+    const message = `Signature lookup failed: ${getErrorMessage(error)}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return { ...soft, ...SOFT_QUERY_FIELDS };
+    }
+    return { success: false, error: message };
   }
 
   if (signatures.length === 0) {

--- a/plugins/web3/steps/query-solana-program-events-core.ts
+++ b/plugins/web3/steps/query-solana-program-events-core.ts
@@ -217,7 +217,11 @@ function resolveQueryContext(
   try {
     chainId = getChainIdFromNetwork(input.network);
   } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+    };
   }
 
   return {
@@ -456,7 +460,11 @@ async function queryProgramEventsInner(
   try {
     rpcManager = await getSolanaProvider({ chainId, userId });
   } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+    };
   }
 
   let signatures: ConfirmedSignatureInfo[];

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -20,8 +20,9 @@ import { evmOnlyGuard } from "@/lib/web3/validate-chain-address";
 import { getErrorMessage } from "@/lib/utils";
 import { resolveBlockRange } from "./block-range-helpers";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
@@ -56,7 +57,7 @@ export type QueryTransactionsResult =
       contractAddressLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 export type QueryTransactionsCoreInput = ReadFailOnErrorInput & {
   network: string;
@@ -251,7 +252,9 @@ type ValidatedInput = {
 
 function validateInputs(
   input: QueryTransactionsCoreInput
-): { success: true; data: ValidatedInput } | { success: false; error: string } {
+):
+  | { success: true; data: ValidatedInput }
+  | (ReadDestinationFailure & { success: false; error: string }) {
   const { contractAddress, abi, abiFunction } = input;
 
   // Resolve the chain first so the address check and the Solana guard below
@@ -273,6 +276,7 @@ function validateInputs(
   if (!ethers.isAddress(contractAddress)) {
     return {
       success: false,
+      destinationError: true,
       error: `Invalid contract address: ${contractAddress}`,
     };
   }
@@ -309,9 +313,19 @@ const SOFT_QUERY_FIELDS = {
 export async function queryTransactionsCore(
   input: QueryTransactionsCoreInput
 ): Promise<QueryTransactionsResult> {
+  return applyReadFailOnError(
+    await queryTransactionsInner(input),
+    input.failOnError,
+    { ...SOFT_QUERY_FIELDS, contractAddressLink: "" }
+  );
+}
+
+async function queryTransactionsInner(
+  input: QueryTransactionsCoreInput
+): Promise<QueryTransactionsResult> {
   const validation = validateInputs(input);
   if (!validation.success) {
-    return { success: false, error: validation.error };
+    return validation;
   }
 
   const { iface, functionFragment, chainId } = validation.data;
@@ -338,10 +352,6 @@ export async function queryTransactionsCore(
       )
   );
   if (!blockRangeResult.success) {
-    const soft = softenReadFailure(input.failOnError, blockRangeResult.error);
-    if (soft) {
-      return { ...soft, ...SOFT_QUERY_FIELDS, contractAddressLink: "" };
-    }
     return { success: false, error: blockRangeResult.error };
   }
   const { range } = blockRangeResult;
@@ -384,10 +394,6 @@ export async function queryTransactionsCore(
   );
 
   if (!txResult.success) {
-    const soft = softenReadFailure(input.failOnError, txResult.error);
-    if (soft) {
-      return { ...soft, ...SOFT_QUERY_FIELDS, contractAddressLink };
-    }
     return { success: false, error: txResult.error };
   }
 

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -19,6 +19,10 @@ import { serializeArg } from "@/lib/web3/serialize-arg";
 import { evmOnlyGuard } from "@/lib/web3/validate-chain-address";
 import { getErrorMessage } from "@/lib/utils";
 import { resolveBlockRange } from "./block-range-helpers";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
 
@@ -40,16 +44,21 @@ export type DecodedTransaction = {
 export type QueryTransactionsResult =
   | {
       success: true;
-      transactions: DecodedTransaction[];
-      fromBlock: number;
-      toBlock: number;
-      totalFetched: number;
-      matchCount: number;
+      // Null when failOnError=false softened a failed query into a success
+      // value so the workflow continues; `error` carries the reason. Null
+      // rather than an empty list so a downstream node cannot read a failed
+      // query as "no matching transactions".
+      transactions: DecodedTransaction[] | null;
+      fromBlock: number | null;
+      toBlock: number | null;
+      totalFetched: number | null;
+      matchCount: number | null;
       contractAddressLink: string;
+      error?: string;
     }
   | { success: false; error: string };
 
-export type QueryTransactionsCoreInput = {
+export type QueryTransactionsCoreInput = ReadFailOnErrorInput & {
   network: string;
   contractAddress: string;
   abi: string;
@@ -288,6 +297,15 @@ function validateInputs(
   };
 }
 
+/** Data fields a softened query reports, so a soft failure never looks like an empty result set. */
+const SOFT_QUERY_FIELDS = {
+  transactions: null,
+  fromBlock: null,
+  toBlock: null,
+  totalFetched: null,
+  matchCount: null,
+} as const;
+
 export async function queryTransactionsCore(
   input: QueryTransactionsCoreInput
 ): Promise<QueryTransactionsResult> {
@@ -320,6 +338,10 @@ export async function queryTransactionsCore(
       )
   );
   if (!blockRangeResult.success) {
+    const soft = softenReadFailure(input.failOnError, blockRangeResult.error);
+    if (soft) {
+      return { ...soft, ...SOFT_QUERY_FIELDS, contractAddressLink: "" };
+    }
     return { success: false, error: blockRangeResult.error };
   }
   const { range } = blockRangeResult;
@@ -362,6 +384,10 @@ export async function queryTransactionsCore(
   );
 
   if (!txResult.success) {
+    const soft = softenReadFailure(input.failOnError, txResult.error);
+    if (soft) {
+      return { ...soft, ...SOFT_QUERY_FIELDS, contractAddressLink };
+    }
     return { success: false, error: txResult.error };
   }
 

--- a/plugins/web3/steps/query-transactions-core.ts
+++ b/plugins/web3/steps/query-transactions-core.ts
@@ -263,7 +263,11 @@ function validateInputs(
   try {
     chainId = getChainIdFromNetwork(input.network);
   } catch (error) {
-    return { success: false, error: getErrorMessage(error) };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+    };
   }
 
   // Transaction querying decodes calls via an EVM ABI function selector,
@@ -338,6 +342,7 @@ async function queryTransactionsInner(
   } catch (error) {
     return {
       success: false,
+      destinationError: true,
       error: getErrorMessage(error),
     };
   }
@@ -363,6 +368,7 @@ async function queryTransactionsInner(
   if (!explorerConfig) {
     return {
       success: false,
+      destinationError: true,
       error: `No explorer configuration found for chain ${chainId}`,
     };
   }

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -20,7 +20,10 @@ import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
-import { softenReadFailure } from "@/plugins/web3/steps/read-fail-on-error-core";
+import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
+} from "@/plugins/web3/steps/read-fail-on-error-core";
 import {
   type AbiOutputParam,
   structureAbiOutputs,
@@ -32,8 +35,8 @@ export type ReadContractCoreInput = {
   abi: string;
   abiFunction: string;
   functionArgs?: string;
-  // See softenReadFailure in read-fail-on-error-core.ts for which failures
-  // this covers.
+  // See applyReadFailOnError in read-fail-on-error-core.ts. When false, no
+  // failure of this step fails the run.
   failOnError?: boolean;
   _context?: { executionId?: string; organizationId?: string };
 };
@@ -48,15 +51,31 @@ export type ReadContractResult =
       // `result` is null when it is set.
       error?: string;
     }
-  | { success: false; error: string; errorClass?: ExecutionErrorType };
+  | (ReadDestinationFailure & {
+      success: false;
+      error: string;
+      errorClass?: ExecutionErrorType;
+    });
 
 /**
  * Core read contract logic
  *
  * Shared between the web3 read-contract step and the future protocol-read step.
+ * Every failure exit runs through applyReadFailOnError, so the toggle covers
+ * the validation exits above the chain call as well as the call itself.
  */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Contract interaction requires extensive validation
 export async function readContractCore(
+  input: ReadContractCoreInput
+): Promise<ReadContractResult> {
+  return applyReadFailOnError(
+    await readContractInner(input),
+    input.failOnError,
+    { result: null, addressLink: "" }
+  );
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Contract interaction requires extensive validation
+async function readContractInner(
   input: ReadContractCoreInput
 ): Promise<ReadContractResult> {
   const { contractAddress, network, abi, abiFunction, functionArgs, _context } =
@@ -90,6 +109,7 @@ export async function readContractCore(
     );
     return {
       success: false,
+      destinationError: true,
       error: `Invalid contract address: ${contractAddress}`,
       errorClass: ExecutionErrorType.USER,
     };
@@ -201,7 +221,12 @@ export async function readContractCore(
       error,
       { plugin_name: "web3", action_name: "read-contract" }
     );
-    return { success: false, error: getErrorMessage(error), errorClass: ExecutionErrorType.USER };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+      errorClass: ExecutionErrorType.USER,
+    };
   }
 
   // Resolve RPC provider
@@ -219,7 +244,12 @@ export async function readContractCore(
         chain_id: String(chainId),
       }
     );
-    return { success: false, error: getErrorMessage(error), errorClass: ExecutionErrorType.SYSTEM };
+    return {
+      success: false,
+      destinationError: true,
+      error: getErrorMessage(error),
+      errorClass: ExecutionErrorType.SYSTEM,
+    };
   }
 
   const contractInterface = new ethers.Interface(
@@ -289,14 +319,6 @@ export async function readContractCore(
       }
     );
     const message = formatContractError(error, contractInterface);
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return {
-        ...soft,
-        result: null,
-        addressLink: await adapter.getAddressUrl(contractAddress),
-      };
-    }
     return {
       success: false,
       error: message,

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -15,8 +15,9 @@ import { validateArgsForAbi } from "@/lib/abi/validate-args";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
+import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { findAbiFunction } from "@/lib/abi/utils";
-import { getErrorMessage } from "@/lib/utils";
+import { getErrorMessage, resolveFailOnError } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
@@ -31,11 +32,27 @@ export type ReadContractCoreInput = {
   abi: string;
   abiFunction: string;
   functionArgs?: string;
+  // Mirrors HTTP Request's failOnError. Defaults to true. When false, a failed
+  // read attempt (RPC transport error, revert) is softened into a success
+  // carrying `error` instead of failing the step, so one bad call inside a For
+  // Each loop does not abort the run. Only the read attempt itself is
+  // softened: config problems (bad ABI/args/address/network, unresolved RPC)
+  // would recur on every run, so they hard-fail regardless of this flag,
+  // mirroring HTTP Request's SSRF/malformed-URL carve-out.
+  failOnError?: boolean;
   _context?: { executionId?: string; organizationId?: string };
 };
 
 export type ReadContractResult =
-  | { success: true; result: unknown; addressLink: string }
+  | {
+      success: true;
+      result: unknown;
+      addressLink: string;
+      // Present only when failOnError=false softened a failed read into a
+      // success value so the workflow continues. Absent on a genuine read;
+      // `result` is null when it is set.
+      error?: string;
+    }
   | { success: false; error: string; errorClass?: ExecutionErrorType };
 
 /**
@@ -276,9 +293,22 @@ export async function readContractCore(
         chain_id: String(chainId),
       }
     );
+    const message = formatContractError(error, contractInterface);
+    if (!resolveFailOnError(input.failOnError)) {
+      // Soft-fail: hand the error to the next node instead of failing the
+      // step. Every web3 URL is an RPC provider endpoint, and withStepLogging
+      // only redacts the success:false branch, so the redaction that a hard
+      // failure would get downstream has to happen here.
+      return {
+        success: true,
+        result: null,
+        addressLink: await adapter.getAddressUrl(contractAddress),
+        error: redactAllUrls(message),
+      };
+    }
     return {
       success: false,
-      error: formatContractError(error, contractInterface),
+      error: message,
       errorClass: ExecutionErrorType.USER,
     };
   }

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -15,12 +15,12 @@ import { validateArgsForAbi } from "@/lib/abi/validate-args";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";
-import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
 import { findAbiFunction } from "@/lib/abi/utils";
-import { getErrorMessage, resolveFailOnError } from "@/lib/utils";
+import { getErrorMessage } from "@/lib/utils";
 import { getAbiFunctionKey } from "@/lib/abi/function-key";
 import { getChainAdapter } from "@/lib/web3/chain-adapter";
 import { formatContractError } from "@/lib/web3/decode-revert-error";
+import { softenReadFailure } from "@/plugins/web3/steps/read-fail-on-error-core";
 import {
   type AbiOutputParam,
   structureAbiOutputs,
@@ -32,13 +32,8 @@ export type ReadContractCoreInput = {
   abi: string;
   abiFunction: string;
   functionArgs?: string;
-  // Mirrors HTTP Request's failOnError. Defaults to true. When false, a failed
-  // read attempt (RPC transport error, revert) is softened into a success
-  // carrying `error` instead of failing the step, so one bad call inside a For
-  // Each loop does not abort the run. Only the read attempt itself is
-  // softened: config problems (bad ABI/args/address/network, unresolved RPC)
-  // would recur on every run, so they hard-fail regardless of this flag,
-  // mirroring HTTP Request's SSRF/malformed-URL carve-out.
+  // See softenReadFailure in read-fail-on-error-core.ts for which failures
+  // this covers.
   failOnError?: boolean;
   _context?: { executionId?: string; organizationId?: string };
 };
@@ -294,16 +289,12 @@ export async function readContractCore(
       }
     );
     const message = formatContractError(error, contractInterface);
-    if (!resolveFailOnError(input.failOnError)) {
-      // Soft-fail: hand the error to the next node instead of failing the
-      // step. Every web3 URL is an RPC provider endpoint, and withStepLogging
-      // only redacts the success:false branch, so the redaction that a hard
-      // failure would get downstream has to happen here.
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
       return {
-        success: true,
+        ...soft,
         result: null,
         addressLink: await adapter.getAddressUrl(contractAddress),
-        error: redactAllUrls(message),
       };
     }
     return {

--- a/plugins/web3/steps/read-fail-on-error-core.ts
+++ b/plugins/web3/steps/read-fail-on-error-core.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared "Fail workflow on error" handling for the web3 read steps.
+ *
+ * IMPORTANT: This file must NOT contain "use step" or be a step file.
+ * It exists so that multiple step files can reuse the soft-fail decision
+ * without exporting functions from "use step" files (which breaks the
+ * workflow bundler).
+ */
+import "server-only";
+import { redactAllUrls } from "@/lib/rpc/scrub-rpc-urls";
+import { resolveFailOnError } from "@/lib/utils";
+
+/** The `failOnError` config field carried by every web3 read action. */
+export type ReadFailOnErrorInput = {
+  // Mirrors HTTP Request's failOnError. Defaults to true. See
+  // softenReadFailure below for which failures the toggle covers.
+  failOnError?: boolean;
+};
+
+/**
+ * The payload a read step returns in place of its `success: false` when the
+ * author turned "Fail workflow on error" off: the next node receives the
+ * error and decides what to do, instead of the run aborting on a transient
+ * miss. Callers spread it over their own success shape with the data fields
+ * set to null, so a downstream node can tell a soft failure apart from a real
+ * read by checking `error`. Returns undefined when the toggle is on, so the
+ * caller falls through to its hard failure.
+ *
+ * Only the on-chain read attempt is eligible. Config problems (bad address or
+ * ABI, unknown network, unresolved RPC, no token selected) recur on every
+ * execution, so callers hard-fail those regardless of the toggle; softening
+ * them would let a broken node run forever without the author noticing. This
+ * mirrors HTTP Request's SSRF and malformed-URL carve-out.
+ *
+ * The message is redacted here because every web3 URL is an RPC provider
+ * endpoint, and withStepLogging only redacts the `success: false` branch (see
+ * redactStepError in step-handler.ts) -- a softened success gets no redaction
+ * safety net downstream.
+ */
+export function softenReadFailure(
+  failOnError: unknown,
+  message: string
+): { success: true; error: string } | undefined {
+  if (resolveFailOnError(failOnError)) {
+    return;
+  }
+  return { success: true, error: redactAllUrls(message) };
+}

--- a/plugins/web3/steps/read-fail-on-error-core.ts
+++ b/plugins/web3/steps/read-fail-on-error-core.ts
@@ -12,37 +12,74 @@ import { resolveFailOnError } from "@/lib/utils";
 
 /** The `failOnError` config field carried by every web3 read action. */
 export type ReadFailOnErrorInput = {
-  // Mirrors HTTP Request's failOnError. Defaults to true. See
-  // softenReadFailure below for which failures the toggle covers.
+  // Mirrors HTTP Request's failOnError. Defaults to true. When false, the step
+  // only fails the run for the destination problems marked below.
   failOnError?: boolean;
 };
 
 /**
- * The payload a read step returns in place of its `success: false` when the
- * author turned "Fail workflow on error" off: the next node receives the
- * error and decides what to do, instead of the run aborting on a transient
- * miss. Callers spread it over their own success shape with the data fields
- * set to null, so a downstream node can tell a soft failure apart from a real
- * read by checking `error`. Returns undefined when the toggle is on, so the
- * caller falls through to its hard failure.
+ * Marks the failures the toggle never covers: the ones where the read has no
+ * usable destination to call.
  *
- * Only the on-chain read attempt is eligible. Config problems (bad address or
- * ABI, unknown network, unresolved RPC, no token selected) recur on every
- * execution, so callers hard-fail those regardless of the toggle; softening
- * them would let a broken node run forever without the author noticing. This
- * mirrors HTTP Request's SSRF and malformed-URL carve-out.
+ * This is the read-side of the line HTTP Request draws (see httpRequest in
+ * lib/workflow/nodes/http-request/perform.ts). There, a missing URL, an
+ * unresolved `{{ }}` token, an SSRF-blocked host and a malformed URL hard-fail
+ * whatever the toggle says, because a null-data success would let a node that
+ * can never work run forever unnoticed. Everything else softens -- including
+ * every non-2xx, so a 400 rejecting the request body and a 404 for a missing
+ * resource both hand the next node an error rather than aborting the run.
+ *
+ * The equivalent split for a chain read: the network, the contract address and
+ * the RPC config are the destination, so they hard-fail. The ABI, the function
+ * name and the arguments are the payload, and whether the chain accepts them
+ * is the 400/404 case, so they soften. That matters most inside a For Each,
+ * where the payload is built per item from `{{currentItem}}`: one item the
+ * contract rejects is a miss to record, not a reason to kill the run.
+ */
+export type ReadDestinationFailure = {
+  // Set only on a failure that leaves the step with nowhere to call.
+  destinationError?: true;
+};
+
+/**
+ * Turn a failed read into a success carrying `error`, when the author has
+ * switched "Fail workflow on error" off.
+ *
+ * Applied once, to the step's final result, so every failure exit is covered.
+ * Applying it per-branch instead is what shipped first, and it silently missed
+ * every validation exit above the chain call: those return before the toggle
+ * is ever read, which is why a node with a bad function name failed identically
+ * in both switch positions.
+ *
+ * `softFields` are the step's data fields, all null, so a downstream node
+ * cannot read a failed lookup as real data.
+ *
+ * Observability is unaffected: every failure path logs through
+ * logUserError/logSystemError before returning, so Sentry, Prometheus and the
+ * execution log still record the failure. Only control flow changes.
  *
  * The message is redacted here because every web3 URL is an RPC provider
  * endpoint, and withStepLogging only redacts the `success: false` branch (see
  * redactStepError in step-handler.ts) -- a softened success gets no redaction
  * safety net downstream.
  */
-export function softenReadFailure(
+export function applyReadFailOnError<TResult extends { success: boolean }>(
+  result: TResult,
   failOnError: unknown,
-  message: string
-): { success: true; error: string } | undefined {
-  if (resolveFailOnError(failOnError)) {
-    return;
+  softFields: Omit<Extract<TResult, { success: true }>, "success" | "error">
+): TResult {
+  if (result.success || resolveFailOnError(failOnError)) {
+    return result;
   }
-  return { success: true, error: redactAllUrls(message) };
+  const failure = result as unknown as ReadDestinationFailure & {
+    error?: string;
+  };
+  if (failure.destinationError) {
+    return result;
+  }
+  return {
+    ...softFields,
+    success: true,
+    error: redactAllUrls(failure.error ?? "Read failed"),
+  } as unknown as TResult;
 }

--- a/plugins/web3/steps/read-solana-account-core.ts
+++ b/plugins/web3/steps/read-solana-account-core.ts
@@ -10,8 +10,9 @@ import {
   resolveSolanaAccountAddress,
 } from "@/lib/web3/solana-account-reader";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 export type ReadSolanaAccountCoreInput = ReadFailOnErrorInput & {
@@ -38,16 +39,26 @@ export type ReadSolanaAccountResult =
       dataLength: number;
       addressLink: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 export async function readSolanaAccountCore(
+  input: ReadSolanaAccountCoreInput
+): Promise<ReadSolanaAccountResult> {
+  return applyReadFailOnError(
+    await readSolanaAccountInner(input),
+    input.failOnError,
+    { exists: null }
+  );
+}
+
+async function readSolanaAccountInner(
   input: ReadSolanaAccountCoreInput
 ): Promise<ReadSolanaAccountResult> {
   const { network, accountAddress } = input;
 
   const resolved = resolveSolanaAccountAddress(network, accountAddress);
   if ("error" in resolved) {
-    return { success: false, error: resolved.error };
+    return { success: false, destinationError: true, error: resolved.error };
   }
   const { adapter, pubkey, chainId } = resolved;
 
@@ -67,10 +78,6 @@ export async function readSolanaAccountCore(
         chain_id: String(chainId),
       }
     );
-    const soft = softenReadFailure(input.failOnError, fetched.error);
-    if (soft) {
-      return { ...soft, exists: null };
-    }
     return { success: false, error: fetched.error };
   }
 

--- a/plugins/web3/steps/read-solana-account-core.ts
+++ b/plugins/web3/steps/read-solana-account-core.ts
@@ -9,14 +9,23 @@ import {
   fetchSolanaAccountInfo,
   resolveSolanaAccountAddress,
 } from "@/lib/web3/solana-account-reader";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
-export type ReadSolanaAccountCoreInput = {
+export type ReadSolanaAccountCoreInput = ReadFailOnErrorInput & {
   network: string;
   accountAddress: string;
   _context?: { executionId?: string };
 };
 
 export type ReadSolanaAccountResult =
+  // `exists: null` is the softened failure failOnError=false produces: the
+  // read did not complete, so whether the account exists is unknown. It is
+  // deliberately not `exists: false`, which a downstream node would read as
+  // the account being absent.
+  | { success: true; exists: null; error: string }
   | { success: true; exists: false }
   | {
       success: true;
@@ -58,6 +67,10 @@ export async function readSolanaAccountCore(
         chain_id: String(chainId),
       }
     );
+    const soft = softenReadFailure(input.failOnError, fetched.error);
+    if (soft) {
+      return { ...soft, exists: null };
+    }
     return { success: false, error: fetched.error };
   }
 

--- a/plugins/web3/steps/read-solana-program-core.ts
+++ b/plugins/web3/steps/read-solana-program-core.ts
@@ -14,8 +14,12 @@ import {
   parsePublicKey,
   resolveSolanaAccountAddress,
 } from "@/lib/web3/solana-account-reader";
+import {
+  type ReadFailOnErrorInput,
+  softenReadFailure,
+} from "./read-fail-on-error-core";
 
-export type ReadSolanaProgramCoreInput = {
+export type ReadSolanaProgramCoreInput = ReadFailOnErrorInput & {
   network: string;
   accountAddress: string;
   programId: string;
@@ -27,12 +31,23 @@ export type ReadSolanaProgramCoreInput = {
 export type ReadSolanaProgramResult =
   | {
       success: true;
+      // Null when failOnError=false softened a failed read into a success
+      // value so the workflow continues; `error` carries the reason.
       result: unknown;
-      owner: string;
-      lamports: number;
+      owner: string | null;
+      lamports: number | null;
       addressLink: string;
+      error?: string;
     }
   | { success: false; error: string };
+
+/** Data fields a softened read reports, so a soft failure never looks like a decoded account. */
+const SOFT_ACCOUNT_FIELDS = {
+  result: null,
+  owner: null,
+  lamports: null,
+  addressLink: "",
+} as const;
 
 /**
  * Recursively converts Anchor's decoded value tree into JSON-safe values:
@@ -125,10 +140,19 @@ export async function readSolanaProgramCore(
         chain_id: String(chainId),
       }
     );
+    const soft = softenReadFailure(input.failOnError, fetched.error);
+    if (soft) {
+      return { ...soft, ...SOFT_ACCOUNT_FIELDS };
+    }
     return { success: false, error: fetched.error };
   }
   if (!fetched.accountInfo) {
-    return { success: false, error: `Account not found: ${accountAddress}` };
+    const message = `Account not found: ${accountAddress}`;
+    const soft = softenReadFailure(input.failOnError, message);
+    if (soft) {
+      return { ...soft, ...SOFT_ACCOUNT_FIELDS };
+    }
+    return { success: false, error: message };
   }
 
   const { owner, lamports, data } = fetched.accountInfo;

--- a/plugins/web3/steps/read-solana-program-core.ts
+++ b/plugins/web3/steps/read-solana-program-core.ts
@@ -15,8 +15,9 @@ import {
   resolveSolanaAccountAddress,
 } from "@/lib/web3/solana-account-reader";
 import {
+  applyReadFailOnError,
+  type ReadDestinationFailure,
   type ReadFailOnErrorInput,
-  softenReadFailure,
 } from "./read-fail-on-error-core";
 
 export type ReadSolanaProgramCoreInput = ReadFailOnErrorInput & {
@@ -39,7 +40,7 @@ export type ReadSolanaProgramResult =
       addressLink: string;
       error?: string;
     }
-  | { success: false; error: string };
+  | (ReadDestinationFailure & { success: false; error: string });
 
 /** Data fields a softened read reports, so a soft failure never looks like a decoded account. */
 const SOFT_ACCOUNT_FIELDS = {
@@ -88,11 +89,21 @@ function serializeAnchorValue(value: unknown): unknown {
 export async function readSolanaProgramCore(
   input: ReadSolanaProgramCoreInput
 ): Promise<ReadSolanaProgramResult> {
+  return applyReadFailOnError(
+    await readSolanaProgramInner(input),
+    input.failOnError,
+    SOFT_ACCOUNT_FIELDS
+  );
+}
+
+async function readSolanaProgramInner(
+  input: ReadSolanaProgramCoreInput
+): Promise<ReadSolanaProgramResult> {
   const { network, accountAddress, programId, idl, accountType } = input;
 
   const resolved = resolveSolanaAccountAddress(network, accountAddress);
   if ("error" in resolved) {
-    return { success: false, error: resolved.error };
+    return { success: false, destinationError: true, error: resolved.error };
   }
   const { adapter, pubkey, chainId } = resolved;
 
@@ -100,6 +111,7 @@ export async function readSolanaProgramCore(
   if (!programPk) {
     return {
       success: false,
+      destinationError: true,
       error: `Invalid Solana program address: ${programId}`,
     };
   }
@@ -140,18 +152,10 @@ export async function readSolanaProgramCore(
         chain_id: String(chainId),
       }
     );
-    const soft = softenReadFailure(input.failOnError, fetched.error);
-    if (soft) {
-      return { ...soft, ...SOFT_ACCOUNT_FIELDS };
-    }
     return { success: false, error: fetched.error };
   }
   if (!fetched.accountInfo) {
     const message = `Account not found: ${accountAddress}`;
-    const soft = softenReadFailure(input.failOnError, message);
-    if (soft) {
-      return { ...soft, ...SOFT_ACCOUNT_FIELDS };
-    }
     return { success: false, error: message };
   }
 

--- a/tests/integration/check-balance-solana.test.ts
+++ b/tests/integration/check-balance-solana.test.ts
@@ -62,10 +62,15 @@ vi.mock("@/lib/workflow/executor/step-handler", async () =>
   (await import("../mocks/step-mocks")).stepHandlerPassthrough()
 );
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (error: { message?: string }) =>
-    error?.message ?? String(error),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (error: { message?: string }) =>
+      error?.message ?? String(error),
+  };
+});
 
 import { checkBalanceStep } from "@/plugins/web3/steps/check-balance";
 

--- a/tests/integration/direct-execution-api.test.ts
+++ b/tests/integration/direct-execution-api.test.ts
@@ -86,10 +86,15 @@ vi.mock("@/lib/billing/execution-guard", () => ({
     "Executions suspended due to unpaid overage invoice. Please update your payment method.",
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (err: unknown) =>
-    err instanceof Error ? err.message : String(err),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (err: unknown) =>
+      err instanceof Error ? err.message : String(err),
+  };
+});
 
 // DB mock -- override global setup mock to support .limit() for the status route
 vi.mock("@/lib/db", () => ({

--- a/tests/integration/execute-node-reserved-fields.test.ts
+++ b/tests/integration/execute-node-reserved-fields.test.ts
@@ -75,10 +75,15 @@ vi.mock("@/app/api/execute/_lib/action-resolver", () => ({
   resolveAction: mocks.resolveAction,
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (err: unknown) =>
-    err instanceof Error ? err.message : String(err),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (err: unknown) =>
+      err instanceof Error ? err.message : String(err),
+  };
+});
 
 vi.mock("@/lib/db/schema", () => ({
   integrations: { id: "id", organizationId: "organizationId" },

--- a/tests/integration/get-spl-token-balance.test.ts
+++ b/tests/integration/get-spl-token-balance.test.ts
@@ -167,10 +167,15 @@ vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
   (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
 );
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (error: { message?: string }) =>
-    error?.message ?? String(error),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (error: { message?: string }) =>
+      error?.message ?? String(error),
+  };
+});
 
 import { checkTokenBalanceStep } from "@/plugins/web3/steps/check-token-balance";
 import { getSplTokenBalanceStep } from "@/plugins/web3/steps/get-spl-token-balance";
@@ -254,7 +259,7 @@ describe("getSplTokenBalanceStep", () => {
     const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.balance).toBe("5");
       expect(result.balance.balanceRaw).toBe("5000000");
       expect(result.balance.decimals).toBe(6);
@@ -286,7 +291,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.balance).toBe("1");
     }
     expect(mockUnpackMint).toHaveBeenCalledWith(
@@ -305,7 +310,7 @@ describe("getSplTokenBalanceStep", () => {
     const result = await getSplTokenBalanceStep(input());
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.balance).toBe("0");
       expect(result.balance.balanceRaw).toBe("0");
     }
@@ -341,7 +346,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.symbol).toBe("USDC");
       expect(result.balance.name).toBe("USD Coin");
     }
@@ -375,7 +380,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.symbol).toBe("???");
       expect(result.balance.name).toBe("Unknown");
     }
@@ -395,7 +400,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.tokenAddress).toBe(MINT);
       expect(result.balance.balance).toBe("3");
     }
@@ -415,7 +420,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.balance).toBe("1");
       expect(result.balance.symbol).toBe("???");
       expect(result.balance.name).toBe("Unknown");
@@ -438,7 +443,7 @@ describe("getSplTokenBalanceStep", () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.balance) {
       expect(result.balance.symbol).toBe("USDC");
       expect(result.balance.name).toBe("USD Coin");
     }
@@ -546,5 +551,47 @@ describe("checkTokenBalanceStep - Solana rejection", () => {
       expect(result.error).toContain("Get SPL Token Balance");
     }
     expect(mockConnectionGetAccountInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe("getSplTokenBalanceStep - failOnError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSolanaProvider.mockResolvedValue({
+      executeWithFailover: vi.fn(),
+    });
+    mockGetAssociatedTokenAddressSync.mockReturnValue(new PublicKey(ATA));
+  });
+
+  it("softens a failed read when the toggle is off", async () => {
+    mockConnectionGetAccountInfo.mockRejectedValueOnce(
+      new Error("RPC timeout")
+    );
+
+    const result = await getSplTokenBalanceStep({
+      ...input(),
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    // Null, not a zero balance: a read that never completed must not report
+    // the wallet as empty.
+    expect(result.balance).toBeNull();
+    expect(result.error).toContain("Failed to check token balance");
+  });
+
+  it("still hard-fails a Solana rejection on the EVM action when the toggle is off", async () => {
+    const result = await checkTokenBalanceStep({
+      network: "solana-devnet",
+      address: WALLET,
+      tokenConfig: MINT,
+      failOnError: false,
+      _context: { ...context(), nodeType: "check-token-balance" },
+    });
+
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/integration/get-transaction-solana.test.ts
+++ b/tests/integration/get-transaction-solana.test.ts
@@ -95,10 +95,15 @@ vi.mock("@/lib/workflow/executor/step-handler", async () =>
   (await import("../mocks/step-mocks")).stepHandlerPassthrough()
 );
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (error: { message?: string }) =>
-    error?.message ?? String(error),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (error: { message?: string }) =>
+      error?.message ?? String(error),
+  };
+});
 
 import { getTransactionStep } from "@/plugins/web3/steps/get-transaction";
 
@@ -201,6 +206,60 @@ describe("getTransactionStep - Solana", () => {
     if (!result.success) {
       expect(result.error).toContain("Invalid transaction hash format");
     }
+    expect(mockConnectionGetTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("getTransactionStep - failOnError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("softens a not-found lookup when the toggle is off", async () => {
+    mockConnectionGetTransaction.mockResolvedValue(null);
+
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: VALID_SIGNATURE,
+      failOnError: false,
+      _context: context(),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.hash).toBeNull();
+    expect(result.from).toBeNull();
+    expect(result.error).toContain("Transaction not found");
+  });
+
+  it("softens a failed lookup when the toggle is off", async () => {
+    mockConnectionGetTransaction.mockRejectedValue(new Error("RPC down"));
+
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: VALID_SIGNATURE,
+      failOnError: false,
+      _context: context(),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.error).toContain("Failed to fetch transaction");
+  });
+
+  it("still hard-fails an invalid signature when the toggle is off", async () => {
+    const result = await getTransactionStep({
+      network: "solana-devnet",
+      transactionHash: "not a valid base58 signature",
+      failOnError: false,
+      _context: context(),
+    });
+
+    expect(result.success).toBe(false);
     expect(mockConnectionGetTransaction).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/query-transactions.test.ts
+++ b/tests/integration/query-transactions.test.ts
@@ -153,12 +153,17 @@ vi.mock("@/lib/rpc/provider-factory", () => ({
 // ---------------------------------------------------------------------------
 // Mock: @/lib/utils
 // ---------------------------------------------------------------------------
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: vi.fn(
-    (error: unknown) =>
-      (error as { message?: string })?.message ?? String(error)
-  ),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: vi.fn(
+      (error: unknown) =>
+        (error as { message?: string })?.message ?? String(error)
+    ),
+  };
+});
 
 import type { NormalizedTransaction } from "@/lib/explorer";
 // ---------------------------------------------------------------------------
@@ -312,7 +317,7 @@ describe("queryTransactionsCore", () => {
     const result = await queryTransactionsCore(defaultInput());
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.transactions)) {
       return;
     }
 
@@ -383,7 +388,7 @@ describe("queryTransactionsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.transactions)) {
       return;
     }
 
@@ -417,7 +422,7 @@ describe("queryTransactionsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.transactions)) {
       return;
     }
 
@@ -445,7 +450,7 @@ describe("queryTransactionsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.transactions)) {
       return;
     }
 

--- a/tests/integration/web3-steps.test.ts
+++ b/tests/integration/web3-steps.test.ts
@@ -120,9 +120,14 @@ vi.mock("@/lib/workflow/executor/step-handler", () => ({
 }));
 
 // Mock utils
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: vi.fn((error) => error?.message || String(error)),
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: vi.fn((error) => error?.message || String(error)),
+  };
+});
 
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { getRpcProvider } from "@/lib/rpc/provider-factory";

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -1255,7 +1255,7 @@ describe("batch-read-contract - failOnError", () => {
     expect(result.success).toBe(false);
   });
 
-  it("still hard-fails a malformed ABI when the toggle is off", async () => {
+  it("softens a malformed ABI, which is payload not destination", async () => {
     setupRpcMocks();
 
     const result = (await runBatch({
@@ -1264,6 +1264,7 @@ describe("batch-read-contract - failOnError", () => {
       failOnError: false,
     })) as SoftResult;
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.results).toBeNull();
   });
 });

--- a/tests/unit/batch-read-contract.test.ts
+++ b/tests/unit/batch-read-contract.test.ts
@@ -1184,3 +1184,86 @@ describe("batch-read-contract - total call limit", () => {
     expect(result.error).toContain("5001");
   });
 });
+
+// ─── failOnError ────────────────────────────────────────────────────────────
+
+describe("batch-read-contract - failOnError", () => {
+  type SoftResult = {
+    success: boolean;
+    results: unknown[] | null;
+    totalCalls: number | null;
+    error?: string;
+  };
+
+  const uniformInput = {
+    inputMode: "uniform",
+    network: "ethereum",
+    abi: JSON.stringify(ERC20_ABI),
+    contractAddress: VALID_ADDRESS,
+    abiFunction: "balanceOf",
+    argsList: JSON.stringify([[VALID_ADDRESS]]),
+  };
+
+  it("softens a failed multicall when the toggle is off", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockRejectedValueOnce(new Error("RPC timeout"));
+
+    const result = (await runBatch({
+      ...uniformInput,
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(true);
+    // Null, not []: a batch that never executed must not look like a batch
+    // whose calls all returned nothing.
+    expect(result.results).toBeNull();
+    expect(result.totalCalls).toBeNull();
+    expect(result.error).toContain("RPC timeout");
+  });
+
+  it("softens a failed multicall in mixed mode too", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockRejectedValueOnce(new Error("RPC timeout"));
+
+    const result = (await runBatch({
+      inputMode: "mixed",
+      calls: JSON.stringify([
+        {
+          network: "ethereum",
+          contractAddress: VALID_ADDRESS,
+          abiFunction: "balanceOf",
+          abi: JSON.stringify(ERC20_ABI),
+          args: [VALID_ADDRESS],
+        },
+      ]),
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(true);
+    expect(result.results).toBeNull();
+  });
+
+  it("still hard-fails an unresolved RPC config when the toggle is off", async () => {
+    mockGetChainIdFromNetwork.mockReturnValue(1);
+    mockGetRpcProvider.mockRejectedValue(new Error("RPC config not found"));
+
+    const result = (await runBatch({
+      ...uniformInput,
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails a malformed ABI when the toggle is off", async () => {
+    setupRpcMocks();
+
+    const result = (await runBatch({
+      ...uniformInput,
+      abi: "not json",
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/batch-write-contract.test.ts
+++ b/tests/unit/batch-write-contract.test.ts
@@ -33,11 +33,17 @@ vi.mock("drizzle-orm", () => ({
   sql: () => ({}),
 }));
 
-vi.mock("@/lib/utils", () => ({
-  getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
-  resolveFailOnError: (failOnError: unknown) =>
-    failOnError !== false && failOnError !== "false",
-}));
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (e: unknown) =>
+      e instanceof Error ? e.message : String(e),
+    resolveFailOnError: (failOnError: unknown) =>
+      failOnError !== false && failOnError !== "false",
+  };
+});
 
 vi.mock("@/lib/utils/id", () => ({
   generateId: () => "test-unique-id",

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -290,13 +290,16 @@ describe("check-allowance - failOnError", () => {
     expect(result.success).toBe(false);
   });
 
-  it("still hard-fails an invalid owner address when the toggle is off", async () => {
+  it("softens an invalid owner address, which is a call argument", async () => {
     setupMocks();
 
     const result = (await checkAllowanceStep(
       makeInput({ ownerAddress: "not-an-address", failOnError: false })
     )) as SoftResult;
 
-    expect(result.success).toBe(false);
+    // owner and spender are arguments to allowance(); the token contract is
+    // the destination. Only the latter aborts the run.
+    expect(result.success).toBe(true);
+    expect(result.allowance).toBeNull();
   });
 });

--- a/tests/unit/check-allowance.test.ts
+++ b/tests/unit/check-allowance.test.ts
@@ -258,3 +258,45 @@ describe("check-allowance - error handling", () => {
     }
   });
 });
+
+describe("check-allowance - failOnError", () => {
+  type SoftResult = {
+    success: boolean;
+    allowance: string | null;
+    error?: string;
+  };
+
+  it("softens a failed read when the toggle is off", async () => {
+    setupMocks();
+    mockAllowance.mockRejectedValue(new Error("RPC timeout"));
+
+    const result = (await checkAllowanceStep(
+      makeInput({ failOnError: false })
+    )) as SoftResult;
+
+    expect(result.success).toBe(true);
+    expect(result.allowance).toBeNull();
+    expect(result.error).toContain("Failed to check allowance");
+  });
+
+  it("still hard-fails an unresolved RPC config when the toggle is off", async () => {
+    setupMocks();
+    mockGetRpcProvider.mockRejectedValue(new Error("RPC config not found"));
+
+    const result = (await checkAllowanceStep(
+      makeInput({ failOnError: false })
+    )) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an invalid owner address when the toggle is off", async () => {
+    setupMocks();
+
+    const result = (await checkAllowanceStep(
+      makeInput({ ownerAddress: "not-an-address", failOnError: false })
+    )) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/query-solana-program-events-core.test.ts
+++ b/tests/unit/query-solana-program-events-core.test.ts
@@ -237,7 +237,7 @@ describe("queryProgramEventsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.events)) {
       return;
     }
     expect(result.events).toHaveLength(2);
@@ -271,7 +271,7 @@ describe("queryProgramEventsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.events)) {
       return;
     }
     expect(result.events).toHaveLength(1);
@@ -304,7 +304,7 @@ describe("queryProgramEventsCore", () => {
     });
 
     expect(result.success).toBe(true);
-    if (!result.success) {
+    if (!(result.success && result.events)) {
       return;
     }
     expect(result.events).toHaveLength(1);
@@ -602,5 +602,64 @@ describe("queryProgramEventsCore", () => {
       expect.anything(),
       expect.objectContaining({ limit: DEFAULT_SIGNATURE_LOOKBACK })
     );
+  });
+});
+
+describe("queryProgramEventsCore - failOnError", () => {
+  type SoftResult = {
+    success: boolean;
+    events: unknown[] | null;
+    signatureCount: number | null;
+    error?: string;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChainIdFromNetwork.mockReturnValue(101);
+    mockGetSolanaProvider.mockResolvedValue({
+      executeWithFailover: mockExecuteWithFailover,
+    });
+    mockDbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    });
+    mockGetSignaturesForAddress.mockRejectedValue(new Error("RPC down"));
+  });
+
+  it("softens a failed signature lookup when the toggle is off", async () => {
+    const result = (await queryProgramEventsCore({
+      network: "solana",
+      programId: PROGRAM_ID,
+      idl: JSON.stringify(IDL),
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(true);
+    // Null, not []: a lookup that never completed must not look like
+    // "no events in range".
+    expect(result.events).toBeNull();
+    expect(result.signatureCount).toBeNull();
+    expect(result.error).toContain("Signature lookup failed");
+  });
+
+  it("hard-fails the same lookup by default", async () => {
+    const result = (await queryProgramEventsCore({
+      network: "solana",
+      programId: PROGRAM_ID,
+      idl: JSON.stringify(IDL),
+    })) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an invalid program id when the toggle is off", async () => {
+    const result = (await queryProgramEventsCore({
+      network: "solana",
+      programId: "not-a-valid-pubkey",
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/unit/query-transactions-core.test.ts
+++ b/tests/unit/query-transactions-core.test.ts
@@ -208,7 +208,7 @@ describe("queryTransactionsCore", () => {
       const result = await queryTransactionsCore(BASE_INPUT);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.transactions) {
         expect(result.matchCount).toBe(1);
         expect(result.transactions[0].hash).toBe("0xabc");
         expect(result.transactions[0].functionName).toBe("transfer");
@@ -324,7 +324,7 @@ describe("queryTransactionsCore", () => {
       const result = await queryTransactionsCore(BASE_INPUT);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.transactions) {
         expect(result.matchCount).toBe(1);
         expect(result.transactions[0].hash).toBe("0xfallback");
       }
@@ -440,7 +440,7 @@ describe("queryTransactionsCore", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.transactions) {
         expect(result.transactions[0].hash).toBe("0xrecovered");
       }
       expect(mockFetch).toHaveBeenCalledTimes(3);
@@ -476,7 +476,7 @@ describe("queryTransactionsCore", () => {
       const result = await queryTransactionsCore(BASE_INPUT);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.transactions) {
         expect(result.transactions[0].hash).toBe("0xprimary");
       }
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -606,7 +606,7 @@ describe("queryTransactionsCore", () => {
       const result = await queryTransactionsCore(BASE_INPUT);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success && result.transactions) {
         expect(result.transactions[0].hash).toBe("0xrecovered");
       }
       expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -649,5 +649,57 @@ describe("queryTransactionsCore", () => {
       }
       expect(mockFetch).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("queryTransactionsCore - failOnError", () => {
+  type SoftResult = {
+    success: boolean;
+    transactions: unknown[] | null;
+    matchCount: number | null;
+    error?: string;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChainIdFromNetwork.mockReturnValue(1);
+    mockDbSelect.mockReturnValue({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    });
+    mockExecuteWithFailover.mockResolvedValue({
+      success: false,
+      error: "Failed to resolve block range: RPC timeout",
+    });
+  });
+
+  it("softens a failed block-range read when the toggle is off", async () => {
+    const result = (await queryTransactionsCore({
+      ...BASE_INPUT,
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(true);
+    // Null, not []: a query that never ran must not look like "no matches".
+    expect(result.transactions).toBeNull();
+    expect(result.matchCount).toBeNull();
+    expect(result.error).toContain("RPC timeout");
+  });
+
+  it("hard-fails the same read by default", async () => {
+    const result = (await queryTransactionsCore(BASE_INPUT)) as SoftResult;
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an invalid contract address when the toggle is off", async () => {
+    const result = (await queryTransactionsCore({
+      ...BASE_INPUT,
+      contractAddress: "not-an-address",
+      failOnError: false,
+    })) as SoftResult;
+
+    expect(result.success).toBe(false);
   });
 });

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -533,19 +533,47 @@ describe("read-contract-core - failOnError", () => {
     expect(result.error).toContain("Vat/not-authorized");
   });
 
-  it("still hard-fails a config error when failOnError is false", async () => {
+  it("softens a function missing from the ABI, like HTTP Request softens a 400", async () => {
     setupRpcMocks();
 
     const result = await readContractCore(
       makeInput({ abiFunction: "notInAbi", failOnError: false })
     );
 
-    expect(result.success).toBe(false);
-    if (result.success) {
+    // The ABI, the function name and the args are the payload, not the
+    // destination. HTTP Request hard-fails only an unusable URL; a request the
+    // far side rejects softens. This is the read-side equivalent, and it is
+    // what makes a For Each survive one item the contract will not accept.
+    expect(result.success).toBe(true);
+    if (!result.success) {
       return;
     }
+    expect(result.result).toBeNull();
     expect(result.error).toContain("not found in ABI");
-    expect(result.errorClass).toBe("user");
+  });
+
+  it("still hard-fails an invalid contract address when failOnError is false", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(
+      makeInput({ contractAddress: "not-an-address", failOnError: false })
+    );
+
+    // The address is the destination: with nowhere to call, a null-data
+    // success would let a permanently broken node run unnoticed.
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an unresolvable network when failOnError is false", async () => {
+    mockGetChainIdFromNetwork.mockImplementation(() => {
+      throw new Error("Unsupported network");
+    });
+
+    const result = await readContractCore(
+      makeInput({ network: "not-a-chain", failOnError: false })
+    );
+
+    expect(result.success).toBe(false);
   });
 
   it("still hard-fails an unresolved RPC config when failOnError is false", async () => {

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -460,3 +460,104 @@ describe("read-contract-core - missing abiFunction (KEEP-371)", () => {
     }
   });
 });
+
+describe("read-contract-core - failOnError", () => {
+  const RPC_FAILURE = new Error(
+    "could not detect network (https://eth-mainnet.g.alchemy.com/v2/secret-key)"
+  );
+
+  it("hard-fails a read failure by default", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockRejectedValueOnce(RPC_FAILURE);
+
+    const result = await readContractCore(makeInput());
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.errorClass).toBe("user");
+  });
+
+  it("softens a read failure into a success when failOnError is false", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockRejectedValueOnce(RPC_FAILURE);
+
+    const result = await readContractCore(makeInput({ failOnError: false }));
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.result).toBeNull();
+    expect(result.error).toContain("Contract call failed");
+  });
+
+  it("accepts the string 'false' the visual editor persists", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockRejectedValueOnce(RPC_FAILURE);
+
+    const result = await readContractCore(
+      makeInput({ failOnError: "false" as unknown as boolean })
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("redacts provider URLs in the softened error", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockRejectedValueOnce(RPC_FAILURE);
+
+    const result = await readContractCore(makeInput({ failOnError: false }));
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.error).not.toContain("alchemy.com");
+    expect(result.error).not.toContain("secret-key");
+  });
+
+  it("softens a revert the same way", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockRejectedValueOnce(
+      new Error("execution reverted: Vat/not-authorized")
+    );
+
+    const result = await readContractCore(makeInput({ failOnError: false }));
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.error).toContain("Vat/not-authorized");
+  });
+
+  it("still hard-fails a config error when failOnError is false", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(
+      makeInput({ abiFunction: "notInAbi", failOnError: false })
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.error).toContain("not found in ABI");
+    expect(result.errorClass).toBe("user");
+  });
+
+  it("still hard-fails an unresolved RPC config when failOnError is false", async () => {
+    mockGetChainIdFromNetwork.mockReturnValue(1);
+    mockGetRpcProvider.mockRejectedValueOnce(new Error("No RPC configured"));
+
+    const result = await readContractCore(makeInput({ failOnError: false }));
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      return;
+    }
+    expect(result.errorClass).toBe("system");
+  });
+});

--- a/tests/unit/read-solana-account.test.ts
+++ b/tests/unit/read-solana-account.test.ts
@@ -135,3 +135,46 @@ describe("readSolanaAccountCore", () => {
     );
   });
 });
+
+describe("readSolanaAccountCore - failOnError", () => {
+  let mockAdapter: {
+    executeWithSolanaFailover: ReturnType<typeof vi.fn>;
+    getAddressUrl: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapter = {
+      executeWithSolanaFailover: vi
+        .fn()
+        .mockRejectedValue(new Error("RPC down")),
+      getAddressUrl: vi.fn().mockResolvedValue(""),
+    };
+    vi.mocked(getChainAdapter).mockReturnValue(mockAdapter as never);
+  });
+
+  it("softens a failed read into exists:null when the toggle is off", async () => {
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: ADDRESS,
+      failOnError: false,
+    });
+
+    // exists must not be false: a read that never completed cannot report the
+    // account as absent.
+    expect(result).toMatchObject({ success: true, exists: null });
+    expect((result as { error: string }).error).toContain(
+      "Failed to read account"
+    );
+  });
+
+  it("still hard-fails an invalid address when the toggle is off", async () => {
+    const result = await readSolanaAccountCore({
+      network: "solana-devnet",
+      accountAddress: "not-a-pubkey!!",
+      failOnError: false,
+    });
+
+    expect(result).toMatchObject({ success: false });
+  });
+});

--- a/tests/unit/read-solana-program.test.ts
+++ b/tests/unit/read-solana-program.test.ts
@@ -231,3 +231,56 @@ describe("readSolanaProgramCore", () => {
     );
   });
 });
+
+describe("readSolanaProgramCore - failOnError", () => {
+  let mockAdapter: {
+    executeWithSolanaFailover: ReturnType<typeof vi.fn>;
+    getAddressUrl: ReturnType<typeof vi.fn>;
+  };
+
+  const validInput = {
+    network: "solana-devnet",
+    accountAddress: ADDRESS,
+    programId: PROGRAM,
+    idl: JSON.stringify(fixtureIdl()),
+    accountType: "Vault",
+    failOnError: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdapter = {
+      executeWithSolanaFailover: vi.fn(),
+      getAddressUrl: vi.fn().mockResolvedValue(""),
+    };
+    vi.mocked(getChainAdapter).mockReturnValue(mockAdapter as never);
+  });
+
+  it("softens a failed read when the toggle is off", async () => {
+    mockAdapter.executeWithSolanaFailover.mockRejectedValue(
+      new Error("RPC down")
+    );
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({ success: true, result: null, owner: null });
+  });
+
+  it("softens a missing account when the toggle is off", async () => {
+    mockAdapter.executeWithSolanaFailover.mockResolvedValue(null);
+
+    const result = await readSolanaProgramCore(validInput);
+
+    expect(result).toMatchObject({ success: true, result: null });
+    expect((result as { error?: string }).error).toContain("Account not found");
+  });
+
+  it("still hard-fails a malformed IDL when the toggle is off", async () => {
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      idl: "{bad",
+    });
+
+    expect(result).toMatchObject({ success: false });
+  });
+});

--- a/tests/unit/read-solana-program.test.ts
+++ b/tests/unit/read-solana-program.test.ts
@@ -275,10 +275,19 @@ describe("readSolanaProgramCore - failOnError", () => {
     expect((result as { error?: string }).error).toContain("Account not found");
   });
 
-  it("still hard-fails a malformed IDL when the toggle is off", async () => {
+  it("softens a malformed IDL, which is payload not destination", async () => {
     const result = await readSolanaProgramCore({
       ...validInput,
       idl: "{bad",
+    });
+
+    expect(result).toMatchObject({ success: true, result: null });
+  });
+
+  it("still hard-fails an invalid account address when the toggle is off", async () => {
+    const result = await readSolanaProgramCore({
+      ...validInput,
+      accountAddress: "not-a-pubkey!!",
     });
 
     expect(result).toMatchObject({ success: false });

--- a/tests/unit/web3-read-fail-on-error.test.ts
+++ b/tests/unit/web3-read-fail-on-error.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The web3 read steps' shared "Fail workflow on error" toggle: when off, a
+// failed on-chain read hands the next node a soft error instead of failing the
+// run, mirroring HTTP Request's failOnError. Config problems always hard-fail.
+
+vi.mock("server-only", () => ({}));
+
+const { mockGetBalance, mockGetAddressUrl, mockGetRpcProvider } = vi.hoisted(
+  () => ({
+    mockGetBalance: vi.fn(),
+    mockGetAddressUrl: vi.fn(),
+    mockGetRpcProvider: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    getBalance: (...args: unknown[]) => mockGetBalance(...args),
+    getAddressUrl: (...args: unknown[]) => mockGetAddressUrl(...args),
+  }),
+}));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (network: string) => {
+    if (network === "mainnet") {
+      return 1;
+    }
+    throw new Error(`Unsupported network: ${network}`);
+  },
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+  isSolanaChain: () => false,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  workflowExecutions: { id: "id", userId: "userId" },
+  explorerConfigs: { id: "id", chainId: "chainId" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: () => ({}),
+  and: () => ({}),
+  sql: () => ({}),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "validation", NETWORK_RPC: "network_rpc" },
+  logUserError: vi.fn(),
+}));
+
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+import { checkBalanceStep } from "@/plugins/web3/steps/check-balance";
+import { queryEventsStep } from "@/plugins/web3/steps/query-events";
+import { softenReadFailure } from "@/plugins/web3/steps/read-fail-on-error-core";
+
+const VALID_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const RPC_URL = "https://eth-mainnet.g.alchemy.com/v2/secret-key";
+
+describe("softenReadFailure", () => {
+  it("returns nothing when the toggle is left at its default", () => {
+    expect(softenReadFailure(undefined, "boom")).toBeUndefined();
+    expect(softenReadFailure(true, "boom")).toBeUndefined();
+    expect(softenReadFailure("true", "boom")).toBeUndefined();
+  });
+
+  it("softens for both the boolean and the string the editor persists", () => {
+    expect(softenReadFailure(false, "boom")).toEqual({
+      success: true,
+      error: "boom",
+    });
+    expect(softenReadFailure("false", "boom")).toEqual({
+      success: true,
+      error: "boom",
+    });
+  });
+
+  it("redacts provider URLs, which nothing downstream would redact", () => {
+    const soft = softenReadFailure(false, `RPC failed: ${RPC_URL}`);
+
+    expect(soft?.error).not.toContain("alchemy.com");
+    expect(soft?.error).not.toContain("secret-key");
+  });
+});
+
+describe("checkBalanceStep - failOnError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAddressUrl.mockResolvedValue("https://etherscan.io/address/0x123");
+    mockGetRpcProvider.mockResolvedValue({});
+  });
+
+  it("hard-fails a failed read by default", async () => {
+    mockGetBalance.mockRejectedValue(new Error(`connection lost ${RPC_URL}`));
+
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: VALID_ADDRESS,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("softens a failed read when the toggle is off", async () => {
+    mockGetBalance.mockRejectedValue(new Error("connection lost"));
+
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: VALID_ADDRESS,
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    // Null, not "0": a read that never completed must not report a balance a
+    // downstream Condition would compare against.
+    expect(result.balance).toBeNull();
+    expect(result.balanceWei).toBeNull();
+    expect(result.address).toBe(VALID_ADDRESS);
+    expect(result.error).toContain("Failed to check balance");
+  });
+
+  it("redacts the provider URL in the softened error", async () => {
+    mockGetBalance.mockRejectedValue(new Error(`connection lost ${RPC_URL}`));
+
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: VALID_ADDRESS,
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.error).not.toContain("alchemy.com");
+    expect(result.error).not.toContain("secret-key");
+  });
+
+  it("still hard-fails an invalid address when the toggle is off", async () => {
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: "not-an-address",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockGetBalance).not.toHaveBeenCalled();
+  });
+
+  it("still hard-fails an unknown network when the toggle is off", async () => {
+    const result = await checkBalanceStep({
+      network: "not-a-chain",
+      address: VALID_ADDRESS,
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an unresolved RPC config when the toggle is off", async () => {
+    mockGetRpcProvider.mockRejectedValue(new Error("No RPC configured"));
+
+    const result = await checkBalanceStep({
+      network: "mainnet",
+      address: VALID_ADDRESS,
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(mockGetBalance).not.toHaveBeenCalled();
+  });
+});
+
+const EVENT_ABI = [
+  {
+    name: "Lift",
+    type: "event",
+    inputs: [{ name: "account", type: "address", indexed: true }],
+  },
+];
+
+describe("queryEventsStep - failOnError", () => {
+  const eventInput = {
+    network: "mainnet",
+    contractAddress: VALID_ADDRESS,
+    abi: JSON.stringify(EVENT_ABI),
+    eventName: "Lift",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAddressUrl.mockResolvedValue("");
+    // resolveBlockRange runs inside executeWithFailover and returns its own
+    // result object, so a failed range read surfaces as this value.
+    mockGetRpcProvider.mockResolvedValue({
+      executeWithFailover: () =>
+        Promise.resolve({
+          success: false,
+          error: "Failed to resolve block range: RPC timeout",
+        }),
+    });
+  });
+
+  it("softens a failed block-range read when the toggle is off", async () => {
+    const result = await queryEventsStep({ ...eventInput, failOnError: false });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    // Null, not []: a query that never ran must not look like "no events".
+    expect(result.events).toBeNull();
+    expect(result.eventCount).toBeNull();
+    expect(result.error).toContain("RPC timeout");
+  });
+
+  it("hard-fails the same read by default", async () => {
+    const result = await queryEventsStep(eventInput);
+
+    expect(result.success).toBe(false);
+  });
+
+  it("still hard-fails an event missing from the ABI when the toggle is off", async () => {
+    const result = await queryEventsStep({
+      ...eventInput,
+      eventName: "NotAnEvent",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/web3-read-fail-on-error.test.ts
+++ b/tests/unit/web3-read-fail-on-error.test.ts
@@ -71,34 +71,65 @@ vi.mock("@/lib/workflow/executor/step-handler", async () =>
 
 import { checkBalanceStep } from "@/plugins/web3/steps/check-balance";
 import { queryEventsStep } from "@/plugins/web3/steps/query-events";
-import { softenReadFailure } from "@/plugins/web3/steps/read-fail-on-error-core";
+import { applyReadFailOnError } from "@/plugins/web3/steps/read-fail-on-error-core";
 
 const VALID_ADDRESS = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const RPC_URL = "https://eth-mainnet.g.alchemy.com/v2/secret-key";
 
-describe("softenReadFailure", () => {
-  it("returns nothing when the toggle is left at its default", () => {
-    expect(softenReadFailure(undefined, "boom")).toBeUndefined();
-    expect(softenReadFailure(true, "boom")).toBeUndefined();
-    expect(softenReadFailure("true", "boom")).toBeUndefined();
+describe("applyReadFailOnError", () => {
+  type Probe =
+    | { success: true; data: unknown; error?: string }
+    | { success: false; destinationError?: true; error: string };
+  const soft = { data: null };
+  const failure: Probe = { success: false, error: "boom" };
+
+  it("leaves the failure alone when the toggle is at its default", () => {
+    expect(applyReadFailOnError<Probe>(failure, undefined, soft)).toBe(failure);
+    expect(applyReadFailOnError<Probe>(failure, true, soft)).toBe(failure);
+    expect(applyReadFailOnError<Probe>(failure, "true", soft)).toBe(failure);
   });
 
   it("softens for both the boolean and the string the editor persists", () => {
-    expect(softenReadFailure(false, "boom")).toEqual({
+    expect(applyReadFailOnError<Probe>(failure, false, soft)).toEqual({
+      data: null,
       success: true,
       error: "boom",
     });
-    expect(softenReadFailure("false", "boom")).toEqual({
+    expect(applyReadFailOnError<Probe>(failure, "false", soft)).toEqual({
+      data: null,
       success: true,
       error: "boom",
     });
   });
 
-  it("redacts provider URLs, which nothing downstream would redact", () => {
-    const soft = softenReadFailure(false, `RPC failed: ${RPC_URL}`);
+  it("never softens a destination failure, whatever the toggle says", () => {
+    // Mirrors HTTP Request refusing to soften an unusable URL: a null-data
+    // success would hide a node that can never work.
+    const unreachable: Probe = {
+      success: false,
+      destinationError: true,
+      error: "Invalid contract address",
+    };
 
-    expect(soft?.error).not.toContain("alchemy.com");
-    expect(soft?.error).not.toContain("secret-key");
+    expect(applyReadFailOnError<Probe>(unreachable, false, soft)).toBe(
+      unreachable
+    );
+  });
+
+  it("leaves a success untouched", () => {
+    const ok: Probe = { success: true, data: 1 };
+
+    expect(applyReadFailOnError<Probe>(ok, false, soft)).toBe(ok);
+  });
+
+  it("redacts provider URLs, which nothing downstream would redact", () => {
+    const withUrl: Probe = { success: false, error: `RPC failed: ${RPC_URL}` };
+    const result = applyReadFailOnError<Probe>(withUrl, false, soft) as {
+      error: string;
+    };
+
+    expect(result.error).not.toContain("alchemy.com");
+    expect(result.error).not.toContain("secret-key");
   });
 });
 
@@ -242,10 +273,25 @@ describe("queryEventsStep - failOnError", () => {
     expect(result.success).toBe(false);
   });
 
-  it("still hard-fails an event missing from the ABI when the toggle is off", async () => {
+  it("softens an event missing from the ABI, which is payload not destination", async () => {
     const result = await queryEventsStep({
       ...eventInput,
       eventName: "NotAnEvent",
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.events).toBeNull();
+    expect(result.error).toContain("NotAnEvent");
+  });
+
+  it("still hard-fails an invalid contract address when the toggle is off", async () => {
+    const result = await queryEventsStep({
+      ...eventInput,
+      contractAddress: "not-an-address",
       failOnError: false,
     });
 


### PR DESCRIPTION
A transient RPC failure, or a single bad item, on a web3 read node aborts the whole execution. Inside a `For Each` loop that means one item kills a run whose other iterations all succeeded.

HTTP Request has solved this since KEEP-444 with a "Fail workflow on error" toggle. None of the web3 read nodes had one.

## What changed

All twelve web3 read actions get the toggle, default on:

Read Contract, Batch Read Contract, Get Native Token Balance, Get ERC20 Token Balance, Get SPL Token Balance, Check ERC20 Allowance, Get Transaction, Query Contract Events, Query Transaction History, Read Solana Account, Read Solana Program (Anchor), Query Solana Program Events.

When the toggle is off, a failed read returns `success: true` with the reason in `error`, so the next node decides. A downstream Condition can match that string to separate known misses from ones that should alert.

## Where the line is drawn

Matching HTTP Request, which hard-fails only an unusable URL (missing, unresolved `{{ }}`, SSRF-blocked, malformed) and softens every response including a 400 rejecting the body and a 404 for a missing resource:

- **Softens** — the call itself, and the ABI, function name and arguments sent with it. These are the payload, and whether the chain accepts them is the 400/404 case. This is what lets a `For Each` survive one item the contract rejects, since the payload is built per item from `{{currentItem}}`.
- **Still aborts, in both toggle positions** — an invalid address, an unknown network, or unresolved RPC config. These leave the step with nowhere to call, and a null-data success would hide a node that can never work.

Destination failures carry an explicit marker rather than relying on error classification, which labels payload and destination problems alike.

The decision is applied once, to each step's final result. An earlier revision wired it per-branch and silently missed every validation exit above the chain call, so a node with a bad ABI function name failed identically in both switch positions. A single boundary cannot drift that way.

## Reading a softened result

Data fields come back **null**, never an empty list or a zero, so a downstream node cannot mistake a query that never ran for one that found nothing. Read Solana Account reports `exists: null` rather than `false`: a read that did not complete cannot say the account is absent.

## Blast radius

No existing workflow changes behaviour. The toggle defaults on, and with it on every result is returned untouched. Protocol Read and the direct-execution API routes build their core input explicitly and never set the flag, so they are unchanged. Write actions are untouched, and a per-call revert inside Batch Read Contract is still isolated into its own `results` entry.

Observability is unchanged: every failure path still logs through `logUserError`/`logSystemError` before returning, so Sentry, Prometheus and the execution log see the failure either way. Only workflow control flow moves.

## Not included

The ticket also floated a configurable retry count as an alternative. That is not implemented. The reported `exceeded max retries (1 retry)` is the SDK's lost-`step_completed` shape rather than a retry the plugin controls, so a retry knob would not have addressed it.