### PR TITLE
fix: #1928 rename parseNativeValueWei to parseNativeValueEther

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -77,7 +77,8 @@ which is exactly the load this policy is meant to move upstream.
 What a plan buys you is a check nothing else provides. A proposal stated out
 loud can be tested against the actual contract before any code exists - and a
 well-evidenced issue can still carry a wrong plan. One report here correctly
-observed that `parseNativeValueWei` parses with `ethers.parseEther`, and
+observed that `parseNativeValueWei`, since renamed to
+`parseNativeValueEther`, parses with `ethers.parseEther`, and
 proposed denominating `value` in wei. The observation was right; the plan would
 have silently changed every existing caller's amount by a factor of 1e18,
 because the API's documented unit is ether and the misleading thing is the

--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -40,7 +40,7 @@ import {
 } from "../_lib/execution-service";
 import { buildProtocolFunctionArgs } from "../_lib/protocol-function-args";
 import { checkRateLimit } from "../_lib/rate-limit";
-import { parseNativeValueWei } from "../_lib/reserved-value";
+import { parseNativeValueEther } from "../_lib/reserved-value";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { requireWallet } from "../_lib/wallet-check";
 
@@ -230,7 +230,7 @@ async function executeProtocolAction(
 
   const ethValue = body.ethValue ? String(body.ethValue) : undefined;
   // Charge any native value forwarded by the protocol write against the cap.
-  const parsedValue = parseNativeValueWei(ethValue);
+  const parsedValue = parseNativeValueEther(ethValue);
   if (!parsedValue.ok) {
     return recordIdempotentResponse(
       idem,

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -4,7 +4,7 @@ export {
   isSolanaNetwork,
   type NodeReservedValue,
   parseNativeValueLamports,
-  parseNativeValueWei,
+  parseNativeValueEther,
   parseNodeNativeValueWei,
   type ReservedValue,
 } from "@/lib/execute/reserved-value";

--- a/app/api/execute/_lib/reserved-value.ts
+++ b/app/api/execute/_lib/reserved-value.ts
@@ -3,8 +3,8 @@ import "server-only";
 export {
   isSolanaNetwork,
   type NodeReservedValue,
-  parseNativeValueLamports,
   parseNativeValueEther,
+  parseNativeValueLamports,
   parseNodeNativeValueWei,
   type ReservedValue,
 } from "@/lib/execute/reserved-value";

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -32,7 +32,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
-import { parseNativeValueWei } from "../_lib/reserved-value";
+import { parseNativeValueEther } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import type { ExecuteResponse } from "../_lib/types";
@@ -151,7 +151,7 @@ async function handleWriteCall(
 
   const redactedInput = redactInput(withRejectedSignerOverride(body, body));
   // Charge any native ETH value sent with the call against the daily value cap.
-  const parsedValue = parseNativeValueWei(body.value as string | undefined);
+  const parsedValue = parseNativeValueEther(body.value as string | undefined);
   if (!parsedValue.ok) {
     return recordIdempotentResponse(
       idem,

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -34,7 +34,7 @@ import { checkRateLimit } from "../_lib/rate-limit";
 import {
   isSolanaNetwork,
   parseNativeValueLamports,
-  parseNativeValueWei,
+  parseNativeValueEther,
 } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
@@ -221,7 +221,7 @@ export async function POST(request: Request): Promise<NextResponse> {
   if (!isTokenTransfer) {
     const parsedValue = isSolanaTransfer
       ? parseNativeValueLamports(amount)
-      : parseNativeValueWei(amount);
+      : parseNativeValueEther(amount);
     if (!parsedValue.ok) {
       return applyRateLimitHeaders(
         await recordIdempotentResponse(

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -33,8 +33,8 @@ import {
 import { checkRateLimit } from "../_lib/rate-limit";
 import {
   isSolanaNetwork,
-  parseNativeValueLamports,
   parseNativeValueEther,
+  parseNativeValueLamports,
 } from "../_lib/reserved-value";
 import { parseSimulateFlag } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";

--- a/lib/execute/native-value.ts
+++ b/lib/execute/native-value.ts
@@ -16,7 +16,8 @@ export const SOLANA_NATIVE_DECIMALS = 9;
 /**
  * Native notional value (in wei) an execution will move, used by the per-org
  * daily spending cap. Parses a human-decimal ETH amount (e.g. "1.5") the same
- * way the web3 cores do (`ethers.parseEther`).
+ * way the web3 cores do (`ethers.parseEther`). Named Ether, not Wei,
+ * because that is the input unit; the returned `valueWei` is still wei.
  *
  * An absent/empty amount reserves "0". Only native value is counted today;
  * ERC-20 token amounts are not yet priced into the cap, so token-only transfers
@@ -29,7 +30,7 @@ export const SOLANA_NATIVE_DECIMALS = 9;
  * and a negative reservation would lower the day's SUM and bank credit against
  * the cap.
  */
-export function parseNativeValueWei(
+export function parseNativeValueEther(
   rawAmount: string | undefined | null
 ): ReservedValue {
   if (rawAmount === undefined || rawAmount === null || rawAmount === "") {
@@ -58,12 +59,12 @@ export function parseNativeValueWei(
  * per-org daily Solana cap (`organizationSpendCaps.dailySolanaValueCapLamports`).
  *
  * Parses a human-decimal SOL amount (e.g. "1.5") at SOL's true 9 decimals
- * rather than reusing `parseNativeValueWei`, whose `ethers.parseEther` is fixed
+ * rather than reusing `parseNativeValueEther`, whose `ethers.parseEther` is fixed
  * at 18. Charging SOL on an 18-decimal scale was only ever a workaround for
  * having a single wei-denominated cap; with a dedicated lamports cap the
  * accurate unit is both correct and safe.
  *
- * Mirrors `parseNativeValueWei`'s contract exactly: absent/empty reserves "0",
+ * Mirrors `parseNativeValueEther`'s contract exactly: absent/empty reserves "0",
  * malformed returns `{ ok: false }` for the caller to decide, and negatives are
  * rejected (a negative reservation would lower the day's SUM and bank credit
  * against the cap).

--- a/lib/execute/reserved-value.ts
+++ b/lib/execute/reserved-value.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import {
   parseNativeValueLamports,
-  parseNativeValueWei,
+  parseNativeValueEther,
 } from "@/lib/execute/native-value";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { isSolanaChain } from "@/lib/rpc/provider-factory";
@@ -10,7 +10,7 @@ import { SOLANA_SPL_MAX_FEE_LAMPORTS } from "@/lib/web3/solana-fees";
 
 export {
   parseNativeValueLamports,
-  parseNativeValueWei,
+  parseNativeValueEther,
   type ReservedValue,
 } from "@/lib/execute/native-value";
 
@@ -108,13 +108,13 @@ export function parseNodeNativeValueWei(
         ? { ok: true, kind: "solana", valueLamports: parsed.valueWei }
         : parsed;
     }
-    const parsed = parseNativeValueWei(amount);
+    const parsed = parseNativeValueEther(amount);
     return parsed.ok
       ? { ok: true, kind: "evm", valueWei: parsed.valueWei }
       : parsed;
   }
 
-  const parsed = parseNativeValueWei(
+  const parsed = parseNativeValueEther(
     typeof config.ethValue === "string" ? config.ethValue : undefined
   );
   return parsed.ok

--- a/lib/execute/reserved-value.ts
+++ b/lib/execute/reserved-value.ts
@@ -1,16 +1,16 @@
 import "server-only";
 
 import {
-  parseNativeValueLamports,
   parseNativeValueEther,
+  parseNativeValueLamports,
 } from "@/lib/execute/native-value";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
 import { isSolanaChain } from "@/lib/rpc/provider-factory";
 import { SOLANA_SPL_MAX_FEE_LAMPORTS } from "@/lib/web3/solana-fees";
 
 export {
-  parseNativeValueLamports,
   parseNativeValueEther,
+  parseNativeValueLamports,
   type ReservedValue,
 } from "@/lib/execute/native-value";
 

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -3,35 +3,35 @@ import { describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import {
-  parseNativeValueWei,
+  parseNativeValueEther,
   parseNodeNativeValueWei,
 } from "@/app/api/execute/_lib/reserved-value";
 
-describe("parseNativeValueWei", () => {
+describe("parseNativeValueEther", () => {
   it("parses a decimal ETH amount to wei", () => {
-    expect(parseNativeValueWei("1.5")).toEqual({
+    expect(parseNativeValueEther("1.5")).toEqual({
       ok: true,
       valueWei: "1500000000000000000",
     });
   });
 
   it("treats undefined/null/empty as 0", () => {
-    expect(parseNativeValueWei(undefined)).toEqual({ ok: true, valueWei: "0" });
-    expect(parseNativeValueWei(null)).toEqual({ ok: true, valueWei: "0" });
-    expect(parseNativeValueWei("")).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueEther(undefined)).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueEther(null)).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueEther("")).toEqual({ ok: true, valueWei: "0" });
   });
 
   it("rejects a non-numeric amount", () => {
-    expect(parseNativeValueWei("abc").ok).toBe(false);
+    expect(parseNativeValueEther("abc").ok).toBe(false);
   });
 
   it("rejects a negative amount (would bank credit against the cap)", () => {
     // ethers.parseEther("-5") returns a negative BigInt without throwing.
-    expect(parseNativeValueWei("-5").ok).toBe(false);
+    expect(parseNativeValueEther("-5").ok).toBe(false);
   });
 
   it("rejects more than 18 decimals", () => {
-    expect(parseNativeValueWei("1.0000000000000000001").ok).toBe(false);
+    expect(parseNativeValueEther("1.0000000000000000001").ok).toBe(false);
   });
 });
 

--- a/tests/unit/reserved-value.test.ts
+++ b/tests/unit/reserved-value.test.ts
@@ -16,7 +16,10 @@ describe("parseNativeValueEther", () => {
   });
 
   it("treats undefined/null/empty as 0", () => {
-    expect(parseNativeValueEther(undefined)).toEqual({ ok: true, valueWei: "0" });
+    expect(parseNativeValueEther(undefined)).toEqual({
+      ok: true,
+      valueWei: "0",
+    });
     expect(parseNativeValueEther(null)).toEqual({ ok: true, valueWei: "0" });
     expect(parseNativeValueEther("")).toEqual({ ok: true, valueWei: "0" });
   });


### PR DESCRIPTION
Closes #1928.

Rename-only, matching the accepted plan on the issue (build against the maintainer comment, not the filed wei-parse proposal).

`parseNativeValueWei` called `ethers.parseEther`. Ether is the published API contract (`docs/api/direct-execution.md`). The Wei name was the defect; changing the parse would 1e18x every existing caller who read the docs.

- Rename `parseNativeValueWei` → `parseNativeValueEther`
- Update re-exports, execute routes, and the existing unit describe
- Behavior unchanged: same `parseEther`, same `valueWei` return
- No local app/test run (identifier rename)
