### PR TITLE
fix: KEEP-1286 update the two fixtures the lock and session changes invalidated

### DIFF
--- a/tests/e2e/vitest/reaper-route.test.ts
+++ b/tests/e2e/vitest/reaper-route.test.ts
@@ -177,13 +177,16 @@ describe.skipIf(SKIP)("reaper route - real-DB integration", () => {
       startedAt: TWO_HOURS_AGO,
     });
 
-    // Wallet lock held by the stale execution → reaper must release it.
+    // Wallet lock held by the stale execution → reaper must release it. The
+    // lock has already lapsed: the reaper only clears locks past expires_at,
+    // because a lock still in the future is one a live heartbeat is renewing.
+    // reaper-classification.test.ts covers the live-lock-is-retained half.
     await db.insert(walletLocks).values({
       walletAddress: TEST_WALLET,
       chainId: TEST_CHAIN_ID,
       lockedBy: staleRunningId,
       lockedAt: TWO_HOURS_AGO,
-      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+      expiresAt: TEN_MINUTES_AGO,
     });
 
     const { GET } = (await import(

--- a/tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts
+++ b/tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts
@@ -133,13 +133,22 @@ vi.mock("@/lib/web3/nonce-manager", () => ({
       walletAddress: string,
       _chainId: number,
       _executionId: string,
-      provider: {
-        getTransactionCount: (addr: string, tag: string) => Promise<number>;
+      // withNonceSession hands over the RpcProviderManager, not a bare
+      // provider, so the session's chain reads get the same per-attempt
+      // timeout and fallback as every other RPC call. Read through the
+      // failover wrapper the way the real chainReader does.
+      rpc: {
+        executeWithFailover: <T>(
+          operation: (provider: {
+            getTransactionCount: (addr: string, tag: string) => Promise<number>;
+          }) => Promise<T>,
+          operationType: "read"
+        ) => Promise<T>;
       }
     ) => {
-      const onChain = await provider.getTransactionCount(
-        walletAddress,
-        "pending"
+      const onChain = await rpc.executeWithFailover(
+        (provider) => provider.getTransactionCount(walletAddress, "pending"),
+        "read"
       );
       nonceCounter.current = onChain;
       sessionMock.walletAddress = walletAddress;


### PR DESCRIPTION
Both `e2e-vitest-ephemeral` failures on staging are fixtures that still describe the behaviour KEEP-1286 (#2252) replaced, not regressions in it. The first staging run to fail is cb70a05c5 - that merge exactly; every run before it passed. No production code changes here.

## reaper-route

`reapStaleExecutions` now clears only locks past `expires_at`. A lock still in the future is one a live heartbeat is renewing, and clearing it hands the wallet to a waiter while the holder is mid-write.

The fixture seeded the lock an hour out and asserted the reaper cleared it, so it now correctly survives the pass and the assertion fails. Seeded lapsed instead, which keeps the route test proving the release path end to end through the HTTP handler. `reaper-classification.test.ts` already covers the live-lock-is-retained half, added in the same commit.

## safe-roles-orchestrator-fork

The failing assertion was a symptom. The underlying error in the run log:

```
TypeError: provider.getTransactionCount is not a function
  at Object.startSession (tests/e2e/vitest/safe-roles-orchestrator-fork.test.ts:140:38)
  at withNonceSession (lib/web3/transaction-manager.ts:402:54)
```

`withNonceSession` now hands `startSession` the `RpcProviderManager` rather than `context.rpcManager.getProvider()`, so session reads get the same per-attempt timeout and failover as every other RPC call. This file stubs `getNonceManager`, and its `startSession` read `getTransactionCount` straight off that fourth argument. It threw, `installRolesWithInitialConfig` caught it and returned `success: false`, and the round-trip assertion failed on the result rather than the cause.

The stub now reads through `executeWithFailover(..., "read")`, the way the real `chainReader` does.

`transaction-flow.test.ts` calls the real `startSession` with a bare provider, which `chainReader` still accepts, and `write-failover.test.ts` uses `vi.fn()`. This stub was the only one that assumed the old shape.

## Verification

- `tsc --noEmit` clean across the project.
- `reaper-route.test.ts` 7/7 against a real Postgres. Restoring the pre-fix file reproduces the exact CI assertion locally, so the fixture change is confirmed as the cause rather than inferred.
- The fork test was not run locally - it needs an anvil mainnet fork against a public archive upstream. CI is the check on that half.