### PR TITLE
docs: document gas-sponsorship fallback and the insufficient_balance failure

### DIFF
--- a/docs/keeper-runs/error-codes.md
+++ b/docs/keeper-runs/error-codes.md
@@ -35,3 +35,31 @@ same: wait a few minutes and try the run again.
 
 If a coded error keeps happening for the same workflow, contact support and
 include the code and the time of the run.
+
+## Action failures with structured codes (not PREFIX-NNNN)
+
+Some action failures are shown with their full, actionable message **and** a
+machine-readable failure code. The most common one on sponsored-capable networks:
+
+### `insufficient_balance`
+
+**What happened**: the transaction needed native gas (or native value) that the
+sending wallet did not hold at broadcast time.
+
+**Why it often appears on sponsored networks**: sponsorship is attempted first
+and silently falls back to direct signing whenever an eligibility condition is
+not met -- gas credits exhausted for the period, an unsupported network, a Safe
+sender, a private-mempool route, or a blocked RPC. The first thing the fallback
+does is check the wallet's native balance, and that is where the run stops.
+
+**What to do**:
+
+1. Fund the wallet address named in the message with at least the stated
+   shortfall amount, then retry, **or**
+2. restore the sponsorship conditions (gas credits on the billing page,
+   supported network, direct-wallet sender, public mempool) so the next
+   attempt is sponsored again -- the wallet then needs no native balance for
+   the gas fee.
+
+See [Gas Management -- When sponsorship falls back](/wallet-management/gas)
+for the full eligibility list.

--- a/docs/keeper-runs/error-codes.md
+++ b/docs/keeper-runs/error-codes.md
@@ -36,30 +36,32 @@ same: wait a few minutes and try the run again.
 If a coded error keeps happening for the same workflow, contact support and
 include the code and the time of the run.
 
-## Action failures with structured codes (not PREFIX-NNNN)
+## Action failures with structured codes (simulate responses)
 
-Some action failures are shown with their full, actionable message **and** a
-machine-readable failure code. The most common one on sponsored-capable networks:
+Some action failures carry a machine-readable failure code alongside the
+message. On the run path this applies to the **simulate** surface: `/api/execute/*`
+simulate responses and MCP simulate results return it as `SimulateFailureCode`.
+Run steps themselves surface the plain message only -- branch on the message
+text, not on the code, when reading run logs or run webhooks.
 
-### `insufficient_balance`
+### `insufficient_balance` (simulate responses)
 
-**What happened**: the transaction needed native gas (or native value) that the
-sending wallet did not hold at broadcast time.
+**What happened**: the gas preflight found the sending wallet could not cover
+the transaction before it was broadcast, so nothing was signed or sent.
 
-**Why it often appears on sponsored networks**: sponsorship is attempted first
-and silently falls back to direct signing whenever an eligibility condition is
-not met -- gas credits exhausted for the period, an unsupported network, a Safe
-sender, a private-mempool route, or a blocked RPC. The first thing the fallback
-does is check the wallet's native balance, and that is where the run stops.
+**Message on the run path** (plain text, no code):
 
-**What to do**:
+```
+Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
+0x...orgWallet with at least 0.000000231 ETH on this chain and retry.
+```
 
-1. Fund the wallet address named in the message with at least the stated
-   shortfall amount, then retry, **or**
-2. restore the sponsorship conditions (gas credits on the billing page,
-   supported network, direct-wallet sender, public mempool) so the next
-   attempt is sponsored again -- the wallet then needs no native balance for
-   the gas fee.
+This message is emitted on every direct-signing write path. On a
+sponsorship-eligible network it additionally means sponsorship fell back (see
+[Gas Management -- When sponsorship falls back](/wallet-management/gas)); on
+other setups it simply means the sending wallet cannot cover the gas.
 
-See [Gas Management -- When sponsorship falls back](/wallet-management/gas)
-for the full eligibility list.
+**What to do**: fund the wallet address named in the message with at least the
+stated shortfall, then retry. On Turnkey-managed wallets on sponsored networks,
+restoring the sponsorship conditions (gas credits, supported network,
+direct-wallet sender, public mempool) also fixes the run without funding.

--- a/docs/keeper-runs/error-codes.md
+++ b/docs/keeper-runs/error-codes.md
@@ -38,30 +38,39 @@ include the code and the time of the run.
 
 ## Action failures with structured codes (simulate responses)
 
-Some action failures carry a machine-readable failure code alongside the
-message. On the run path this applies to the **simulate** surface: `/api/execute/*`
-simulate responses and MCP simulate results return it as `SimulateFailureCode`.
-Run steps themselves surface the plain message only -- branch on the message
-text, not on the code, when reading run logs or run webhooks.
+Some action failures carry a machine-readable code alongside the message. This
+applies to the **simulate** surface only: `/api/execute/*` responses with
+`simulate: true` return it in the `code` field, and MCP simulate results surface
+it as a `Reason code:` line. Run steps carry the plain message with no code --
+when reading run logs or run webhooks, key on the message text.
 
 ### `insufficient_balance` (simulate responses)
 
-**What happened**: the gas preflight found the sending wallet could not cover
-the transaction before it was broadcast, so nothing was signed or sent.
+**What happened**: the simulator found that the funding address could not cover
+the native value the call sends. The comparison is against that value only; the
+simulator adds no gas term. A call that sends no native value therefore never
+produces this code -- an empty wallet on a zero-value call fails with the node's
+own revert message instead. See [Direct Execution](/api/direct-execution) for
+the full response shape.
 
-**Message on the run path** (plain text, no code):
+**Related message on the run path** (plain text, no code): before an EVM write
+action signs anything, a gas preflight checks that the funding address holds the
+native value plus the minimum gas any transaction costs. When it does not, the
+step fails before broadcast with:
 
 ```
 Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
 0x...orgWallet with at least 0.000000231 ETH on this chain and retry.
 ```
 
-This message is emitted on every direct-signing write path. On a
-sponsorship-eligible network it additionally means sponsorship fell back (see
+This message is emitted by every EVM write action. On a sponsorship-eligible
+network it additionally means sponsorship fell back (see
 [Gas Management -- When sponsorship falls back](/wallet-management/gas)); on
-other setups it simply means the sending wallet cannot cover the gas.
+other setups it simply means the funding address cannot cover the gas.
 
-**What to do**: fund the wallet address named in the message with at least the
-stated shortfall, then retry. On Turnkey-managed wallets on sponsored networks,
-restoring the sponsorship conditions (gas credits, supported network,
-direct-wallet sender, public mempool) also fixes the run without funding.
+**What to do**: fund the address named in the message with at least the stated
+shortfall, then retry. For a write that sends no native value on a
+sponsorship-eligible network, restoring the sponsorship conditions (gas credits,
+supported network, direct-wallet sender, public mempool) also fixes the run
+without funding. A write that sends native value always needs that value in the
+wallet; sponsorship covers the fee only.

--- a/docs/keeper-runs/error-codes.md
+++ b/docs/keeper-runs/error-codes.md
@@ -39,7 +39,8 @@ include the code and the time of the run.
 ## Action failures with structured codes (simulate responses)
 
 Some action failures carry a machine-readable code alongside the message. This
-applies to the **simulate** surface only: `/api/execute/*` responses with
+applies to the **simulate** surface only: `/api/execute/transfer`,
+`/api/execute/contract-call` and `/api/execute/check-and-execute` responses with
 `simulate: true` return it in the `code` field, and MCP simulate results surface
 it as a `Reason code:` line. Run steps carry the plain message with no code --
 when reading run logs or run webhooks, key on the message text.
@@ -49,9 +50,10 @@ when reading run logs or run webhooks, key on the message text.
 **What happened**: the simulator found that the funding address could not cover
 the native value the call sends. The comparison is against that value only; the
 simulator adds no gas term. A call that sends no native value therefore never
-produces this code -- an empty wallet on a zero-value call fails with the node's
-own revert message instead. See [Direct Execution](/api/direct-execution) for
-the full response shape.
+produces this code: when a wallet that cannot cover gas makes such a call fail,
+the node's own `insufficient funds` error comes back with no `code`, and with a
+`failureKind` of `validation` or `unavailable` rather than `revert`. See
+[Direct Execution](/api/direct-execution) for the full response shape.
 
 **Related message on the run path** (plain text, no code): before an EVM write
 action signs anything, a gas preflight checks that the funding address holds the
@@ -63,14 +65,16 @@ Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
 0x...orgWallet with at least 0.000000231 ETH on this chain and retry.
 ```
 
-This message is emitted by every EVM write action. On a sponsorship-eligible
-network it additionally means sponsorship fell back (see
-[Gas Management -- When sponsorship falls back](/wallet-management/gas)); on
-other setups it simply means the funding address cannot cover the gas.
+The preflight runs in the Web3 plugin's EVM write actions and in the protocol
+actions built on them. Actions on chains with their own transaction path, such
+as Tempo, do not run it. Reaching the preflight means the wallet is paying gas
+itself -- either the step was never eligible for sponsorship, or a sponsored
+attempt fell back (see
+[Gas Management -- When sponsorship falls back](/wallet-management/gas)). The
+run output does not distinguish the two.
 
 **What to do**: fund the address named in the message with at least the stated
-shortfall, then retry. For a write that sends no native value on a
-sponsorship-eligible network, restoring the sponsorship conditions (gas credits,
-supported network, direct-wallet sender, public mempool) also fixes the run
-without funding. A write that sends native value always needs that value in the
-wallet; sponsorship covers the fee only.
+shortfall, then retry. For a write that sends no native value, restoring the
+sponsorship conditions (gas credits, supported network, direct-wallet sender,
+public mempool) can also fix the run without funding. A write that sends native
+value always needs that value in the wallet; sponsorship covers the fee only.

--- a/docs/keeper-runs/troubleshooting.md
+++ b/docs/keeper-runs/troubleshooting.md
@@ -72,6 +72,12 @@ When a workflow does not behave as expected, the Runs panel provides the informa
 3. Verify contract function parameters
 4. Wait for pending transactions to clear
 
+> **Gas-sponsored workflows**: if the error reads `Insufficient ETH balance ...
+> Fund <address> ...`, sponsorship silently fell back to wallet-paid gas (see
+> [Gas Management](/wallet-management/gas)). Fund the address named in the
+> message or restore the sponsorship conditions, then retry. Failure code:
+> `insufficient_balance` (see [Run Error Codes](/keeper-runs/error-codes)).
+
 ### Slow Execution Times
 
 **Symptoms**: Runs complete but take longer than expected.

--- a/docs/keeper-runs/troubleshooting.md
+++ b/docs/keeper-runs/troubleshooting.md
@@ -72,11 +72,13 @@ When a workflow does not behave as expected, the Runs panel provides the informa
 3. Verify contract function parameters
 4. Wait for pending transactions to clear
 
-> **Gas-sponsored workflows**: if the error reads `Insufficient ETH balance ...
-> Fund <address> ...`, sponsorship silently fell back to wallet-paid gas (see
-> [Gas Management](/wallet-management/gas)). Fund the address named in the
-> message or restore the sponsorship conditions, then retry. Failure code:
-> `insufficient_balance` (see [Run Error Codes](/keeper-runs/error-codes)).
+> **Direct-signing gas failures**: if the error reads `Insufficient ETH balance
+> ... Fund <address> ...`, the gas preflight stopped the transaction before
+> broadcast. On a sponsorship-eligible network (Turnkey-managed wallet, gas
+> credits remaining, supported network, direct-wallet sender, public mempool)
+> this additionally means sponsorship fell back; otherwise it means the sending
+> wallet cannot cover gas. Fund the address named in the message and retry
+> (see [Gas Management](/wallet-management/gas)).
 
 ### Slow Execution Times
 

--- a/docs/keeper-runs/troubleshooting.md
+++ b/docs/keeper-runs/troubleshooting.md
@@ -72,13 +72,13 @@ When a workflow does not behave as expected, the Runs panel provides the informa
 3. Verify contract function parameters
 4. Wait for pending transactions to clear
 
-> **Gas preflight failures**: if the error reads `Insufficient ETH balance
-> ... Fund <address> ...`, the gas preflight stopped the transaction before
-> broadcast, so there is no transaction hash to look up. On a
-> sponsorship-eligible network (gas credits remaining, supported network,
-> direct-wallet sender, public mempool) this additionally means sponsorship fell
-> back; otherwise it means the funding address cannot cover gas. Fund the
-> address named in the message and retry
+> **Gas preflight failures**: if the error reads `Insufficient <token> balance
+> ... Fund <address> ...` -- where `<token>` is the chain's native gas token, so
+> the wording differs per network -- the gas preflight stopped the transaction
+> before broadcast, so there is no transaction hash to look up. It means the
+> funding address cannot cover gas. On a network where sponsorship applies it
+> may also mean a sponsored attempt fell back to direct signing, which the run
+> output does not distinguish. Fund the address named in the message and retry
 > (see [Gas Management](/wallet-management/gas)).
 
 ### Slow Execution Times

--- a/docs/keeper-runs/troubleshooting.md
+++ b/docs/keeper-runs/troubleshooting.md
@@ -72,12 +72,13 @@ When a workflow does not behave as expected, the Runs panel provides the informa
 3. Verify contract function parameters
 4. Wait for pending transactions to clear
 
-> **Direct-signing gas failures**: if the error reads `Insufficient ETH balance
+> **Gas preflight failures**: if the error reads `Insufficient ETH balance
 > ... Fund <address> ...`, the gas preflight stopped the transaction before
-> broadcast. On a sponsorship-eligible network (Turnkey-managed wallet, gas
-> credits remaining, supported network, direct-wallet sender, public mempool)
-> this additionally means sponsorship fell back; otherwise it means the sending
-> wallet cannot cover gas. Fund the address named in the message and retry
+> broadcast, so there is no transaction hash to look up. On a
+> sponsorship-eligible network (gas credits remaining, supported network,
+> direct-wallet sender, public mempool) this additionally means sponsorship fell
+> back; otherwise it means the funding address cannot cover gas. Fund the
+> address named in the message and retry
 > (see [Gas Management](/wallet-management/gas)).
 
 ### Slow Execution Times

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -97,27 +97,34 @@ Sponsored gas is metered in USD against your plan's monthly gas credit cap (show
 ### When sponsorship falls back
 
 Sponsorship is attempted first and falls back to direct signing (your wallet pays
-the gas) whenever any eligibility condition above is not met. The fallback is
-silent by design -- the run continues -- but the operator-visible result depends
-on your wallet balance:
+the gas) when the attempt returns no sponsored client. A fallback run simply lacks
+the **Gas sponsored** badge that a sponsored run carries in the Runs panel; the
+run output does not say why sponsorship was skipped.
 
-- **Wallet holds native gas**: the run completes, paid from your wallet. Nothing
-  in the run output tells you sponsorship was skipped, so if you expected
-  sponsored gas, check your remaining gas credits on the billing page.
-- **Wallet has no native gas**: the transaction fails before broadcast with a
-  structured error:
+What the fallback does next depends on the wallet balance:
+
+- **Wallet holds native gas**: the run completes, paid from your wallet.
+- **Wallet has no native gas**: the gas preflight runs before the transaction is
+  broadcast and fails the step with:
 
   ```
   Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
-  0x26833b05be49036d4de306b1f4fba7713cc84de5 with at least 0.000000231 ETH
-  on this chain and retry.
+  0x...orgWallet with at least 0.000000231 ETH on this chain and retry.
   ```
 
-  The failure code is `insufficient_balance` (see [Run Error Codes](/keeper-runs/error-codes)).
-  The address named in the message is the wallet to fund; the amount is the exact
-  shortfall. Funding that address and retrying is sufficient -- or restore the
-  sponsorship conditions (gas credits, supported network, direct-wallet sender,
-  public mempool) so the next attempt is sponsored again.
+  Nothing was broadcast at this point, so there is no transaction hash to look
+  up. Fund the address named in the message and retry.
+
+This message is emitted on every direct-signing write path. On a
+sponsorship-eligible network (see the conditions above, plus the Turnkey-managed
+wallet requirement) it additionally means sponsorship fell back -- funding the
+address fixes the run either way.
+
+The eligibility conditions are the user-controllable subset. Sponsorship can
+still be unavailable per organization and wallet even when all of them hold: the
+sponsored client is only created when the organization's active wallet is
+Turnkey-managed (a self-imported wallet never gets a sponsored client), and
+Turnkey can still reject an activity at submission time.
 
 ## FAQ
 

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -94,6 +94,31 @@ Workflows that route through a Safe (Sender ON) are not gas sponsored. The spons
 
 Sponsored gas is metered in USD against your plan's monthly gas credit cap (shown on the billing page). Mainnet usage counts against the cap; testnet usage is not charged. When the cap is reached, sponsorship pauses for the rest of the period and transactions pay gas from the wallet.
 
+### When sponsorship falls back
+
+Sponsorship is attempted first and falls back to direct signing (your wallet pays
+the gas) whenever any eligibility condition above is not met. The fallback is
+silent by design -- the run continues -- but the operator-visible result depends
+on your wallet balance:
+
+- **Wallet holds native gas**: the run completes, paid from your wallet. Nothing
+  in the run output tells you sponsorship was skipped, so if you expected
+  sponsored gas, check your remaining gas credits on the billing page.
+- **Wallet has no native gas**: the transaction fails before broadcast with a
+  structured error:
+
+  ```
+  Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
+  0x26833b05be49036d4de306b1f4fba7713cc84de5 with at least 0.000000231 ETH
+  on this chain and retry.
+  ```
+
+  The failure code is `insufficient_balance` (see [Run Error Codes](/keeper-runs/error-codes)).
+  The address named in the message is the wallet to fund; the amount is the exact
+  shortfall. Funding that address and retrying is sufficient -- or restore the
+  sponsorship conditions (gas credits, supported network, direct-wallet sender,
+  public mempool) so the next attempt is sponsored again.
+
 ## FAQ
 
 ### What happens if I leave the gas limit empty?

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -120,14 +120,19 @@ What the fallback does next depends on the wallet balance:
   ```
 
   Nothing was broadcast at this point, so there is no transaction hash to look
-  up. Fund the address named in the message and retry.
+  up. Fund the address named in the message and retry. The preflight caches the
+  balance and the gas price for about ten seconds, so a retry started right
+  after the funds land can repeat the same error; give it a few seconds.
 
-This message is emitted by every EVM write action. On a sponsorship-eligible
-network it additionally means sponsorship fell back; funding the address fixes
-the run either way. For a write that sends no native value, restoring the
-eligibility conditions above also fixes it without funding. A write that sends
-native value always needs that value in the wallet, because sponsorship covers
-the fee only (see [What sponsorship covers](#what-sponsorship-covers)).
+The preflight runs in the Web3 plugin's EVM write actions and in the protocol
+actions built on them. Actions on chains with their own transaction path, such
+as Tempo, do not run it. Reaching the preflight means the wallet is paying gas
+itself -- either the step was never eligible for sponsorship, or a sponsored
+attempt fell back -- and funding the address fixes the run either way. For a
+write that sends no native value, restoring the eligibility conditions above can
+also fix it without funding. A write that sends native value always needs that
+value in the wallet, because sponsorship covers the fee only (see
+[What sponsorship covers](#what-sponsorship-covers)).
 
 ## FAQ
 

--- a/docs/wallet-management/gas.md
+++ b/docs/wallet-management/gas.md
@@ -97,9 +97,16 @@ Sponsored gas is metered in USD against your plan's monthly gas credit cap (show
 ### When sponsorship falls back
 
 Sponsorship is attempted first and falls back to direct signing (your wallet pays
-the gas) when the attempt returns no sponsored client. A fallback run simply lacks
-the **Gas sponsored** badge that a sponsored run carries in the Runs panel; the
-run output does not say why sponsorship was skipped.
+the gas) whenever any eligibility condition above is not met. Sponsorship can
+also be unavailable for a specific organization or wallet even when all of them
+hold: Turnkey can reject an activity at submission time, and the step then falls
+back the same way.
+
+The Runs panel shows a **Gas sponsored** badge on each sponsored step; a step
+that fell back has no badge. The badge is per step, so a run with one sponsored
+step and one fallback step still shows it on the sponsored step. The run-level
+**Sponsored** filter (under **Used gas**) lists runs that drew on gas credits.
+The run output does not say why sponsorship was skipped.
 
 What the fallback does next depends on the wallet balance:
 
@@ -115,16 +122,12 @@ What the fallback does next depends on the wallet balance:
   Nothing was broadcast at this point, so there is no transaction hash to look
   up. Fund the address named in the message and retry.
 
-This message is emitted on every direct-signing write path. On a
-sponsorship-eligible network (see the conditions above, plus the Turnkey-managed
-wallet requirement) it additionally means sponsorship fell back -- funding the
-address fixes the run either way.
-
-The eligibility conditions are the user-controllable subset. Sponsorship can
-still be unavailable per organization and wallet even when all of them hold: the
-sponsored client is only created when the organization's active wallet is
-Turnkey-managed (a self-imported wallet never gets a sponsored client), and
-Turnkey can still reject an activity at submission time.
+This message is emitted by every EVM write action. On a sponsorship-eligible
+network it additionally means sponsorship fell back; funding the address fixes
+the run either way. For a write that sends no native value, restoring the
+eligibility conditions above also fixes it without funding. A write that sends
+native value always needs that value in the wallet, because sponsorship covers
+the fee only (see [What sponsorship covers](#what-sponsorship-covers)).
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

Sponsorship falls back silently to direct signing whenever an eligibility condition is not met — gas credits exhausted, unsupported network, Safe sender, private mempool route, or a blocked RPC. The operator only sees the downstream failure:

```
Insufficient ETH balance. Have: 0.0, Need: 0.000000231. Fund
0x26833b05be49036d4de306b1f4fba7713cc84de5 with at least 0.000000231 ETH
on this chain and retry.
```

(code `insufficient_balance`, from `lib/execute/native-balance.ts` `describeNativeShortfall`) — and nothing in the docs connected that error to the fallback. First-hand hit during a live integration on Base Sepolia.

## Changes

- `docs/wallet-management/gas.md`: new **When sponsorship falls back** section — the fallback conditions, the two observable outcomes (wallet-pays success vs the `insufficient_balance` failure), and both remedies (fund the named address / restore sponsorship conditions)
- `docs/keeper-runs/error-codes.md`: document the structured `insufficient_balance` action failure (not a PREFIX-NNNN code), its sponsorship-fallback cause, and the fix
- `docs/keeper-runs/troubleshooting.md`: cross-link from Transaction Failures

## Verification

- Behavior read from `lib/web3/sponsored-transaction-manager.ts` (`executeSponsoredTransaction` returns `null` on every ineligible condition, triggering the direct-signing fallback) and `lib/execute/native-balance.ts` (`describeNativeShortfall` message + `insufficient_balance` code)
- Verified against staging commit `d249519c5d7dcf66b8405e065cd7988a647ac442`
- Reproduced live on Base Sepolia: a funded-position workflow failed with exactly this error until the named address was funded

Docs-only change; no behavior touched. Submitted to the **KeeperHub — The Agent Economy** hackathon bounty (DoraHacks) as a separate BUIDL.