### PR TITLE
fix(analytics): show every chain in the network filter and reorder the run filters

### DIFF
--- a/app/api/analytics/facets/route.ts
+++ b/app/api/analytics/facets/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { parseRunFilters } from "@/lib/analytics/parse-run-filters";
-import { getStatusFacets } from "@/lib/analytics/queries";
+import { getRunFacets } from "@/lib/analytics/queries";
 import { parseTimeRange } from "@/lib/analytics/time-range";
 import { apiError } from "@/lib/api-error";
 import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   try {
     const params = req.nextUrl.searchParams;
-    const statusCounts = await getStatusFacets(
+    const facets = await getRunFacets(
       authCtx.organizationId,
       parseTimeRange(params.get("range")),
       {
@@ -40,7 +40,7 @@ export async function GET(req: NextRequest): Promise<Response> {
         ...parseRunFilters(params),
       }
     );
-    return NextResponse.json({ statusCounts });
+    return NextResponse.json(facets);
   } catch (error: unknown) {
     return apiError(error, "Failed to fetch analytics facets");
   }

--- a/app/api/analytics/facets/route.ts
+++ b/app/api/analytics/facets/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { parseRunFilters } from "@/lib/analytics/parse-run-filters";
 import { getRunFacets } from "@/lib/analytics/queries";
 import { parseTimeRange } from "@/lib/analytics/time-range";
+import type { FacetDimension } from "@/lib/analytics/types";
 import { apiError } from "@/lib/api-error";
 import { SCOPE_MCP_READ } from "@/lib/mcp/oauth-scopes";
 import { resolveOrganizationId } from "@/lib/middleware/auth-helpers";
@@ -30,6 +31,14 @@ export async function GET(req: NextRequest): Promise<Response> {
 
   try {
     const params = req.nextUrl.searchParams;
+    // Explicit, and status-only by default: the dashboard's poll must never
+    // pull the step-log counts by accident.
+    const valid = new Set<FacetDimension>(["status", "network", "gas"]);
+    const dimensions = params
+      .getAll("dimension")
+      .filter((value): value is FacetDimension =>
+        valid.has(value as FacetDimension)
+      );
     const facets = await getRunFacets(
       authCtx.organizationId,
       parseTimeRange(params.get("range")),
@@ -37,6 +46,7 @@ export async function GET(req: NextRequest): Promise<Response> {
         customStart: params.get("customStart") ?? undefined,
         customEnd: params.get("customEnd") ?? undefined,
         projectId: params.get("projectId") ?? undefined,
+        ...(dimensions.length > 0 ? { dimensions } : {}),
         ...parseRunFilters(params),
       }
     );

--- a/components/analytics/date-range-filter.tsx
+++ b/components/analytics/date-range-filter.tsx
@@ -212,6 +212,11 @@ export function DateRangeFilter(): ReactNode {
           // the transitions, so this deliberately does nothing.
           onSelect={NOOP}
           selected={selected}
+          // Two months side by side each pad their grid with the neighbour's
+          // days, so the end of September appeared in both panels, once as its
+          // own date and once as October's padding - and a selected range lit
+          // up in both places.
+          showOutsideDays={false}
         />
       </PopoverContent>
     </Popover>

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -19,6 +19,8 @@ type FilterPopoverProps = {
   onClear: () => void;
   /** Omitted by a single-choice dimension, which has nothing to select all of. */
   onSelectAll?: () => void;
+  /** Fired when the panel opens, for counts too expensive to load eagerly. */
+  onOpen?: () => void;
   children: ReactNode;
 };
 

--- a/components/analytics/filter-popover.tsx
+++ b/components/analytics/filter-popover.tsx
@@ -2,6 +2,7 @@
 
 import { Check, ChevronDown } from "lucide-react";
 import type { ReactNode } from "react";
+import { useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -30,11 +31,21 @@ export function FilterPopover({
   selectedCount,
   onClear,
   onSelectAll,
+  onOpen,
   children,
 }: FilterPopoverProps): ReactNode {
   const slug = label.toLowerCase().replace(/\s+/g, "-");
+  // Only the opening edge asks: closing the panel must not spend another query.
+  const handleOpenChange = useCallback(
+    (open: boolean): void => {
+      if (open) {
+        onOpen?.();
+      }
+    },
+    [onOpen]
+  );
   return (
-    <Popover>
+    <Popover onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           className={cn(

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -31,6 +31,7 @@ import {
   useChainDisplay,
 } from "@/lib/hooks/use-chain-display";
 import { FilterCheckbox, FilterPopover, FilterRadio } from "./filter-popover";
+import { useLazyFacet } from "./use-lazy-facet";
 
 type StatusGroup = {
   key: string;
@@ -205,6 +206,7 @@ function SourceFilter(): ReactNode {
 function NetworkFilter(): ReactNode {
   const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
   const counts = useAtomValue(analyticsFacetsAtom).networkCounts;
+  const loadCounts = useLazyFacet("network");
   const chains = useChainDisplay();
   const clear = useCallback((): void => setNetworks([]), [setNetworks]);
 
@@ -234,6 +236,7 @@ function NetworkFilter(): ReactNode {
     <FilterPopover
       label="Network"
       onClear={clear}
+      onOpen={loadCounts}
       onSelectAll={options.length > 0 ? selectAll : undefined}
       selectedCount={networks.length}
     >
@@ -288,6 +291,7 @@ const ALL_GAS: GasSpend[] = GAS_GROUPS.flatMap((group) =>
 function GasFilter(): ReactNode {
   const [gas, setGas] = useAtom(analyticsGasFiltersAtom);
   const counts = useAtomValue(analyticsFacetsAtom).gasCounts;
+  const loadCounts = useLazyFacet("gas");
   const clear = useCallback((): void => setGas([]), [setGas]);
   const selectAll = useCallback((): void => setGas(ALL_GAS), [setGas]);
 
@@ -308,6 +312,7 @@ function GasFilter(): ReactNode {
     <FilterPopover
       label="Gas"
       onClear={clear}
+      onOpen={loadCounts}
       onSelectAll={selectAll}
       selectedCount={gas.length}
     >

--- a/components/analytics/runs-filters.tsx
+++ b/components/analytics/runs-filters.tsx
@@ -18,12 +18,11 @@ import type {
 } from "@/lib/analytics/types";
 import {
   analyticsDurationFilterAtom,
+  analyticsFacetsAtom,
   analyticsGasFiltersAtom,
   analyticsNetworkFiltersAtom,
-  analyticsNetworksAtom,
   analyticsSearchAtom,
   analyticsSourceFiltersAtom,
-  analyticsStatusFacetsAtom,
   analyticsStatusFiltersAtom,
 } from "@/lib/atoms/analytics";
 import { sortChainsByName } from "@/lib/chains/sort-chains";
@@ -92,7 +91,7 @@ function toggle<T>(values: T[], value: T): T[] {
 
 function StatusFilter(): ReactNode {
   const [statuses, setStatuses] = useAtom(analyticsStatusFiltersAtom);
-  const facets = useAtomValue(analyticsStatusFacetsAtom);
+  const facets = useAtomValue(analyticsFacetsAtom).statusCounts;
 
   const toggleMember = useCallback(
     (value: NormalizedStatus): void => {
@@ -205,25 +204,25 @@ function SourceFilter(): ReactNode {
 
 function NetworkFilter(): ReactNode {
   const [networks, setNetworks] = useAtom(analyticsNetworkFiltersAtom);
-  const breakdown = useAtomValue(analyticsNetworksAtom);
+  const counts = useAtomValue(analyticsFacetsAtom).networkCounts;
   const chains = useChainDisplay();
   const clear = useCallback((): void => setNetworks([]), [setNetworks]);
 
-  // Chains the window actually saw. A chain with no runs in the window is not
-  // an option, because selecting it could only return nothing. Ordered through
-  // the same comparator the chain picker on a web3 node uses, so the two lists
-  // read the same way.
+  // Every chain the window's runs touched, not only the ones that spent gas.
+  // Sourcing these from the gas breakdown meant a chain the org merely reads
+  // on, or whose gas was never recorded, was missing from the filter entirely.
+  // Ordered through the comparator the chain picker on a web3 node shares.
   const options = useMemo(
     () =>
       sortChainsByName(
-        breakdown.map((entry) => ({
-          value: entry.network,
-          label: chains.name(entry.network),
-          count: entry.executionCount,
+        Object.entries(counts).map(([network, count]) => ({
+          value: network,
+          label: chains.name(network),
+          count,
         })),
         (option) => option.label
       ),
-    [breakdown, chains]
+    [counts, chains]
   );
 
   const selectAll = useCallback(
@@ -286,12 +285,9 @@ const ALL_GAS: GasSpend[] = GAS_GROUPS.flatMap((group) =>
   group.members.map((member) => member.value)
 );
 
-/**
- * Whether a run spent anything on chain. Sponsored runs count as paid: the org
- * drew on gas credit for them, so they are not free.
- */
 function GasFilter(): ReactNode {
   const [gas, setGas] = useAtom(analyticsGasFiltersAtom);
+  const counts = useAtomValue(analyticsFacetsAtom).gasCounts;
   const clear = useCallback((): void => setGas([]), [setGas]);
   const selectAll = useCallback((): void => setGas(ALL_GAS), [setGas]);
 
@@ -322,6 +318,10 @@ function GasFilter(): ReactNode {
           <div key={group.key}>
             <FilterCheckbox
               checked={selected.length === members.length}
+              count={members.reduce(
+                (sum, value) => sum + (counts[value] ?? 0),
+                0
+              )}
               indeterminate={
                 selected.length > 0 && selected.length < members.length
               }
@@ -332,6 +332,7 @@ function GasFilter(): ReactNode {
               group.members.map((member) => (
                 <FilterCheckbox
                   checked={gas.includes(member.value)}
+                  count={counts[member.value] ?? 0}
                   indented
                   key={member.value}
                   label={member.label}
@@ -469,10 +470,10 @@ export function RunsFilters(): ReactNode {
         <SearchBox />
         <div className="h-5 w-px bg-border" />
         <StatusFilter />
-        <NetworkFilter />
-        <DurationFilter />
-        <GasFilter />
         <SourceFilter />
+        <DurationFilter />
+        <NetworkFilter />
+        <GasFilter />
         <ClearAllButton />
       </div>
     </ChainDisplayProvider>

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -258,9 +258,14 @@ export function useAnalytics(): UseAnalyticsReturn {
       ),
       wrapSection(
         processSection<RunFacets>(facetsPromise, "Facets", ctx, (data) => {
-          // Merge: this response carries status only, and replacing would drop
-          // whichever step-log counts a dropdown had already loaded.
-          setFacets((current) => ({ ...current, ...data }));
+          // Take the status counts alone. The response still carries the other
+          // two keys, empty, because they were not computed - spreading the
+          // whole object would blank whichever step-log counts a dropdown had
+          // already loaded, on every poll tick.
+          setFacets((current) => ({
+            ...current,
+            statusCounts: data.statusCounts,
+          }));
         })
       ),
     ]);

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -10,7 +10,7 @@ import {
 import type {
   AnalyticsSummary,
   NetworkBreakdown,
-  StatusFacets,
+  RunFacets,
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
 import {
@@ -18,6 +18,7 @@ import {
   analyticsCustomStartAtom,
   analyticsDurationFilterAtom,
   analyticsErrorAtom,
+  analyticsFacetsAtom,
   analyticsGasFiltersAtom,
   analyticsLastUpdatedAtom,
   analyticsLoadingAtom,
@@ -28,7 +29,6 @@ import {
   analyticsRunsAtom,
   analyticsSearchAtom,
   analyticsSourceFiltersAtom,
-  analyticsStatusFacetsAtom,
   analyticsStatusFiltersAtom,
   analyticsSummaryAtom,
   analyticsTimeSeriesAtom,
@@ -111,7 +111,7 @@ export function useAnalytics(): UseAnalyticsReturn {
   const setTimeSeries = useSetAtom(analyticsTimeSeriesAtom);
   const setNetworks = useSetAtom(analyticsNetworksAtom);
   const setRuns = useSetAtom(analyticsRunsAtom);
-  const setStatusFacets = useSetAtom(analyticsStatusFacetsAtom);
+  const setFacets = useSetAtom(analyticsFacetsAtom);
   const setLastUpdated = useSetAtom(analyticsLastUpdatedAtom);
 
   const eventSourceRef = useRef<EventSource | null>(null);
@@ -250,14 +250,9 @@ export function useAnalytics(): UseAnalyticsReturn {
         })
       ),
       wrapSection(
-        processSection<{ statusCounts: StatusFacets }>(
-          facetsPromise,
-          "Facets",
-          ctx,
-          (data) => {
-            setStatusFacets(data.statusCounts);
-          }
-        )
+        processSection<RunFacets>(facetsPromise, "Facets", ctx, (data) => {
+          setFacets(data);
+        })
       ),
     ]);
   }, [
@@ -278,7 +273,7 @@ export function useAnalytics(): UseAnalyticsReturn {
     setTimeSeries,
     setNetworks,
     setRuns,
-    setStatusFacets,
+    setFacets,
     setLastUpdated,
   ]);
 

--- a/components/analytics/use-analytics.ts
+++ b/components/analytics/use-analytics.ts
@@ -151,7 +151,14 @@ export function useAnalytics(): UseAnalyticsReturn {
     const runsQuery = buildRunsQuery(filters);
     // The status counts sit under every filter except status itself, so the
     // facets request carries the same query with that one dimension lifted.
-    const facetsQuery = buildRunsQuery({ ...filters, omitStatus: true });
+    // Status only. The network and gas counts read the step logs, and this
+    // request repeats every poll for every open dashboard, so they are fetched
+    // when their dropdown opens instead.
+    const facetsQuery = buildRunsQuery({
+      ...filters,
+      omitStatus: true,
+      dimensions: ["status"],
+    });
 
     const { signal } = controller;
 
@@ -251,7 +258,9 @@ export function useAnalytics(): UseAnalyticsReturn {
       ),
       wrapSection(
         processSection<RunFacets>(facetsPromise, "Facets", ctx, (data) => {
-          setFacets(data);
+          // Merge: this response carries status only, and replacing would drop
+          // whichever step-log counts a dropdown had already loaded.
+          setFacets((current) => ({ ...current, ...data }));
         })
       ),
     ]);

--- a/components/analytics/use-lazy-facet.ts
+++ b/components/analytics/use-lazy-facet.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useRef } from "react";
+import { buildRunsQuery } from "@/lib/analytics/runs-query";
+import type { FacetDimension, RunFacets } from "@/lib/analytics/types";
+import {
+  analyticsCustomEndAtom,
+  analyticsCustomStartAtom,
+  analyticsDurationFilterAtom,
+  analyticsFacetsAtom,
+  analyticsGasFiltersAtom,
+  analyticsNetworkFiltersAtom,
+  analyticsProjectIdAtom,
+  analyticsRangeAtom,
+  analyticsSearchAtom,
+  analyticsSourceFiltersAtom,
+  analyticsStatusFiltersAtom,
+} from "@/lib/atoms/analytics";
+
+/**
+ * Loads one facet dimension on demand.
+ *
+ * Network and gas counts both read `workflow_execution_logs`, which is the
+ * table that took prod down when the run filters walked it too eagerly. Putting
+ * them on the dashboard's ten-second poll would pay that cost for every open
+ * tab forever, so they are fetched when the dropdown that shows them opens, and
+ * only when the window or the other filters have actually moved since.
+ */
+export function useLazyFacet(dimension: FacetDimension): () => void {
+  const setFacets = useSetAtom(analyticsFacetsAtom);
+  const range = useAtomValue(analyticsRangeAtom);
+  const statuses = useAtomValue(analyticsStatusFiltersAtom);
+  const sources = useAtomValue(analyticsSourceFiltersAtom);
+  const networks = useAtomValue(analyticsNetworkFiltersAtom);
+  const gas = useAtomValue(analyticsGasFiltersAtom);
+  const duration = useAtomValue(analyticsDurationFilterAtom);
+  const search = useAtomValue(analyticsSearchAtom);
+  const projectId = useAtomValue(analyticsProjectIdAtom);
+  const customStart = useAtomValue(analyticsCustomStartAtom);
+  const customEnd = useAtomValue(analyticsCustomEndAtom);
+  const lastQuery = useRef<string | null>(null);
+
+  return useCallback((): void => {
+    const query = buildRunsQuery({
+      range,
+      statuses,
+      sources,
+      networks,
+      gas,
+      duration,
+      search,
+      projectId,
+      customStart,
+      customEnd,
+      omitStatus: true,
+      dimensions: [dimension],
+    });
+    // Opening the same dropdown twice over unchanged filters asks nothing.
+    if (lastQuery.current === query) {
+      return;
+    }
+    lastQuery.current = query;
+
+    fetch(`/api/analytics/facets?${query}`)
+      .then((res) => (res.ok ? (res.json() as Promise<RunFacets>) : null))
+      .then((data) => {
+        if (data) {
+          setFacets((current) => ({ ...current, ...data }));
+        }
+      })
+      .catch(() => {
+        // A missing count leaves the option unlabelled; the filter still works.
+        lastQuery.current = null;
+      });
+  }, [
+    dimension,
+    range,
+    statuses,
+    sources,
+    networks,
+    gas,
+    duration,
+    search,
+    projectId,
+    customStart,
+    customEnd,
+    setFacets,
+  ]);
+}

--- a/components/analytics/use-lazy-facet.ts
+++ b/components/analytics/use-lazy-facet.ts
@@ -40,8 +40,14 @@ export function useLazyFacet(dimension: FacetDimension): () => void {
   const customStart = useAtomValue(analyticsCustomStartAtom);
   const customEnd = useAtomValue(analyticsCustomEndAtom);
   const lastQuery = useRef<string | null>(null);
+  const inFlight = useRef<AbortController | null>(null);
 
   return useCallback((): void => {
+    // The status filter is carried, unlike the status facet's own request:
+    // only the dimension being counted is lifted, and the server lifts network
+    // and gas itself. Lifting status here too would label a chain with a count
+    // taken across every status, which the listing contradicts the moment the
+    // reader ticks it.
     const query = buildRunsQuery({
       range,
       statuses,
@@ -53,7 +59,6 @@ export function useLazyFacet(dimension: FacetDimension): () => void {
       projectId,
       customStart,
       customEnd,
-      omitStatus: true,
       dimensions: [dimension],
     });
     // Opening the same dropdown twice over unchanged filters asks nothing.
@@ -62,16 +67,37 @@ export function useLazyFacet(dimension: FacetDimension): () => void {
     }
     lastQuery.current = query;
 
-    fetch(`/api/analytics/facets?${query}`)
+    // One request at a time per dimension: reopening after the window moved
+    // must not let the older response land last and win.
+    inFlight.current?.abort();
+    const controller = new AbortController();
+    inFlight.current = controller;
+
+    fetch(`/api/analytics/facets?${query}`, { signal: controller.signal })
       .then((res) => (res.ok ? (res.json() as Promise<RunFacets>) : null))
       .then((data) => {
-        if (data) {
-          setFacets((current) => ({ ...current, ...data }));
+        if (!data) {
+          return;
         }
+        // Take this dimension's key alone. The response fills the dimensions it
+        // was not asked to compute with {}, so merging the whole object would
+        // blank the counts another dropdown, or the poll, had already loaded.
+        setFacets((current) => ({
+          statusCounts:
+            dimension === "status" ? data.statusCounts : current.statusCounts,
+          networkCounts:
+            dimension === "network"
+              ? data.networkCounts
+              : current.networkCounts,
+          gasCounts: dimension === "gas" ? data.gasCounts : current.gasCounts,
+        }));
       })
       .catch(() => {
         // A missing count leaves the option unlabelled; the filter still works.
-        lastQuery.current = null;
+        // An abort is not a failure: the newer request owns `lastQuery` now.
+        if (!controller.signal.aborted) {
+          lastQuery.current = null;
+        }
       });
   }, [
     dimension,

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -49,6 +49,7 @@ import type {
   GasSpend,
   NetworkBreakdown,
   NormalizedStatus,
+  RunFacets,
   RunQueryFilters,
   RunSource,
   StatusFacets,
@@ -1626,7 +1627,7 @@ END`;
  * status filter. Every other filter applies; the status filter itself does not,
  * so a count says how many runs ticking that status would bring in.
  */
-export function getStatusFacets(
+export function getRunFacets(
   organizationId: string,
   range: TimeRange,
   options: RunQueryFilters & {
@@ -1634,10 +1635,10 @@ export function getStatusFacets(
     customEnd?: string;
     projectId?: string;
   } = {}
-): Promise<StatusFacets> {
+): Promise<RunFacets> {
   const { customStart, customEnd, projectId, ...filters } = options;
   const compute = () =>
-    computeStatusFacets(
+    computeRunFacets(
       organizationId,
       range,
       filters,
@@ -1667,17 +1668,28 @@ function hasFilters(filters: RunQueryFilters): boolean {
   );
 }
 
-async function computeStatusFacets(
+async function computeRunFacets(
   organizationId: string,
   range: TimeRange,
   filters: RunQueryFilters,
   customStart?: string,
   customEnd?: string,
   projectId?: string
-): Promise<StatusFacets> {
+): Promise<RunFacets> {
   const rangeStart = getTimeRangeStart(range, customStart);
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const wanted = resolveSources(filters.sources, projectId);
+
+  const [networkCounts, gasCounts] = await Promise.all([
+    computeNetworkFacets(
+      organizationId,
+      rangeStart,
+      rangeEnd,
+      filters,
+      projectId
+    ),
+    computeGasFacets(organizationId, rangeStart, rangeEnd, filters, projectId),
+  ]);
 
   const workflowRows = wanted.workflow
     ? await db
@@ -1715,12 +1727,114 @@ async function computeStatusFacets(
         .groupBy(sql`1`)
     : [];
 
-  const facets: StatusFacets = {};
+  const statusCounts: StatusFacets = {};
   for (const row of [...workflowRows, ...directRows]) {
     const status = row.status as NormalizedStatus;
-    facets[status] = (facets[status] ?? 0) + (Number(row.value) || 0);
+    statusCounts[status] =
+      (statusCounts[status] ?? 0) + (Number(row.value) || 0);
   }
-  return facets;
+  return { statusCounts, networkCounts, gasCounts };
+}
+
+/**
+ * Distinct chains the window's runs touched, counted per run rather than per
+ * step. Deliberately not the gas breakdown: that one only counts steps that
+ * spent gas, so a chain the org only reads on - or one whose gas was never
+ * recorded - never appeared as an option to filter by.
+ */
+async function computeNetworkFacets(
+  organizationId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+  filters: RunQueryFilters,
+  projectId?: string
+): Promise<Record<string, number>> {
+  const wanted = resolveSources(filters.sources, projectId);
+  const withoutNetworks: RunQueryFilters = { ...filters, networks: undefined };
+
+  const workflowRows = wanted.workflow
+    ? await db
+        .select({
+          network: workflowExecutionLogs.network,
+          value: sql<number>`COUNT(DISTINCT ${workflowExecutions.id})`,
+        })
+        .from(workflowExecutionLogs)
+        .innerJoin(
+          workflowExecutions,
+          eq(workflowExecutionLogs.executionId, workflowExecutions.id)
+        )
+        .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+        .where(
+          and(
+            eq(workflows.organizationId, organizationId),
+            projectId ? eq(workflows.projectId, projectId) : undefined,
+            gte(workflowExecutions.startedAt, rangeStart),
+            lt(workflowExecutions.startedAt, rangeEnd),
+            isNull(workflowExecutions.deletedAt),
+            isNotNull(workflowExecutionLogs.network),
+            ...workflowFilterConditions(withoutNetworks, rangeStart)
+          )
+        )
+        .groupBy(workflowExecutionLogs.network)
+    : [];
+
+  const directRows = wanted.direct
+    ? await db
+        .select({ network: directExecutions.network, value: count() })
+        .from(directExecutions)
+        .where(
+          and(
+            eq(directExecutions.organizationId, organizationId),
+            gte(directExecutions.createdAt, rangeStart),
+            lt(directExecutions.createdAt, rangeEnd),
+            isNotNull(directExecutions.network),
+            ...directFilterConditions(withoutNetworks)
+          )
+        )
+        .groupBy(directExecutions.network)
+    : [];
+
+  const counts: Record<string, number> = {};
+  for (const row of [...workflowRows, ...directRows]) {
+    if (!row.network) {
+      continue;
+    }
+    counts[row.network] = (counts[row.network] ?? 0) + (Number(row.value) || 0);
+  }
+  return counts;
+}
+
+/**
+ * How many runs sit in each gas bucket. Counted one bucket at a time because
+ * sponsored and wallet overlap, so a single grouped pass cannot express them.
+ */
+async function computeGasFacets(
+  organizationId: string,
+  rangeStart: Date,
+  rangeEnd: Date,
+  filters: RunQueryFilters,
+  projectId?: string
+): Promise<Partial<Record<GasSpend, number>>> {
+  const withoutGas: RunQueryFilters = { ...filters, gas: undefined };
+  const values: GasSpend[] = ["sponsored", "wallet", "free"];
+
+  const totals = await Promise.all(
+    values.map((value) =>
+      getUnifiedRunsTotal(
+        organizationId,
+        rangeStart,
+        rangeEnd,
+        { ...withoutGas, gas: [value] },
+        projectId
+      )
+    )
+  );
+
+  const counts: Partial<Record<GasSpend, number>> = {};
+  for (const [index, value] of values.entries()) {
+    counts[value] = totals[index];
+  }
+  return counts;
 }
 
 async function getUnifiedRunsTotal(

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -192,7 +192,7 @@ function workflowNetworkCondition(networks: string[], logsFrom: Date): SQL {
     SELECT ${workflowExecutionLogs.executionId}
       FROM ${workflowExecutionLogs}
      WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
-       AND COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")}) IN (${sql.join(
+       AND ${stepNetwork} IN (${sql.join(
          networks.map((network) => sql`${network}`),
          sql`, `
        )})
@@ -233,6 +233,16 @@ const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt
 // backfill has not reached - still classify correctly.
 const filterStepGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC))`;
 const filterStepSponsored = sql`${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'`;
+
+/**
+ * The chain a step ran on. The denormalised column is only populated on rows
+ * the executor wrote after it was added, and on what the backfill has reached,
+ * so the JSONB it was derived from is still the answer for everything older.
+ * Every reader has to use this same expression: matching on it while listing
+ * options from the bare column offers a filter a chain it will then match, and
+ * hides every chain whose column was never filled.
+ */
+const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
 
 /**
  * Gas facts per execution, aggregated once over the window.
@@ -1755,7 +1765,7 @@ async function computeNetworkFacets(
   const workflowRows = wanted.workflow
     ? await db
         .select({
-          network: workflowExecutionLogs.network,
+          network: sql<string | null>`${stepNetwork}`,
           value: sql<number>`COUNT(DISTINCT ${workflowExecutions.id})`,
         })
         .from(workflowExecutionLogs)
@@ -1771,11 +1781,13 @@ async function computeNetworkFacets(
             gte(workflowExecutions.startedAt, rangeStart),
             lt(workflowExecutions.startedAt, rangeEnd),
             isNull(workflowExecutions.deletedAt),
-            isNotNull(workflowExecutionLogs.network),
+            sql`${stepNetwork} IS NOT NULL`,
             ...workflowFilterConditions(withoutNetworks, rangeStart)
           )
         )
-        .groupBy(workflowExecutionLogs.network)
+        // Ordinal, because the expression carries bound parameters that would
+        // bind a second time and stop matching the select.
+        .groupBy(sql`1`)
     : [];
 
   const directRows = wanted.direct

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -187,11 +187,10 @@ function directStatusesCondition(statuses: NormalizedStatus[]): SQL {
  * same COALESCE(column, JSONB) the listing reads them through. EXISTS keeps a
  * run that touched any selected chain without multiplying it per matching step.
  */
-function workflowNetworkCondition(networks: string[], logsFrom: Date): SQL {
+function workflowNetworkCondition(networks: string[], scope: LogScope): SQL {
   return sql`${workflowExecutions.id} IN (
     SELECT ${workflowExecutionLogs.executionId}
-      FROM ${workflowExecutionLogs}
-     WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
+    ${scopedLogs(scope)}
        AND ${stepNetwork} IN (${sql.join(
          networks.map((network) => sql`${network}`),
          sql`, `
@@ -245,6 +244,45 @@ const filterStepSponsored = sql`${workflowExecutionLogs.outputRaw}->>'sponsored'
 const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
 
 /**
+ * What a log subquery is allowed to see. These subqueries used to be bounded by
+ * nothing but the window's lower edge, so each one aggregated every tenant's
+ * step logs and paid the de-TOAST and JSONB parse of `output` / `output_raw` on
+ * all of them. On a table whose bulk is TOAST that is CPU, not IO, and enough
+ * concurrent page loads accumulate into backends that never finish.
+ */
+type LogScope = {
+  organizationId: string;
+  rangeStart: Date;
+  rangeEnd: Date;
+  projectId?: string;
+};
+
+/**
+ * FROM + WHERE for a scoped read of the step logs. The joins narrow the scan to
+ * one organization's executions inside the window before any JSONB is touched,
+ * and the caller appends its own predicates with AND.
+ */
+function scopedLogs(scope: LogScope): SQL {
+  const project = scope.projectId
+    ? sql` AND scoped_wf.project_id = ${scope.projectId}`
+    : sql``;
+  // Bound as ISO text: a raw template has no column to map a Date through, the
+  // way the drizzle comparison helpers do.
+  const from = scope.rangeStart.toISOString();
+  const to = scope.rangeEnd.toISOString();
+  return sql`
+      FROM ${workflowExecutionLogs}
+      JOIN ${workflowExecutions} AS scoped_exec
+        ON scoped_exec.id = ${workflowExecutionLogs.executionId}
+      JOIN ${workflows} AS scoped_wf
+        ON scoped_wf.id = scoped_exec.workflow_id
+     WHERE scoped_wf.organization_id = ${scope.organizationId}
+       AND scoped_exec.started_at >= ${from}
+       AND scoped_exec.started_at < ${to}
+       AND ${workflowExecutionLogs.startedAt} >= ${from}${project}`;
+}
+
+/**
  * Gas facts per execution, aggregated once over the window.
  *
  * These were correlated subqueries on workflow_executions.id, so the planner
@@ -259,7 +297,7 @@ const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputFie
  * inside the window has started_at >= the window start; and a step may finish
  * after the window closes, so there is no upper bound to apply.
  */
-function workflowGasTotals(logsFrom: Date): SQL {
+function workflowGasTotals(scope: LogScope): SQL {
   return sql`(
     SELECT ${workflowExecutionLogs.executionId} AS execution_id,
            COALESCE(SUM(${filterStepGasWei}), 0) AS step_gas_wei,
@@ -268,8 +306,7 @@ function workflowGasTotals(logsFrom: Date): SQL {
              ${filterStepGasWei} > 0
              AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
            ), false) AS unsponsored_gas_step
-      FROM ${workflowExecutionLogs}
-     WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
+    ${scopedLogs(scope)}
      GROUP BY ${workflowExecutionLogs.executionId}
   )`;
 }
@@ -279,13 +316,18 @@ function workflowGasTotals(logsFrom: Date): SQL {
  * execution_id is nullable, and a NULL reaching a NOT IN below would make the
  * whole predicate answer NULL, so the rows are dropped here at the source.
  */
-const workflowLedgerTotals = sql`(
-  SELECT ${gasCreditUsage.executionId} AS execution_id,
-         COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0) AS sponsored_gas_wei
-    FROM ${gasCreditUsage}
-   WHERE ${gasCreditUsage.executionId} IS NOT NULL
-   GROUP BY ${gasCreditUsage.executionId}
-)`;
+function workflowLedgerTotals(scope: LogScope): SQL {
+  return sql`(
+    SELECT ${gasCreditUsage.executionId} AS execution_id,
+           COALESCE(SUM(CAST(${gasCreditUsage.gasCostWei} AS NUMERIC)), 0) AS sponsored_gas_wei
+      FROM ${gasCreditUsage}
+     WHERE ${gasCreditUsage.executionId} IS NOT NULL
+       AND ${gasCreditUsage.organizationId} = ${scope.organizationId}
+       AND ${gasCreditUsage.createdAt} >= ${scope.rangeStart.toISOString()}
+       AND ${gasCreditUsage.createdAt} < ${scope.rangeEnd.toISOString()}
+     GROUP BY ${gasCreditUsage.executionId}
+  )`;
+}
 
 /**
  * One predicate per gas category. Sponsored is "gas credit covered a leg";
@@ -294,7 +336,7 @@ const workflowLedgerTotals = sql`(
  * run with no step rows at all - absent from the aggregate rather than present
  * with a zero - still reads as free.
  */
-function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
+function workflowGasCondition(value: GasSpend, scope: LogScope): SQL {
   if (value === "sponsored") {
     // Only the marker decides this one, so it reads output_raw directly rather
     // than paying for the gas rollup - and its JSONB decode - that the other
@@ -302,17 +344,16 @@ function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
     return sql`(
       ${workflowExecutions.id} IN (
         SELECT ${workflowExecutionLogs.executionId}
-          FROM ${workflowExecutionLogs}
-         WHERE ${gte(workflowExecutionLogs.startedAt, logsFrom)}
+        ${scopedLogs(scope)}
            AND ${filterStepSponsored}
       )
       OR ${workflowExecutions.id} IN (
-        SELECT s.execution_id FROM ${workflowLedgerTotals} AS s
+        SELECT s.execution_id FROM ${workflowLedgerTotals(scope)} AS s
          WHERE s.sponsored_gas_wei > 0
       )
     )`;
   }
-  const totals = workflowGasTotals(logsFrom);
+  const totals = workflowGasTotals(scope);
   if (value === "wallet") {
     // Both signals have to agree there is an unsponsored share: a step that
     // burned gas without the sponsored marker, and a total the ledger did not
@@ -321,7 +362,7 @@ function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
     return sql`${workflowExecutions.id} IN (
       SELECT g.execution_id
         FROM ${totals} AS g
-        LEFT JOIN ${workflowLedgerTotals} AS s ON s.execution_id = g.execution_id
+        LEFT JOIN ${workflowLedgerTotals(scope)} AS s ON s.execution_id = g.execution_id
        WHERE g.unsponsored_gas_step
          AND g.step_gas_wei > COALESCE(s.sponsored_gas_wei, 0)
     )`;
@@ -332,7 +373,7 @@ function workflowGasCondition(value: GasSpend, logsFrom: Date): SQL {
        WHERE g.step_gas_wei > 0 OR g.sponsored_step
     )
     AND ${workflowExecutions.id} NOT IN (
-      SELECT s.execution_id FROM ${workflowLedgerTotals} AS s
+      SELECT s.execution_id FROM ${workflowLedgerTotals(scope)} AS s
        WHERE s.sponsored_gas_wei > 0
     )
   )`;
@@ -374,7 +415,7 @@ function gasCondition(
  */
 function workflowFilterConditions(
   filters: RunQueryFilters,
-  rangeStart: Date,
+  scope: LogScope,
   skipStatuses = false
 ): SQL[] {
   const conditions: SQL[] = [];
@@ -384,7 +425,7 @@ function workflowFilterConditions(
   }
   const networks = filters.networks ?? [];
   if (networks.length > 0) {
-    conditions.push(workflowNetworkCondition(networks, rangeStart));
+    conditions.push(workflowNetworkCondition(networks, scope));
   }
   if (filters.durationMinMs !== undefined) {
     conditions.push(
@@ -401,7 +442,7 @@ function workflowFilterConditions(
     conditions.push(workflowSearchCondition(search));
   }
   const gas = gasCondition(filters.gas ?? [], (value) =>
-    workflowGasCondition(value, rangeStart)
+    workflowGasCondition(value, scope)
   );
   if (gas) {
     conditions.push(gas);
@@ -1307,7 +1348,14 @@ async function fetchWorkflowRuns(
     isNull(workflowExecutions.deletedAt),
   ];
 
-  conditions.push(...workflowFilterConditions(filters, rangeStart));
+  conditions.push(
+    ...workflowFilterConditions(filters, {
+      organizationId,
+      rangeStart,
+      rangeEnd,
+      projectId,
+    })
+  );
 
   if (cursor) {
     conditions.push(lt(workflowExecutions.startedAt, new Date(cursor)));
@@ -1584,7 +1632,14 @@ async function getWorkflowRunsTotal(
   if (projectId) {
     conditions.push(eq(workflows.projectId, projectId));
   }
-  conditions.push(...workflowFilterConditions(filters, rangeStart));
+  conditions.push(
+    ...workflowFilterConditions(filters, {
+      organizationId,
+      rangeStart,
+      rangeEnd,
+      projectId,
+    })
+  );
   const result = await db
     .select({ count: count() })
     .from(workflowExecutions)
@@ -1713,7 +1768,11 @@ async function computeRunFacets(
             gte(workflowExecutions.startedAt, rangeStart),
             lt(workflowExecutions.startedAt, rangeEnd),
             isNull(workflowExecutions.deletedAt),
-            ...workflowFilterConditions(filters, rangeStart, true)
+            ...workflowFilterConditions(
+              filters,
+              { organizationId, rangeStart, rangeEnd, projectId },
+              true
+            )
           )
         )
         // Group by the select ordinal: the CASE carries a bound parameter, and
@@ -1782,7 +1841,12 @@ async function computeNetworkFacets(
             lt(workflowExecutions.startedAt, rangeEnd),
             isNull(workflowExecutions.deletedAt),
             sql`${stepNetwork} IS NOT NULL`,
-            ...workflowFilterConditions(withoutNetworks, rangeStart)
+            ...workflowFilterConditions(withoutNetworks, {
+              organizationId,
+              rangeStart,
+              rangeEnd,
+              projectId,
+            })
           )
         )
         // Ordinal, because the expression carries bound parameters that would

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -46,6 +46,7 @@ import {
 } from "./time-range";
 import type {
   AnalyticsSummary,
+  FacetDimension,
   GasSpend,
   NetworkBreakdown,
   NormalizedStatus,
@@ -1699,14 +1700,18 @@ export function getRunFacets(
     customStart?: string;
     customEnd?: string;
     projectId?: string;
+    /** Which counts to compute; only status is cheap enough to poll for. */
+    dimensions?: FacetDimension[];
   } = {}
 ): Promise<RunFacets> {
-  const { customStart, customEnd, projectId, ...filters } = options;
+  const { customStart, customEnd, projectId, dimensions, ...filters } = options;
+  const wanted = new Set<FacetDimension>(dimensions ?? ["status"]);
   const compute = () =>
     computeRunFacets(
       organizationId,
       range,
       filters,
+      wanted,
       customStart,
       customEnd,
       projectId
@@ -1717,7 +1722,12 @@ export function getRunFacets(
     return compute();
   }
   return cachedAnalytics(
-    analyticsCacheKey("facets", [organizationId, range, projectId]),
+    analyticsCacheKey("facets", [
+      organizationId,
+      range,
+      projectId,
+      [...wanted].sort().join("+"),
+    ]),
     compute
   );
 }
@@ -1737,6 +1747,7 @@ async function computeRunFacets(
   organizationId: string,
   range: TimeRange,
   filters: RunQueryFilters,
+  dimensions: Set<FacetDimension>,
   customStart?: string,
   customEnd?: string,
   projectId?: string
@@ -1745,56 +1756,70 @@ async function computeRunFacets(
   const rangeEnd = customEnd ? new Date(customEnd) : new Date();
   const wanted = resolveSources(filters.sources, projectId);
 
+  // Both of these read the step logs, the table that took prod down when the
+  // run filters walked it too eagerly, so neither is computed unless asked for.
   const [networkCounts, gasCounts] = await Promise.all([
-    computeNetworkFacets(
-      organizationId,
-      rangeStart,
-      rangeEnd,
-      filters,
-      projectId
-    ),
-    computeGasFacets(organizationId, rangeStart, rangeEnd, filters, projectId),
+    dimensions.has("network")
+      ? computeNetworkFacets(
+          organizationId,
+          rangeStart,
+          rangeEnd,
+          filters,
+          projectId
+        )
+      : {},
+    dimensions.has("gas")
+      ? computeGasFacets(
+          organizationId,
+          rangeStart,
+          rangeEnd,
+          filters,
+          projectId
+        )
+      : {},
   ]);
 
-  const workflowRows = wanted.workflow
-    ? await db
-        .select({ status: workflowNormalizedStatus, value: count() })
-        .from(workflowExecutions)
-        .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-        .where(
-          and(
-            eq(workflows.organizationId, organizationId),
-            projectId ? eq(workflows.projectId, projectId) : undefined,
-            gte(workflowExecutions.startedAt, rangeStart),
-            lt(workflowExecutions.startedAt, rangeEnd),
-            isNull(workflowExecutions.deletedAt),
-            ...workflowFilterConditions(
-              filters,
-              { organizationId, rangeStart, rangeEnd, projectId },
-              true
+  const workflowRows =
+    wanted.workflow && dimensions.has("status")
+      ? await db
+          .select({ status: workflowNormalizedStatus, value: count() })
+          .from(workflowExecutions)
+          .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
+          .where(
+            and(
+              eq(workflows.organizationId, organizationId),
+              projectId ? eq(workflows.projectId, projectId) : undefined,
+              gte(workflowExecutions.startedAt, rangeStart),
+              lt(workflowExecutions.startedAt, rangeEnd),
+              isNull(workflowExecutions.deletedAt),
+              ...workflowFilterConditions(
+                filters,
+                { organizationId, rangeStart, rangeEnd, projectId },
+                true
+              )
             )
           )
-        )
-        // Group by the select ordinal: the CASE carries a bound parameter, and
-        // repeating the expression here would bind a second placeholder that
-        // Postgres does not recognise as the same expression.
-        .groupBy(sql`1`)
-    : [];
+          // Group by the select ordinal: the CASE carries a bound parameter, and
+          // repeating the expression here would bind a second placeholder that
+          // Postgres does not recognise as the same expression.
+          .groupBy(sql`1`)
+      : [];
 
-  const directRows = wanted.direct
-    ? await db
-        .select({ status: directNormalizedStatus, value: count() })
-        .from(directExecutions)
-        .where(
-          and(
-            eq(directExecutions.organizationId, organizationId),
-            gte(directExecutions.createdAt, rangeStart),
-            lt(directExecutions.createdAt, rangeEnd),
-            ...directFilterConditions(filters, true)
+  const directRows =
+    wanted.direct && dimensions.has("status")
+      ? await db
+          .select({ status: directNormalizedStatus, value: count() })
+          .from(directExecutions)
+          .where(
+            and(
+              eq(directExecutions.organizationId, organizationId),
+              gte(directExecutions.createdAt, rangeStart),
+              lt(directExecutions.createdAt, rangeEnd),
+              ...directFilterConditions(filters, true)
+            )
           )
-        )
-        .groupBy(sql`1`)
-    : [];
+          .groupBy(sql`1`)
+      : [];
 
   const statusCounts: StatusFacets = {};
   for (const row of [...workflowRows, ...directRows]) {

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -1734,7 +1734,11 @@ export function getRunFacets(
 
 function hasFilters(filters: RunQueryFilters): boolean {
   return Boolean(
-    (filters.sources?.length ?? 0) > 0 ||
+    // Statuses reach this call for the network and gas dimensions, which do not
+    // lift them - and the cache key does not name them, so a status-filtered
+    // count must not be stored under, or served from, the unfiltered key.
+    (filters.statuses?.length ?? 0) > 0 ||
+      (filters.sources?.length ?? 0) > 0 ||
       (filters.networks?.length ?? 0) > 0 ||
       filters.durationMinMs !== undefined ||
       filters.durationMaxMs !== undefined ||
@@ -1989,10 +1993,6 @@ export async function getStepLogs(
   executionId: string,
   organizationId: string
 ): Promise<StepLog[]> {
-  // Both read the denormalised column first and the JSONB second, matching the
-  // runs table, so a row the backfill has reached and one it has not resolve
-  // the same way.
-  const stepNetwork = sql`COALESCE(${workflowExecutionLogs.network}, ${logInputField("network")})`;
   // `triggerGasUsed` is the last arm on purpose: it is the fee on the
   // transaction that fired an on-chain trigger, which the keeper did not send.
   // It is deliberately absent from `gasUsed` so no rollup counts it as the

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -324,8 +324,11 @@ function workflowLedgerTotals(scope: LogScope): SQL {
       FROM ${gasCreditUsage}
      WHERE ${gasCreditUsage.executionId} IS NOT NULL
        AND ${gasCreditUsage.organizationId} = ${scope.organizationId}
+       -- Lower bound only, for the same reason the step scan has none: the
+       -- charge is written when it settles, which can be after the window
+       -- closes for a run that started just inside it. An upper bound here
+       -- would drop that row and refile a sponsored run as wallet or free.
        AND ${gasCreditUsage.createdAt} >= ${scope.rangeStart.toISOString()}
-       AND ${gasCreditUsage.createdAt} < ${scope.rangeEnd.toISOString()}
      GROUP BY ${gasCreditUsage.executionId}
   )`;
 }

--- a/lib/analytics/runs-query.ts
+++ b/lib/analytics/runs-query.ts
@@ -1,5 +1,11 @@
 import { type DurationPresetId, durationPreset } from "./duration-presets";
-import type { GasSpend, NormalizedStatus, RunSource, TimeRange } from "./types";
+import type {
+  FacetDimension,
+  GasSpend,
+  NormalizedStatus,
+  RunSource,
+  TimeRange,
+} from "./types";
 
 export type RunsQueryInput = {
   range: TimeRange;
@@ -16,6 +22,8 @@ export type RunsQueryInput = {
   page?: number;
   /** Drop the status dimension, for the facet request that counts each status. */
   omitStatus?: boolean;
+  /** Which facet counts to ask for; the server defaults to status alone. */
+  dimensions?: FacetDimension[];
 };
 
 /**
@@ -48,6 +56,10 @@ export function buildRunsQuery(input: RunsQueryInput): string {
   }
   if (preset?.maxMs !== undefined) {
     params.set("durationMax", String(preset.maxMs));
+  }
+
+  for (const dimension of input.dimensions ?? []) {
+    params.append("dimension", dimension);
   }
 
   const search = input.search?.trim();

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -186,6 +186,15 @@ export type RunFacets = {
   gasCounts: Partial<Record<GasSpend, number>>;
 };
 
+/**
+ * Which counts a facets request wants. They are not equally cheap: status
+ * counts group `workflow_executions` alone, while network and gas both reach
+ * into the step logs - network to decode a chain out of JSONB, gas to run one
+ * count per bucket. Only status is cheap enough to ride the dashboard's poll;
+ * the other two are asked for when their dropdown is opened.
+ */
+export type FacetDimension = "status" | "network" | "gas";
+
 export type RunsFilters = RunQueryFilters & {
   range: TimeRange;
   cursor?: string;

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -174,6 +174,18 @@ export type RunQueryFilters = {
  */
 export type StatusFacets = Partial<Record<NormalizedStatus, number>>;
 
+/**
+ * Counts for every filter dimension that offers them, each computed with its
+ * own dimension lifted. Networks are keyed by the chain id a run's steps
+ * recorded, and include chains a run merely touched: a filter offering only the
+ * chains that spent gas hides every chain the org reads on.
+ */
+export type RunFacets = {
+  statusCounts: StatusFacets;
+  networkCounts: Record<string, number>;
+  gasCounts: Partial<Record<GasSpend, number>>;
+};
+
 export type RunsFilters = RunQueryFilters & {
   range: TimeRange;
   cursor?: string;

--- a/lib/atoms/analytics.ts
+++ b/lib/atoms/analytics.ts
@@ -7,7 +7,7 @@ import type {
   NormalizedStatus,
   RunSource,
   RunsResponse,
-  StatusFacets,
+  RunFacets,
   TimeRange,
   TimeSeriesBucket,
 } from "@/lib/analytics/types";
@@ -37,7 +37,11 @@ export const analyticsGasFiltersAtom = atom<GasSpend[]>([]);
 export const analyticsDurationFilterAtom = atom<DurationPresetId | null>(null);
 
 // Run counts per status, for the counts beside each status option.
-export const analyticsStatusFacetsAtom = atom<StatusFacets>({});
+export const analyticsFacetsAtom = atom<RunFacets>({
+  statusCounts: {},
+  networkCounts: {},
+  gasCounts: {},
+});
 
 export const analyticsSearchAtom = atom("");
 

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -37,6 +37,7 @@ const REBALANCE_ID = `${PREFIX}wf_rebalance`;
 
 const BASE = "8453";
 const ARBITRUM = "42161";
+const OPTIMISM = "10";
 
 type Seed = {
   id: string;
@@ -47,6 +48,8 @@ type Seed = {
   network?: string;
   /** Carries the gas-station marker a web3 step core writes on a sponsored tx. */
   sponsored?: boolean;
+  /** Chain recorded only in the step's JSONB, with the column left null. */
+  legacyNetwork?: string;
 };
 
 // One run per interesting combination, so a filter that over- or under-selects
@@ -82,6 +85,15 @@ const SEEDS: Seed[] = [
     status: "success",
     durationMs: 2000,
     network: ARBITRUM,
+  },
+  {
+    id: `${PREFIX}legacy_chain`,
+    workflowId: NIGHTLY_ID,
+    status: "success",
+    durationMs: 2500,
+    // Chain only in the JSONB, as every row written before the denormalised
+    // column existed still has it.
+    legacyNetwork: OPTIMISM,
   },
   {
     id: `${PREFIX}sponsored`,
@@ -196,13 +208,14 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       nodeName: string;
       nodeType: string;
       status: "success";
-      network: string;
+      network: string | null;
       gasUsedWei: string | null;
       outputRaw: { sponsored: boolean } | null;
+      input: unknown;
       startedAt: Date;
     }> = [];
     for (const seed of SEEDS) {
-      if (seed.network === undefined) {
+      if (seed.network === undefined && seed.legacyNetwork === undefined) {
         continue;
       }
       logRows.push({
@@ -212,7 +225,10 @@ describe.skipIf(SKIP)("analytics run filters", () => {
         nodeName: "Step",
         nodeType: "web3/transfer",
         status: "success" as const,
-        network: seed.network,
+        network: seed.network ?? null,
+        input: seed.legacyNetwork
+          ? JSON.stringify({ network: seed.legacyNetwork })
+          : null,
         gasUsedWei: seed.status === "success" ? "21000" : null,
         outputRaw: seed.sponsored ? { sponsored: true } : null,
         startedAt: now,
@@ -277,7 +293,12 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       [`${PREFIX}external_err`, `${PREFIX}system_err`].sort()
     );
     expect(await idsFor({ durationMaxMs: 5000 })).toEqual(
-      [`${PREFIX}ok`, `${PREFIX}sponsored`, `${PREFIX}user_err`].sort()
+      [
+        `${PREFIX}ok`,
+        `${PREFIX}legacy_chain`,
+        `${PREFIX}sponsored`,
+        `${PREFIX}user_err`,
+      ].sort()
     );
   });
 
@@ -297,7 +318,9 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(await idsFor({ gas: ["sponsored"] })).toEqual([
       `${PREFIX}sponsored`,
     ]);
-    expect(await idsFor({ gas: ["wallet"] })).toEqual([`${PREFIX}ok`]);
+    expect(await idsFor({ gas: ["wallet"] })).toEqual(
+      [`${PREFIX}ok`, `${PREFIX}legacy_chain`].sort()
+    );
 
     const free = await idsFor({ gas: ["free"] });
     expect(free).not.toContain(`${PREFIX}ok`);
@@ -321,15 +344,20 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     const { networkCounts } = await getRunFacets(ORG_ID, "7d");
     // The seeded runs record a chain on their step but no gas on most of them.
     // Sourcing the options from the gas breakdown dropped exactly those.
-    expect(Object.keys(networkCounts).sort()).toEqual([ARBITRUM, BASE].sort());
+    // Optimism is only in the JSONB. Listing options from the denormalised
+    // column alone dropped it, while the filter would have matched it.
+    expect(Object.keys(networkCounts).sort()).toEqual(
+      [ARBITRUM, BASE, OPTIMISM].sort()
+    );
     expect(networkCounts[BASE]).toBeGreaterThan(0);
     expect(networkCounts[ARBITRUM]).toBeGreaterThan(0);
+    expect(networkCounts[OPTIMISM]).toBe(1);
   });
 
   it("counts each gas bucket, including the empty ones", async () => {
     const { gasCounts } = await getRunFacets(ORG_ID, "7d");
     expect(gasCounts.sponsored).toBe(1);
-    expect(gasCounts.wallet).toBe(1);
+    expect(gasCounts.wallet).toBe(2);
     expect(gasCounts.free).toBeGreaterThan(0);
   });
 
@@ -338,7 +366,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(facets.error).toBe(1);
     expect(facets.external_error).toBe(1);
     expect(facets.system_error).toBe(1);
-    expect(facets.success).toBe(2);
+    expect(facets.success).toBe(3);
     expect(facets.skipped).toBe(1);
     expect(facets.running).toBe(1);
   });

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type {
+  FacetDimension,
   NormalizedStatus,
   RunFacets,
   RunQueryFilters,
@@ -128,7 +129,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
   let getRunFacets: (
     organizationId: string,
     range: "7d",
-    options?: RunQueryFilters
+    options?: RunQueryFilters & { dimensions?: FacetDimension[] }
   ) => Promise<RunFacets>;
 
   async function cleanup(): Promise<void> {
@@ -387,11 +388,13 @@ describe.skipIf(SKIP)("analytics run filters", () => {
 
     // Isolation runs both ways: the neighbour sees only its own run, and its
     // run never inflates this org's counts.
-    const neighbour = await getRunFacets(OTHER_ORG_ID, "7d");
+    const neighbour = await getRunFacets(OTHER_ORG_ID, "7d", {
+      dimensions: ["network", "gas"],
+    });
     expect(neighbour.networkCounts).toEqual({ [BASE]: 1 });
     expect(neighbour.gasCounts.wallet).toBe(1);
 
-    const mine = await getRunFacets(ORG_ID, "7d");
+    const mine = await getRunFacets(ORG_ID, "7d", { dimensions: ["network"] });
     const myBaseRuns = await idsFor({ networks: [BASE] });
     expect(mine.networkCounts[BASE]).toBe(myBaseRuns.length);
     expect(myBaseRuns).not.toContain(`${PREFIX}other_run`);
@@ -406,7 +409,9 @@ describe.skipIf(SKIP)("analytics run filters", () => {
   });
 
   it("offers every chain a run touched, not only the ones that spent gas", async () => {
-    const { networkCounts } = await getRunFacets(ORG_ID, "7d");
+    const { networkCounts } = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["network"],
+    });
     // The seeded runs record a chain on their step but no gas on most of them.
     // Sourcing the options from the gas breakdown dropped exactly those.
     // Optimism is only in the JSONB. Listing options from the denormalised
@@ -419,15 +424,37 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(networkCounts[OPTIMISM]).toBe(1);
   });
 
+  // The dashboard polls facets every ten seconds for every open tab. Network
+  // and gas both read the step logs, so a default that included them would put
+  // that table back under exactly the load that took prod down.
+  it("counts only statuses unless the costly dimensions are asked for", async () => {
+    const polled = await getRunFacets(ORG_ID, "7d");
+    expect(Object.keys(polled.statusCounts).length).toBeGreaterThan(0);
+    expect(polled.networkCounts).toEqual({});
+    expect(polled.gasCounts).toEqual({});
+
+    const onDemand = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["network"],
+    });
+    expect(Object.keys(onDemand.networkCounts).length).toBeGreaterThan(0);
+    // And asking for one does not silently drag the others along.
+    expect(onDemand.gasCounts).toEqual({});
+    expect(onDemand.statusCounts).toEqual({});
+  });
+
   it("counts each gas bucket, including the empty ones", async () => {
-    const { gasCounts } = await getRunFacets(ORG_ID, "7d");
+    const { gasCounts } = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["gas"],
+    });
     expect(gasCounts.sponsored).toBe(1);
     expect(gasCounts.wallet).toBe(2);
     expect(gasCounts.free).toBeGreaterThan(0);
   });
 
   it("counts each status separately for the filter's counts", async () => {
-    const { statusCounts: facets } = await getRunFacets(ORG_ID, "7d");
+    const { statusCounts: facets } = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["status"],
+    });
     expect(facets.error).toBe(1);
     expect(facets.external_error).toBe(1);
     expect(facets.system_error).toBe(1);
@@ -438,6 +465,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
 
   it("counts under the other filters but not under the status filter", async () => {
     const { statusCounts: facets } = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["status"],
       networks: [ARBITRUM],
       statuses: ["success"],
     });

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -4,8 +4,8 @@ import postgres from "postgres";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type {
   NormalizedStatus,
+  RunFacets,
   RunQueryFilters,
-  StatusFacets,
   UnifiedRun,
 } from "../../../lib/analytics/types";
 import {
@@ -111,11 +111,11 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     range: "7d",
     options?: RunQueryFilters & { limit?: number }
   ) => Promise<{ runs: UnifiedRun[]; total: number }>;
-  let getStatusFacets: (
+  let getRunFacets: (
     organizationId: string,
     range: "7d",
     options?: RunQueryFilters
-  ) => Promise<StatusFacets>;
+  ) => Promise<RunFacets>;
 
   async function cleanup(): Promise<void> {
     await queryClient`DELETE FROM workflow_execution_logs WHERE execution_id LIKE ${`${PREFIX}%`}`;
@@ -220,7 +220,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     }
     await db.insert(workflowExecutionLogs).values(logRows);
 
-    ({ getUnifiedRuns, getStatusFacets } = await import(
+    ({ getUnifiedRuns, getRunFacets } = await import(
       "@/lib/analytics/queries"
     ));
   });
@@ -317,8 +317,24 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(total).toBe(3);
   });
 
+  it("offers every chain a run touched, not only the ones that spent gas", async () => {
+    const { networkCounts } = await getRunFacets(ORG_ID, "7d");
+    // The seeded runs record a chain on their step but no gas on most of them.
+    // Sourcing the options from the gas breakdown dropped exactly those.
+    expect(Object.keys(networkCounts).sort()).toEqual([ARBITRUM, BASE].sort());
+    expect(networkCounts[BASE]).toBeGreaterThan(0);
+    expect(networkCounts[ARBITRUM]).toBeGreaterThan(0);
+  });
+
+  it("counts each gas bucket, including the empty ones", async () => {
+    const { gasCounts } = await getRunFacets(ORG_ID, "7d");
+    expect(gasCounts.sponsored).toBe(1);
+    expect(gasCounts.wallet).toBe(1);
+    expect(gasCounts.free).toBeGreaterThan(0);
+  });
+
   it("counts each status separately for the filter's counts", async () => {
-    const facets = await getStatusFacets(ORG_ID, "7d");
+    const { statusCounts: facets } = await getRunFacets(ORG_ID, "7d");
     expect(facets.error).toBe(1);
     expect(facets.external_error).toBe(1);
     expect(facets.system_error).toBe(1);
@@ -328,7 +344,7 @@ describe.skipIf(SKIP)("analytics run filters", () => {
   });
 
   it("counts under the other filters but not under the status filter", async () => {
-    const facets = await getStatusFacets(ORG_ID, "7d", {
+    const { statusCounts: facets } = await getRunFacets(ORG_ID, "7d", {
       networks: [ARBITRUM],
       statuses: ["success"],
     });

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -123,13 +123,21 @@ describe.skipIf(SKIP)("analytics run filters", () => {
   let db: ReturnType<typeof drizzle>;
   let getUnifiedRuns: (
     organizationId: string,
-    range: "7d",
-    options?: RunQueryFilters & { limit?: number }
+    range: "7d" | "custom",
+    options?: RunQueryFilters & {
+      limit?: number;
+      customStart?: string;
+      customEnd?: string;
+    }
   ) => Promise<{ runs: UnifiedRun[]; total: number }>;
   let getRunFacets: (
     organizationId: string,
     range: "7d",
-    options?: RunQueryFilters & { dimensions?: FacetDimension[] }
+    options?: RunQueryFilters & {
+      dimensions?: FacetDimension[];
+      customStart?: string;
+      customEnd?: string;
+    }
   ) => Promise<RunFacets>;
 
   async function cleanup(): Promise<void> {
@@ -398,6 +406,55 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     const myBaseRuns = await idsFor({ networks: [BASE] });
     expect(mine.networkCounts[BASE]).toBe(myBaseRuns.length);
     expect(myBaseRuns).not.toContain(`${PREFIX}other_run`);
+  });
+
+  // A gas charge is recorded when it settles, so for a run that started just
+  // inside a closed window the ledger row can land after the window's end.
+  it("still reads a charge that settled after the window closed", async () => {
+    const runStartedAt = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    const windowEnd = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const settledAfter = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(workflowExecutions).values({
+      id: `${PREFIX}late_charge`,
+      workflowId: NIGHTLY_ID,
+      userId: USER_ID,
+      status: "success",
+      duration: "1000",
+      startedAt: runStartedAt,
+      completedAt: runStartedAt,
+    });
+    await db.insert(workflowExecutionLogs).values({
+      id: `${PREFIX}late_charge_log`,
+      executionId: `${PREFIX}late_charge`,
+      nodeId: "n1",
+      nodeName: "Step",
+      nodeType: "web3/transfer",
+      status: "success",
+      network: BASE,
+      gasUsedWei: "21000",
+      startedAt: runStartedAt,
+    });
+    await queryClient`
+      INSERT INTO gas_credit_usage
+        (id, organization_id, chain_id, tx_hash, execution_id, gas_used,
+         gas_price_wei, gas_cost_wei, gas_cost_micro_usd, eth_price_usd, created_at)
+      VALUES (${`${PREFIX}late_credit`}, ${ORG_ID}, 8453, '0xlate',
+              ${`${PREFIX}late_charge`}, '21000', '1', '21000', '1', '1',
+              ${settledAfter.toISOString()})`;
+
+    const { runs } = await getUnifiedRuns(ORG_ID, "custom", {
+      gas: ["sponsored"],
+      limit: 50,
+      customStart: runStartedAt.toISOString(),
+      customEnd: windowEnd.toISOString(),
+    });
+    expect(runs.map((run) => run.id)).toContain(`${PREFIX}late_charge`);
+
+    // Removed again so the count assertions further down keep their fixture.
+    await queryClient`DELETE FROM gas_credit_usage WHERE id = ${`${PREFIX}late_credit`}`;
+    await queryClient`DELETE FROM workflow_execution_logs WHERE id = ${`${PREFIX}late_charge_log`}`;
+    await queryClient`DELETE FROM workflow_executions WHERE id = ${`${PREFIX}late_charge`}`;
   });
 
   it("reports the total under the filters, not the unfiltered count", async () => {

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -38,6 +38,8 @@ const REBALANCE_ID = `${PREFIX}wf_rebalance`;
 const BASE = "8453";
 const ARBITRUM = "42161";
 const OPTIMISM = "10";
+// A neighbour whose rows must never appear in the org under test.
+const OTHER_ORG_ID = `${PREFIX}org_other`;
 
 type Seed = {
   id: string;
@@ -187,6 +189,42 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       },
     ]);
 
+    await db.insert(organization).values({
+      id: OTHER_ORG_ID,
+      name: "other org",
+      slug: OTHER_ORG_ID,
+      createdAt: now,
+    });
+    await db.insert(workflows).values({
+      id: `${PREFIX}wf_other`,
+      name: "Neighbour workflow",
+      userId: USER_ID,
+      organizationId: OTHER_ORG_ID,
+      enabled: true,
+      nodes: [],
+      edges: [],
+    });
+    await db.insert(workflowExecutions).values({
+      id: `${PREFIX}other_run`,
+      workflowId: `${PREFIX}wf_other`,
+      userId: USER_ID,
+      status: "success",
+      duration: "1000",
+      startedAt: now,
+      completedAt: now,
+    });
+    await db.insert(workflowExecutionLogs).values({
+      id: `${PREFIX}other_log`,
+      executionId: `${PREFIX}other_run`,
+      nodeId: "n1",
+      nodeName: "Step",
+      nodeType: "web3/transfer",
+      status: "success",
+      network: BASE,
+      gasUsedWei: "99999",
+      startedAt: now,
+    });
+
     await db.insert(workflowExecutions).values(
       SEEDS.map((seed) => ({
         id: seed.id,
@@ -330,6 +368,33 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(await idsFor({ gas: ["sponsored", "wallet", "free"] })).toEqual(
       await idsFor({})
     );
+  });
+
+  // Results were never wrong here - the outer query is org-scoped, so a
+  // neighbour's rows could not appear. What the subqueries lacked was a bound
+  // of their own, so they aggregated every tenant's step logs, and paid the
+  // JSONB decode on all of them, before the outer filter threw the work away.
+  // This guards the half that is observable from the outside.
+  it("keeps one organization's runs and counts to itself", async () => {
+    for (const filters of [
+      { gas: ["wallet"] as const },
+      { gas: ["sponsored"] as const },
+      { networks: [BASE] },
+    ]) {
+      const ids = await idsFor(filters as RunQueryFilters);
+      expect(ids.every((id) => id.startsWith(PREFIX))).toBe(true);
+    }
+
+    // Isolation runs both ways: the neighbour sees only its own run, and its
+    // run never inflates this org's counts.
+    const neighbour = await getRunFacets(OTHER_ORG_ID, "7d");
+    expect(neighbour.networkCounts).toEqual({ [BASE]: 1 });
+    expect(neighbour.gasCounts.wallet).toBe(1);
+
+    const mine = await getRunFacets(ORG_ID, "7d");
+    const myBaseRuns = await idsFor({ networks: [BASE] });
+    expect(mine.networkCounts[BASE]).toBe(myBaseRuns.length);
+    expect(myBaseRuns).not.toContain(`${PREFIX}other_run`);
   });
 
   it("reports the total under the filters, not the unfiltered count", async () => {

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -383,6 +383,10 @@ describe.skipIf(SKIP)("analytics run filters", () => {
       { networks: [BASE] },
     ]) {
       const ids = await idsFor(filters as RunQueryFilters);
+      // The neighbour's run shares PREFIX - teardown deletes by it - so the
+      // prefix alone proves nothing about tenancy. Name the row that would
+      // leak.
+      expect(ids).not.toContain(`${PREFIX}other_run`);
       expect(ids.every((id) => id.startsWith(PREFIX))).toBe(true);
     }
 
@@ -421,6 +425,20 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     );
     expect(networkCounts[BASE]).toBeGreaterThan(0);
     expect(networkCounts[ARBITRUM]).toBeGreaterThan(0);
+    expect(networkCounts[OPTIMISM]).toBe(1);
+  });
+
+  // Only the dimension being counted is lifted. Counting chains across every
+  // status would label Base with three runs while ticking it returned one, and
+  // - because the facets cache key does not name the statuses - would serve
+  // that same answer to every other status selection.
+  it("counts chains under the status filter, not across all statuses", async () => {
+    const { networkCounts } = await getRunFacets(ORG_ID, "7d", {
+      dimensions: ["network"],
+      statuses: ["success"],
+    });
+    expect(networkCounts[BASE]).toBe(1);
+    expect(networkCounts[ARBITRUM]).toBe(1);
     expect(networkCounts[OPTIMISM]).toBe(1);
   });
 


### PR DESCRIPTION
Follow-ups from reviewing the run filters on a deployed environment.

**Only one network appeared in the filter.** The options came from the gas breakdown, which counts only steps that spent gas. A chain the org merely reads on, or one whose gas was never recorded against a step, never appeared as something to filter by. Networks now come from their own facet: distinct chains the window's runs touched, counted per run rather than per step, with every other filter applied. The gas breakdown keeps its own meaning for the chart.

**Gas filtering.** The predicate is sound and was verified against all four shapes real data comes in: gas in the denormalised column, gas only in the pre-backfill JSONB, sponsorship recorded only in the ledger, and no gas at all. Each returns exactly the runs it should. What was missing was any sense of how large each bucket is, so a legitimately empty bucket was indistinguishable from a filter that does nothing. The gas options now carry counts.

**Filter order** now follows the table columns: name, status, source, duration, network, gas.

**Calendar.** Two months side by side each padded their grid with the neighbour's days, so the end of September was drawn in both panels, once as its own date and once as October's padding, and a selected range lit up in both. The padding is off for the range picker.

Verified with 12 database-backed tests against real Postgres, including the network facet returning chains that spent no gas, plus 26 unit tests.