### PR TITLE
fix: KEEP-1293 retry only pre-broadcast failures and drop the gas-bump framing

### DIFF
--- a/app/api/execute/_lib/retry.ts
+++ b/app/api/execute/_lib/retry.ts
@@ -5,9 +5,23 @@ import type { RetryConfig } from "./types";
 const DEFAULT_MAX_RETRIES = 3;
 export const DEFAULT_TIMEOUT_MS = 120_000;
 
+/**
+ * The shape the web3 step cores actually return. The failure branch carries a
+ * `transactionHash` whenever the send reached the chain but its outcome could
+ * not be read - see the OnChainPendingError path in
+ * lib/web3/chain-adapter/evm.ts and its handling in
+ * plugins/web3/steps/write-contract-core.ts - and an `errorClass` alongside it.
+ * Modelling that hash is what lets the retry gate below see a live
+ * transaction instead of only a string.
+ */
 export type TransactionResult =
   | { success: true; transactionHash: string; [key: string]: unknown }
-  | { success: false; error: string };
+  | {
+      success: false;
+      error: string;
+      transactionHash?: string;
+      [key: string]: unknown;
+    };
 
 type ExecuteFn<T> = () => Promise<T>;
 
@@ -19,7 +33,8 @@ type SuccessPredicate<T> = (result: T) => boolean;
 
 /**
  * Extracts an error message from a failed result for retryability checks.
- * Return undefined if the result has no extractable error string.
+ * Return undefined to make the result non-retryable, either because it has no
+ * extractable error string or because the extractor knows a retry is unsafe.
  */
 type ErrorExtractor<T> = (result: T) => string | undefined;
 
@@ -54,8 +69,25 @@ type RetryOptions<T> = {
 };
 
 const TX_SUCCESS: SuccessPredicate<TransactionResult> = (r) => r.success;
-const TX_ERROR: ErrorExtractor<TransactionResult> = (r) =>
-  r.success ? undefined : r.error;
+
+/**
+ * A failure carrying a transaction hash is never retryable, whatever it says.
+ * The hash is proof that a transaction is live: it was broadcast and either
+ * reverted or could not be read back. A retry cannot replace it - nothing is
+ * pinned, so the next attempt signs an independent transaction at the next
+ * nonce - so the hash decides this, not the error text. Withholding the string
+ * is what makes the result non-retryable; it is still carried on the `failed`
+ * outcome, and the node route reads the hash off it.
+ */
+const TX_ERROR: ErrorExtractor<TransactionResult> = (r) => {
+  if (r.success) {
+    return;
+  }
+  if (typeof r.transactionHash === "string" && r.transactionHash !== "") {
+    return;
+  }
+  return r.error;
+};
 
 /**
  * Default options for web3 TransactionResult-shaped outputs.
@@ -80,14 +112,21 @@ export const genericRetryOptions: RetryOptions<unknown> = {
  * A retry re-runs executeFn from scratch. It is not a replacement transaction:
  * nothing is pinned, so a web3 step that retries opens a new nonce session and
  * signs an independent transaction at the next nonce. Retries are therefore
- * only safe when the previous attempt is known not to have broadcast, which is
- * what isRetryableError below is responsible for deciding.
+ * only safe when the previous attempt is known not to have broadcast.
  *
- * The timeout path is the exception, and the caller carries it: on timeout the
- * in-flight executeFn promise is abandoned but not cancelled, and a transaction
- * it already broadcast can still confirm. A timeoutMs below the chain's
- * confirmation latency can therefore produce two confirmed transactions. Set
- * timeoutMs above the confirmation latency of the target chain.
+ * Two things decide that, in order. The guarantee is the hash gate in TX_ERROR
+ * above: a returned failure carrying a transaction hash is never retried, so
+ * an outcome the step could not read back cannot be sent twice. The string
+ * list below is a secondary filter over the failures that carry no hash, and
+ * it is a heuristic - it can only ever say which error texts look like a send
+ * that did not happen.
+ *
+ * Neither covers the timeout path, which the caller carries: on timeout the
+ * in-flight executeFn promise is abandoned but not cancelled, so no result and
+ * no hash ever come back, and a transaction it already broadcast can still
+ * confirm. A timeoutMs below the chain's confirmation latency can therefore
+ * produce two confirmed transactions. Set timeoutMs above the confirmation
+ * latency of the target chain.
  */
 export async function executeWithRetry<T>(
   executeFn: ExecuteFn<T>,
@@ -133,12 +172,18 @@ export async function executeWithRetry<T>(
 }
 
 /**
- * Connection-level failures only: the attempt came back with no result at all.
- * A retry signs a fresh transaction at the next nonce, so nothing that says a
- * transaction is already live may be listed here - "nonce has already been
- * used", "already known", "replacement fee too low" and "transaction
- * underpriced" each report a broadcast that happened, and retrying on them
- * sends a second, independent transaction rather than replacing the first.
+ * Consulted only for failures that carry no transaction hash, so it is a
+ * filter and not the guarantee - the hash gate in TX_ERROR is. A retry signs a
+ * fresh transaction at the next nonce, so nothing whose text implies a
+ * broadcast already happened may be listed here. That rules out the nonce
+ * conflicts enumerated in NONCE_CONFLICT_MESSAGE_PATTERNS
+ * (lib/web3/submit-signed.ts), which is the canonical set: "nonce has already
+ * been used", "already known" and "replacement fee too low" were listed here
+ * and are gone. Bare "transaction underpriced" was also listed and is also
+ * gone, for a different reason - it is the pool rejecting a fee below its
+ * minimum, so nothing is live, but with no gas bump a retry re-sends the same
+ * fee and fails identically. Only the "replacement transaction underpriced"
+ * variant reports a broadcast.
  */
 const RETRYABLE_PATTERNS = ["timeout", "ETIMEDOUT", "ECONNRESET"];
 

--- a/app/api/execute/_lib/retry.ts
+++ b/app/api/execute/_lib/retry.ts
@@ -4,17 +4,12 @@ import type { RetryConfig } from "./types";
 
 const DEFAULT_MAX_RETRIES = 3;
 export const DEFAULT_TIMEOUT_MS = 120_000;
-const DEFAULT_GAS_BUMP_PERCENT = 10;
 
 export type TransactionResult =
   | { success: true; transactionHash: string; [key: string]: unknown }
   | { success: false; error: string };
 
-type GasBumpOverrides = {
-  gasBumpMultiplier?: number;
-};
-
-type ExecuteFn<T> = (overrides?: GasBumpOverrides) => Promise<T>;
+type ExecuteFn<T> = () => Promise<T>;
 
 /**
  * Determines whether a result represents a successful execution.
@@ -32,7 +27,6 @@ function resolveConfig(config?: RetryConfig): Required<RetryConfig> {
   return {
     maxRetries: config?.maxRetries ?? DEFAULT_MAX_RETRIES,
     timeoutMs: config?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-    gasBumpPercent: config?.gasBumpPercent ?? DEFAULT_GAS_BUMP_PERCENT,
   };
 }
 
@@ -81,20 +75,19 @@ export const genericRetryOptions: RetryOptions<unknown> = {
 };
 
 /**
- * Execute a function with automatic retry and optional gas price bumping.
+ * Execute a function with automatic retry.
  *
- * On timeout or failure, resubmits with a higher gas price multiplier.
- * Each retry bumps the multiplier by gasBumpPercent (default 10%).
+ * A retry re-runs executeFn from scratch. It is not a replacement transaction:
+ * nothing is pinned, so a web3 step that retries opens a new nonce session and
+ * signs an independent transaction at the next nonce. Retries are therefore
+ * only safe when the previous attempt is known not to have broadcast, which is
+ * what isRetryableError below is responsible for deciding.
  *
- * The executeFn receives optional GasBumpOverrides containing a cumulative
- * gas bump multiplier. The caller is responsible for applying this multiplier
- * to maxFeePerGas/maxPriorityFeePerGas when building the transaction.
- *
- * NOTE: On timeout, the original executeFn promise is abandoned but not cancelled.
- * For EVM transactions this is acceptable -- the retry uses a bumped gas price which
- * acts as a replacement transaction at the same nonce. If the original tx already
- * mined before the retry is submitted, the retry will fail with "nonce already used"
- * which is classified as retryable but will ultimately exhaust retries harmlessly.
+ * The timeout path is the exception, and the caller carries it: on timeout the
+ * in-flight executeFn promise is abandoned but not cancelled, and a transaction
+ * it already broadcast can still confirm. A timeoutMs below the chain's
+ * confirmation latency can therefore produce two confirmed transactions. Set
+ * timeoutMs above the confirmation latency of the target chain.
  */
 export async function executeWithRetry<T>(
   executeFn: ExecuteFn<T>,
@@ -103,16 +96,9 @@ export async function executeWithRetry<T>(
 ): Promise<RetryResult<T>> {
   const resolved = resolveConfig(config);
   let retryCount = 0;
-  let cumulativeBumpMultiplier = 1.0;
 
   for (let attempt = 0; attempt <= resolved.maxRetries; attempt++) {
-    const overrides: GasBumpOverrides =
-      attempt === 0 ? {} : { gasBumpMultiplier: cumulativeBumpMultiplier };
-
-    const resultOrTimeout = await withTimeout(
-      executeFn(overrides),
-      resolved.timeoutMs
-    );
+    const resultOrTimeout = await withTimeout(executeFn(), resolved.timeoutMs);
 
     if (resultOrTimeout === "timeout") {
       if (attempt >= resolved.maxRetries) {
@@ -123,7 +109,6 @@ export async function executeWithRetry<T>(
         };
       }
       retryCount++;
-      cumulativeBumpMultiplier *= 1 + resolved.gasBumpPercent / 100;
       continue;
     }
 
@@ -138,7 +123,6 @@ export async function executeWithRetry<T>(
     }
 
     retryCount++;
-    cumulativeBumpMultiplier *= 1 + resolved.gasBumpPercent / 100;
   }
 
   return {
@@ -148,15 +132,15 @@ export async function executeWithRetry<T>(
   };
 }
 
-const RETRYABLE_PATTERNS = [
-  "replacement fee too low",
-  "nonce has already been used",
-  "transaction underpriced",
-  "already known",
-  "timeout",
-  "ETIMEDOUT",
-  "ECONNRESET",
-];
+/**
+ * Connection-level failures only: the attempt came back with no result at all.
+ * A retry signs a fresh transaction at the next nonce, so nothing that says a
+ * transaction is already live may be listed here - "nonce has already been
+ * used", "already known", "replacement fee too low" and "transaction
+ * underpriced" each report a broadcast that happened, and retrying on them
+ * sends a second, independent transaction rather than replacing the first.
+ */
+const RETRYABLE_PATTERNS = ["timeout", "ETIMEDOUT", "ECONNRESET"];
 
 function isRetryableError(error: string): boolean {
   const lower = error.toLowerCase();

--- a/app/api/execute/_lib/types.ts
+++ b/app/api/execute/_lib/types.ts
@@ -59,7 +59,6 @@ export type ExecuteErrorResponse = {
 export type RetryConfig = {
   maxRetries?: number;
   timeoutMs?: number;
-  gasBumpPercent?: number;
 };
 
 export type NodeExecuteRequest = {

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -79,17 +79,6 @@ function validateRetryConfig(
       error: "retry.timeoutMs must be a number between 1000 and 600000",
     };
   }
-  if (
-    r.gasBumpPercent !== undefined &&
-    (typeof r.gasBumpPercent !== "number" ||
-      r.gasBumpPercent < 0 ||
-      r.gasBumpPercent > 100)
-  ) {
-    return {
-      valid: false,
-      error: "retry.gasBumpPercent must be a number between 0 and 100",
-    };
-  }
 
   const attempts = ((r.maxRetries as number | undefined) ?? 0) + 1;
   const perAttempt =
@@ -106,7 +95,6 @@ function validateRetryConfig(
     data: {
       maxRetries: r.maxRetries as number | undefined,
       timeoutMs: r.timeoutMs as number | undefined,
-      gasBumpPercent: r.gasBumpPercent as number | undefined,
     },
   };
 }

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -761,13 +761,15 @@ Check the status of a direct execution.
   evidence that nothing was retried. Where the field is set, each count is a
   fresh execution of the step rather than a replacement of an earlier
   transaction: nothing is resubmitted at a pinned nonce and no gas price is
-  bumped. Retries are limited to failures that returned no result at all
-  (connection resets and timeouts); an error reporting that a transaction is
-  already live - a used nonce, an already-known hash, an underpriced
-  replacement - is never retried, because a retry there would sign a second,
-  independent transaction at the next nonce. A timeout is the one case where
-  the earlier attempt may still be in flight: it is abandoned rather than
-  cancelled, so a per-attempt timeout shorter than the chain's confirmation
+  bumped. A failure that carries a transaction hash is therefore never
+  retried, whatever its message says: the hash means a transaction is already
+  live, and a retry would sign a second one rather than replace it. Of the
+  failures that carry no hash, only connection-level errors (resets and
+  timeouts) are retried, and an error reporting that a transaction is already
+  live - a used nonce, an already-known hash, an underpriced replacement - is
+  not. The one case left open is an attempt that exceeds its own per-attempt
+  timeout: it is abandoned rather than cancelled, so nothing comes back to
+  carry a hash, and a per-attempt timeout shorter than the chain's confirmation
   latency can leave two transactions confirmed.
 - `gasPriceWei`: the effective gas price, as a decimal string. On EVM chains
   this is in wei. On Solana it is the micro-lamports-per-compute-unit price of

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -754,11 +754,21 @@ Check the status of a direct execution.
   When a body sends both, the routes disagree about which wins: `contract-call`
   takes `network`, while `transfer` and `check-and-execute` take `chainId`.
   Send one.
-- `retryCount`: internal re-submissions of a node execution, which is
+- `retryCount`: internal re-executions of a node execution, which is
   `/api/execute/node` and is not covered by this page. It is always `0` for the
   transfer, contract-call and check-and-execute endpoints documented here,
-  whatever happened internally - those paths never set it. A `0` is therefore
-  not evidence that no nonce replacement or gas bump occurred.
+  whatever happened internally - those paths never set it, so a `0` is not
+  evidence that nothing was retried. Where the field is set, each count is a
+  fresh execution of the step rather than a replacement of an earlier
+  transaction: nothing is resubmitted at a pinned nonce and no gas price is
+  bumped. Retries are limited to failures that returned no result at all
+  (connection resets and timeouts); an error reporting that a transaction is
+  already live - a used nonce, an already-known hash, an underpriced
+  replacement - is never retried, because a retry there would sign a second,
+  independent transaction at the next nonce. A timeout is the one case where
+  the earlier attempt may still be in flight: it is abandoned rather than
+  cancelled, so a per-attempt timeout shorter than the chain's confirmation
+  latency can leave two transactions confirmed.
 - `gasPriceWei`: the effective gas price, as a decimal string. On EVM chains
   this is in wei. On Solana it is the micro-lamports-per-compute-unit price of
   the priority component, as described in

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 869
+      "line": 879
     },
     {
       "method": "POST",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -538,7 +538,7 @@
       "path": "/api/workflows/{workflowId}/simulate",
       "route_file": "app/api/workflows/[workflowId]/simulate/route.ts",
       "source": "docs/api/direct-execution.md",
-      "line": 879
+      "line": 881
     },
     {
       "method": "POST",

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -29,7 +29,7 @@ describe("executeWithRetry", () => {
       }
     });
 
-    it("retries on retryable error and eventually succeeds", async () => {
+    it("retries on a connection-level error and eventually succeeds", async () => {
       let attempt = 0;
       const result = await executeWithRetry<TransactionResult>(
         () => {
@@ -37,7 +37,7 @@ describe("executeWithRetry", () => {
           if (attempt < 3) {
             return Promise.resolve({
               success: false as const,
-              error: "nonce has already been used",
+              error: "connect ECONNRESET 10.0.0.1:443",
             });
           }
           return Promise.resolve({
@@ -52,6 +52,30 @@ describe("executeWithRetry", () => {
       expect(result.outcome).toBe("success");
       expect(result.retryCount).toBe(2);
     });
+
+    it.each([
+      "nonce has already been used",
+      "already known",
+      "replacement fee too low",
+      "transaction underpriced",
+    ])(
+      "does not retry post-broadcast error %s, which would send a second transaction",
+      async (error) => {
+        let calls = 0;
+        const result = await executeWithRetry<TransactionResult>(
+          () => {
+            calls++;
+            return Promise.resolve({ success: false as const, error });
+          },
+          { maxRetries: 3 },
+          transactionRetryOptions
+        );
+
+        expect(calls).toBe(1);
+        expect(result.outcome).toBe("failed");
+        expect(result.retryCount).toBe(0);
+      }
+    );
 
     it("returns failed on non-retryable error", async () => {
       const result = await executeWithRetry<TransactionResult>(
@@ -84,36 +108,6 @@ describe("executeWithRetry", () => {
       if (result.outcome === "timeout") {
         expect(result.error).toContain("Timed out");
       }
-    });
-
-    it("passes gas bump overrides on retries", async () => {
-      const overridesSeen: unknown[] = [];
-      let attempt = 0;
-
-      await executeWithRetry<TransactionResult>(
-        (overrides) => {
-          overridesSeen.push(overrides);
-          attempt++;
-          if (attempt < 3) {
-            return Promise.resolve({
-              success: false as const,
-              error: "transaction underpriced",
-            });
-          }
-          return Promise.resolve({
-            success: true as const,
-            transactionHash: "0x",
-          });
-        },
-        { maxRetries: 3, gasBumpPercent: 20 },
-        transactionRetryOptions
-      );
-
-      expect(overridesSeen[0]).toEqual({});
-      expect(overridesSeen[1]).toHaveProperty("gasBumpMultiplier");
-      const bump1 = (overridesSeen[1] as { gasBumpMultiplier: number })
-        .gasBumpMultiplier;
-      expect(bump1).toBeCloseTo(1.2, 5);
     });
   });
 

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -77,6 +77,31 @@ describe("executeWithRetry", () => {
       }
     );
 
+    it("does not retry a hash-carrying failure whose error reads as a timeout", async () => {
+      let calls = 0;
+      const result = await executeWithRetry<TransactionResult>(
+        () => {
+          calls++;
+          return Promise.resolve({
+            success: false as const,
+            error:
+              "Transaction sent but receipt could not be read (timeout (code=TIMEOUT))",
+            transactionHash: "0xbroadcast",
+            chainId: 11_155_111,
+          });
+        },
+        { maxRetries: 3 },
+        transactionRetryOptions
+      );
+
+      expect(calls).toBe(1);
+      expect(result.outcome).toBe("failed");
+      expect(result.retryCount).toBe(0);
+      if (result.outcome === "failed" && !result.result.success) {
+        expect(result.result.transactionHash).toBe("0xbroadcast");
+      }
+    });
+
     it("returns failed on non-retryable error", async () => {
       const result = await executeWithRetry<TransactionResult>(
         () =>


### PR DESCRIPTION
Linear: [KEEP-1293](https://linear.app/keeperhub/issue/KEEP-1293)

## Root cause

`POST /api/execute/node` accepts an opt-in `retry` body. The retry helper passed a cumulative gas-bump multiplier to its callback, and its comment described a timeout retry as acting "as a replacement transaction at the same nonce".

Neither is true. The route wraps the step as `async () => stepFn(stepInput)` and never binds the overrides, so a retry re-runs the step from scratch: a new nonce session is opened and an independent transaction is signed at nonce N+1, at the same fee. Nothing is pinned and nothing is replaced.

That would be merely useless if the retryable set were pre-broadcast errors. It was not. `RETRYABLE_PATTERNS` listed `nonce has already been used`, `already known`, `replacement fee too low` and `transaction underpriced` - the four signals that mean the previous attempt already reached the chain. Retrying on those broadcast a second, independent transaction. A caller who sets `retry.timeoutMs` below the chain's confirmation latency could end up with two confirmed transactions and a `failed` execution row.

## What changed

- `app/api/execute/_lib/retry.ts`
  - Removed the `GasBumpOverrides` / `gasBumpMultiplier` plumbing and the `DEFAULT_GAS_BUMP_PERCENT` constant. Nothing read them except the test that asserted they were passed.
  - Replaced the same-nonce-replacement comment with what the helper actually does, including the residual hazard the caller now owns: on timeout the in-flight promise is abandoned rather than cancelled, so a `timeoutMs` below the chain's confirmation latency can still leave two transactions confirmed.
  - `RETRYABLE_PATTERNS` is now `timeout`, `ETIMEDOUT`, `ECONNRESET` only, with a comment naming the four removed patterns and why they must not come back.
- `app/api/execute/_lib/types.ts` and `app/api/execute/node/route.ts`: dropped `retry.gasBumpPercent`. With the multiplier gone it configured nothing, so keeping a validated request field that bumps no gas would preserve exactly the framing this ticket removes. This is a loosening rather than a break: the field is not documented anywhere, and validation is not strict about unknown keys, so a body that still sends it is now ignored instead of range-checked. Flagging it as the one judgment call in the diff.
- `tests/unit/retry.test.ts`: dropped the gas-bump-overrides test; the "retries and eventually succeeds" case now uses `ECONNRESET` instead of `nonce has already been used`; and a new `it.each` case asserts that each of the four post-broadcast strings is called exactly once, returns `failed`, and reports `retryCount: 0`. That test is the regression guard for the double-send.
- `docs/api/direct-execution.md`: rewrote the `retryCount` bullet, which claimed a `0` "is not evidence that no nonce replacement or gas bump occurred". It now says a count is a fresh execution rather than a replacement, that retries are limited to failures returning no result, that already-live errors are never retried, and that a short per-attempt timeout can still leave two transactions confirmed. `specs/api-coverage.json` regenerated with `pnpm check:api-docs` (one line-number shift).

## What this deliberately does not do

Same-nonce replacement and nonce pinning were considered and rejected on KEEP-1291. This is the cheap branch: stop retrying on errors that mean the first transaction landed, and make the code and the docs describe what actually happens. The timeout window remains, now documented rather than papered over.

## Verification

`tsc --noEmit` clean, `biome check` clean on the changed files, `vitest run tests/unit/retry.test.ts tests/unit/oauth-scope-route-gate.test.ts tests/unit/execute-auth-anonymous.test.ts` - 41 passed, `tsx scripts/check-api-docs-routes.ts` - no drift.

---

## Follow-up (31d67324b): the string list alone did not close it

Review found a residual double-send on the main EVM write path, verified against the code and reproduced as a failing test. It is pre-existing - `"timeout"` was in the base pattern list - but the first commit asserted an invariant it did not enforce.

`lib/web3/chain-adapter/evm.ts` throws `OnChainPendingError({ message: "Transaction sent but receipt could not be read (" + getErrorMessage(error) + ")", transactionHash: tx.hash })` when a receipt read fails for any unclassified reason. A read that times out puts `timeout` into that interpolated message. `plugins/web3/steps/write-contract-core.ts` catches it and returns `{ success: false, error, errorClass, transactionHash: broadcastHash, chainId }` - the same shape exists in `transfer-funds-core.ts`, `transfer-token-core.ts`, `approve-token-core.ts` and `batch-write-contract-core.ts`. `TX_ERROR` read `r.error` and nothing else, `isRetryableError` is a case-insensitive substring test, `"timeout"` matched, and the retry signed a second independent transaction at the next nonce - while holding an object that carried the first transaction's hash. `OnChainPendingError.transactionHash` is non-optional, so the hash is always there on that path. It needs no packet loss, only a chain slower than the receipt read.

The fix is structural rather than another string edit:

- `TX_ERROR` returns `undefined` - not retryable - for any failure carrying a non-empty `transactionHash`. The hash is proof a transaction is live, so it decides, not the error text. This covers mined reverts and any future error string as well.
- `TransactionResult`'s failure branch now models `transactionHash` and the other fields the step cores actually return. It was `{ success: false; error: string }`, which is plausibly why the signal was never available to the gate.
- New test: a `success: false` result with `"...(timeout (code=TIMEOUT))"` and a `transactionHash`, asserting the callback runs exactly once, `outcome` is `failed`, `retryCount` is 0. Removing the gate makes it fail with `expected 4 to be 1` - the four sends are the bug, measured. The `it.each` over the four removed strings is unchanged.
- The comments now say what enforces what: the hash gate is the guarantee, the pattern list is a secondary filter over hash-less failures, and the per-attempt timeout remains open because an abandoned attempt returns no result and so no hash.
- Corrected reason for one removal: bare `"transaction underpriced"` is the pool rejecting a fee below its minimum, so nothing is live - the removal is still right (with no gas bump a retry re-sends the same fee and fails identically) but not for the reason first given. Only `"replacement transaction underpriced"` implies a broadcast, which is what `NONCE_CONFLICT_MESSAGE_PATTERNS` in `lib/web3/submit-signed.ts` and `CHAIN_REJECTION_PATTERNS` in `lib/errors/classify.ts` both list. The comment now cross-references `submit-signed.ts` as the canonical set.
- `docs/api/direct-execution.md` re-worded around the hash gate; `specs/api-coverage.json` regenerated.

### The hash now survives to the execution row

Confirmed, and it is a real improvement. A hash-carrying failure returns `outcome: "failed"`, which `unwrapRetryResult` maps to `{ ok: true, result }`, so it reaches `handleResult` rather than the `!invokeResult.ok` branch at `route.ts:458` that calls `failExecution(executionId, invokeResult.error)` with no hash. `handleResult` already reads `output.transactionHash` and `output.chainId` and passes both to `failExecution(executionId, errorMsg, { transactionHash, chainId })`, whose returned `settled.status` is authoritative for the response. So a broadcast whose receipt could not be read can now settle `unconfirmed` and be closed by the reconciler, instead of being written off as `error`. That is the KEEP-1281 outcome arriving early on this path; the `failExecution` call at `route.ts:458` is untouched and remains KEEP-1281's scope.
