### PR TITLE
fix: #2105 add example values to MCP workflow-call OpenAPI 200 schemas

### DIFF
--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -264,6 +264,12 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
               data: { type: "string" },
               value: { type: "string" },
             },
+            example: {
+              type: "calldata",
+              to: "0x0000000000000000000000000000000000000001",
+              data: "0xa9059cbb",
+              value: "0",
+            },
           },
         },
       },
@@ -279,6 +285,10 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
             properties: {
               executionId: { type: "string" },
               status: { type: "string", const: "running" },
+            },
+            example: {
+              executionId: "exec_example_000000000000000000000001",
+              status: "running",
             },
           },
         },

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -217,6 +217,63 @@ describe("GET /api/openapi", () => {
     expect(op.requestBody).toBeDefined();
   });
 
+  it("MCP workflow-call 200 schemas carry static example values (#2105)", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-read-ex",
+            name: "Read Example",
+            description: null,
+            listedSlug: "read-example",
+            inputSchema: null,
+            priceUsdcPerCall: "0",
+            workflowType: "read",
+            category: null,
+            chain: null,
+          },
+          {
+            id: "wf-write-ex",
+            name: "Write Example",
+            description: null,
+            listedSlug: "write-example",
+            inputSchema: null,
+            priceUsdcPerCall: null,
+            workflowType: "write",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const request = new Request("https://app.keeperhub.com/api/openapi");
+    const response = await GET(request);
+    const body = await response.json();
+
+    const readSchema =
+      body.paths["/api/mcp/workflows/read-example/call"].post.responses["200"]
+        .content["application/json"].schema;
+    expect(readSchema.example).toEqual({
+      executionId: "exec_example_000000000000000000000001",
+      status: "running",
+    });
+
+    const writeSchema =
+      body.paths["/api/mcp/workflows/write-example/call"].post.responses["200"]
+        .content["application/json"].schema;
+    expect(writeSchema.example.type).toBe("calldata");
+    expect(writeSchema.example).toEqual(
+      expect.objectContaining({
+        type: "calldata",
+        to: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+        data: expect.stringMatching(/^0x[0-9a-fA-F]*$/),
+        value: "0",
+      })
+    );
+  });
+
   it("free write workflows still declare `security: []` and no 402", async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({


### PR DESCRIPTION
Closes #2105.

Adds a static `example` on both hardcoded `/api/mcp/workflows/{slug}/call` 200-response schemas in `buildPathEntry`:

- write-type: `{ type: "calldata", to, data, value }` matching `handleWriteWorkflow` / `PaymentDeliverable` in `app/api/mcp/workflows/[slug]/call/route.ts`
- read-type: `{ executionId, status: "running" }` matching the fire-and-forget timeout fallback documented on `createAndStartExecution`

`data: "0xa9059cbb"` is the public ERC-20 `transfer(address,uint256)` selector (first 4 bytes of keccak256 of that signature). `value: "0"` is a string because the schema types `value` as string (wei). `to` is the all-zero-but-one address so the example is a 20-byte hex string without pointing at a live contract.

No runtime behaviour change. Unit test pins both examples.

Hackathon note: KeeperHub Agent Economy OSS bounty track; author tenk-earn. Not a cash claim.
