### PR TITLE
chore(scripts): #2247 add a regenerable trace-method availability probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -364,3 +364,10 @@ EXECUTE_DEFAULT_STABLECOIN_CAP_MICRO_USD=
 # Applies alongside the per-call figure above, since a batch payout packs many
 # recipients into a single transaction. Defaults to 2000 USD.
 EXECUTE_DEFAULT_BATCH_STABLECOIN_CAP_MICRO_USD=
+
+# Path to lib/rpc/rpc-config.ts, read only by scripts/trace-method-probe.test.mjs
+# so the parser is exercised against the real config rather than a vendored
+# snapshot that can go stale. Unset is the normal case: the test resolves the
+# file relative to itself and skips if it is not there. Set it only to point the
+# test at a config outside the working tree. No runtime code reads this.
+RPC_CONFIG_PATH=

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dep-audit": "tsx scripts/dep-audit.ts",
     "discover": "tsx tests/e2e/playwright/discover.ts",
     "test:health": "tsx tests/e2e/playwright/health.ts",
+    "test:trace-probe": "node --test scripts/trace-method-probe.test.mjs",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:vitest": "vitest run tests/e2e/vitest tests/e2e/postgres-world.test.ts --exclude '**/protocol-coverage/**'",
     "test:e2e:schedule": "vitest run tests/e2e/vitest/schedule-pipeline.test.ts",

--- a/scripts/trace-method-probe.mjs
+++ b/scripts/trace-method-probe.mjs
@@ -1,0 +1,811 @@
+#!/usr/bin/env node
+/**
+ * trace-method-probe — regenerable trace-method availability probe
+ *
+ * The survey answering #2247 is #2273. This is the tool that keeps that table
+ * checkable: re-run it and the numbers are re-derived from live endpoints
+ * rather than trusted from a one-shot run.
+ *
+ * Why that matters concretely: trace size scales with a block's internal call
+ * depth, not its transaction count, so two probes of the same chain and the
+ * same tx count can differ several-fold. #2273 measured a 5-tx plasma-mainnet
+ * block at 63 KiB / 101 KiB; this tool measured a different 5-tx block on the
+ * same chain at 348 KB / 562 KB. Both are correct. A single block therefore
+ * under-determines the cost envelope #2241 needs, and re-running is the cheap
+ * way to bound it.
+ *
+ * Reports, per chain in `lib/rpc/rpc-config.ts`:
+ *   1. which trace methods the endpoint actually answers
+ *   2. response size (raw + gzipped) for one block's traces
+ *   3. fetch and parse time
+ *
+ * Three design rules, because the survey is only worth what it can be trusted on:
+ *
+ *   REGENERABLE — the chain list is parsed out of `rpc-config.ts` at run time,
+ *   never hand-typed. The config drifts (it gained plasma/0g/robinhood since
+ *   #2239 was written); a hand-copied table would silently go stale.
+ *
+ *   HONEST — we record the exact error body and classify from it. "method not
+ *   found", a 401 tier gate and a timeout are three different findings and the
+ *   distinction is most of the value here. Nothing is inferred from a docs page.
+ *
+ *   POLITE — these are free third-party endpoints. Strictly sequential, one
+ *   delay between every request, tiny sample. We are surveying capability, not
+ *   load-testing someone's public infrastructure.
+ *
+ * Usage:
+ *   node scripts/trace-method-probe.mjs                        # all chains, live-fetch the config
+ *   node scripts/trace-method-probe.mjs --only 1,8453          # just these chain ids
+ *   node scripts/trace-method-probe.mjs --mainnets             # skip testnets
+ *   node scripts/trace-method-probe.mjs --config ./rpc.ts      # use a local rpc-config.ts
+ *   node scripts/trace-method-probe.mjs --dry-run              # resolve targets, make no requests
+ *   node scripts/trace-method-probe.mjs --out ./results        # output directory (default ./out)
+ *
+ * Writes results.json (full raw record) and report.md (the table).
+ * No dependencies. Node 20+.
+ */
+
+import { gzipSync } from "node:zlib";
+import { mkdir, writeFile, readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const CONFIG_URL =
+  "https://raw.githubusercontent.com/KeeperHub/keeperhub/staging/lib/rpc/rpc-config.ts";
+
+// Politeness + safety limits.
+const REQUEST_DELAY_MS = 750; // between every request, including retries
+const REQUEST_TIMEOUT_MS = 45_000; // a full-block trace is legitimately slow
+const LIVENESS_TIMEOUT_MS = 15_000;
+const MAX_RESPONSE_BYTES = 96 * 1024 * 1024; // guard; record truncation if hit
+const BLOCKS_BEHIND_HEAD = 5; // avoid an unfinalised head being reorged mid-probe
+const BLOCK_SCAN_LIMIT = 12; // how far back to look for a block with transactions
+
+/** Solana chain ids in CHAIN_CONFIG. No `debug_trace*`; recorded N/A, not dropped. */
+const SOLANA_CHAIN_IDS = new Set([101, 103]);
+
+/** Known testnet chain ids, so --mainnets can filter without guessing from names. */
+const TESTNET_CHAIN_IDS = new Set([
+  11155111, 84532, 421614, 80002, 97, 11155420, 43113, 42431, 9746, 16602,
+  46630, 103,
+]);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// 1. Resolve targets from rpc-config.ts
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse PUBLIC_RPCS and CHAIN_CONFIG out of rpc-config.ts.
+ *
+ * Regex over TypeScript is fragile, so this asserts on the shape it found and
+ * throws rather than silently surveying half the config. A loud failure here is
+ * the correct outcome if upstream restructures the file.
+ */
+export function parseChainConfig(source) {
+  const publicBlock = source.match(
+    /export const PUBLIC_RPCS\s*=\s*\{([\s\S]*?)\n\};/,
+  );
+  if (!publicBlock) {
+    throw new Error("PUBLIC_RPCS block not found — rpc-config.ts shape changed");
+  }
+  const urls = new Map();
+  for (const m of publicBlock[1].matchAll(
+    /^\s*([A-Z0-9_]+):\s*"([^"]+)"/gm,
+  )) {
+    urls.set(m[1], m[2]);
+  }
+
+  const chainBlock = source.match(
+    /export const CHAIN_CONFIG:[^=]*=\s*\{([\s\S]*?)\n\};/,
+  );
+  if (!chainBlock) {
+    throw new Error("CHAIN_CONFIG block not found — rpc-config.ts shape changed");
+  }
+
+  const chains = [];
+  const entryRe = /^ {2}(\d+):\s*\{([\s\S]*?)^ {2}\},/gm;
+  for (const m of chainBlock[1].matchAll(entryRe)) {
+    const chainId = Number(m[1]);
+    const body = m[2];
+    const pick = (field) => {
+      const hit = body.match(
+        new RegExp(`${field}:\\s*PUBLIC_RPCS\\.([A-Z0-9_]+)`),
+      );
+      return hit ? { key: hit[1], url: urls.get(hit[1]) } : null;
+    };
+    chains.push({
+      chainId,
+      jsonKey: body.match(/jsonKey:\s*"([^"]+)"/)?.[1] ?? `chain-${chainId}`,
+      primary: pick("publicDefault"),
+      fallback: pick("publicFallback"),
+      chainType: SOLANA_CHAIN_IDS.has(chainId) ? "solana" : "evm",
+      isTestnet: TESTNET_CHAIN_IDS.has(chainId),
+    });
+  }
+
+  if (chains.length === 0) {
+    throw new Error("CHAIN_CONFIG parsed to zero entries — shape changed");
+  }
+  const missing = chains.filter((c) => !c.primary?.url);
+  if (missing.length) {
+    throw new Error(
+      `no publicDefault URL resolved for: ${missing.map((c) => c.jsonKey).join(", ")}`,
+    );
+  }
+
+  // CHAIN_CONFIG carries no isTestnet field (it exists only in the operator
+  // JSON shape), so TESTNET_CHAIN_IDS is hand-maintained — which makes it the
+  // one thing here that can silently drift. Cross-check it against the naming
+  // convention and warn loudly rather than quietly mislabel a new chain.
+  const looksTestnet = /sepolia|testnet|devnet|fuji|amoy|galileo|goerli|holesky/i;
+  for (const c of chains) {
+    const byName = looksTestnet.test(c.jsonKey);
+    if (byName !== c.isTestnet) {
+      process.stderr.write(
+        `WARN: ${c.jsonKey} (${c.chainId}) — name says ${byName ? "testnet" : "mainnet"}, ` +
+          `TESTNET_CHAIN_IDS says ${c.isTestnet ? "testnet" : "mainnet"}. Update the set.\n`,
+      );
+    }
+  }
+  return chains;
+}
+
+async function loadConfig(path) {
+  if (path) return readFile(path, "utf8");
+  const res = await fetch(CONFIG_URL);
+  if (!res.ok) {
+    throw new Error(`fetching rpc-config.ts: HTTP ${res.status}`);
+  }
+  return res.text();
+}
+
+// ---------------------------------------------------------------------------
+// 2. JSON-RPC transport
+// ---------------------------------------------------------------------------
+
+/**
+ * One JSON-RPC call. Never throws for a protocol-level failure — a refusal is a
+ * result, not an error, and the survey needs the exact body either way.
+ */
+async function rpc(url, method, params, timeoutMs = REQUEST_TIMEOUT_MS) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  const started = performance.now();
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      signal: ac.signal,
+    });
+
+    // Read through the stream with a hard cap rather than res.arrayBuffer():
+    // a full-block trace can be enormous, and buffering it whole before
+    // checking the size would let one pathological chain OOM the survey.
+    // `bytesSeen` counts everything that arrived, including the chunk that
+    // tripped the cap, so the size finding stays truthful when truncated.
+    const chunks = [];
+    let bytesSeen = 0;
+    let truncated = false;
+    for await (const chunk of res.body ?? []) {
+      bytesSeen += chunk.length;
+      if (bytesSeen > MAX_RESPONSE_BYTES) {
+        truncated = true;
+        break;
+      }
+      chunks.push(chunk);
+    }
+    // Cancel rather than abort: aborting the controller mid-read surfaces as an
+    // AbortError in the catch below and would be misreported as a timeout.
+    if (truncated) await res.body?.cancel().catch(() => {});
+
+    const buf = Buffer.concat(chunks);
+    const fetchMs = performance.now() - started;
+    const text = buf.toString("utf8");
+
+    // A truncated body cannot be parsed, and reporting that as a malformed
+    // response would be wrong — the endpoint answered, the answer was just
+    // bigger than we are willing to hold. Size is scope item 3, so this is a
+    // result, not a failure.
+    const parseStarted = performance.now();
+    let body = null;
+    let parseError = null;
+    if (!truncated) {
+      try {
+        body = JSON.parse(text);
+      } catch (err) {
+        parseError = err.message;
+      }
+    }
+    const parseMs = performance.now() - parseStarted;
+
+    return {
+      httpStatus: res.status,
+      bytesRaw: bytesSeen,
+      bytesGzip: buf.length ? gzipSync(buf).length : 0,
+      fetchMs: Math.round(fetchMs),
+      parseMs: Math.round(parseMs),
+      truncated,
+      body,
+      parseError,
+      // Kept verbatim and short: this is the evidence, not a summary of it.
+      rawSnippet: text.slice(0, 400),
+    };
+  } catch (err) {
+    return {
+      transportError: err.name === "AbortError" ? "timeout" : err.message,
+      fetchMs: Math.round(performance.now() - started),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** A refusal that payment or credentials would lift. */
+const TIER_PATTERNS = [
+  /api[ -]?key/,
+  /upgrade/,
+  /\bpaid\b/,
+  /\bplan\b/,
+  /\btier\b/,
+  /subscription/,
+  /not authori[sz]ed|unauthori[sz]ed/,
+  /forbidden/,
+  /access denied/,
+  /sign ?up|register/,
+  // "Archive requests require a personal token" (publicnode/allnodes) — the
+  // word "token" only reads as auth in a "requires ..." construction, which is
+  // why this is a phrase pattern and not a bare /token/.
+  /requires? (a |an )?[\w ]*\b(token|key|account|credential)/,
+];
+
+/** A refusal no amount of money lifts on this endpoint. */
+const NOT_SUPPORTED_PATTERNS = [
+  /does not exist/,
+  /not found/,
+  /unsupported|not supported/,
+  /not available|unavailable/,
+  /disabled|not enabled/,
+  // 1rpc.io answers `-32600 "Method trace_block not allowed"` — code -32600 is
+  // "invalid request", so without this the verdict falls through to the
+  // catch-all `error` and a plain absence looks unclassified. Observed on the
+  // eth-mainnet fallback; tempo says the same thing but with -32601.
+  /not allowed|not permitted/,
+];
+
+/**
+ * Failures that say "ask again" rather than "no". A survey that records a
+ * transient blip as a capability finding is simply wrong, so these get one
+ * retry before being believed.
+ */
+const RETRYABLE = new Set([
+  "timeout",
+  "transport-error",
+  "server-error",
+  "rate-limited",
+]);
+const RETRYABLE_MESSAGE = /temporary|please retry|try again|internal error/i;
+
+function shouldRetry(status, message) {
+  return (
+    RETRYABLE.has(status) ||
+    (status === "error" && RETRYABLE_MESSAGE.test(String(message ?? "")))
+  );
+}
+
+/**
+ * Classify one probe result into the categories the issue actually cares about.
+ *
+ * PRECEDENCE: a structured JSON-RPC error outranks the HTTP status.
+ *
+ * That ordering is load-bearing and was wrong in the first draft. Base's public
+ * endpoint answers an unsupported method with **HTTP 403** and a body of
+ * `-32601 "rpc method is unsupported"` — reading the 403 first labels it
+ * `tier-gated`, i.e. "traces are purchasable on Base", when in fact the method
+ * is simply absent. Ethereum's publicnode endpoint answers `trace_block` with
+ * HTTP 403 too, but a body of `-32602 "Archive requests require a personal
+ * token"` — a real gate. Same status, opposite findings; only the body
+ * separates them.
+ *
+ * Both httpStatus and errorCode are kept in results.json so a reader can
+ * re-judge any call this makes.
+ */
+export function classify(r) {
+  if (r.transportError) {
+    return r.transportError === "timeout" ? "timeout" : "transport-error";
+  }
+  // Before the HTTP branches: the endpoint did answer, and "the answer exceeded
+  // our cap" is a finding about size, not about availability.
+  if (r.truncated) return "too-large";
+
+  const err = r.body?.error;
+  if (err) {
+    const msg = String(err.message ?? "").toLowerCase();
+    // Tier first: "not available on the free plan" matches both vocabularies,
+    // and calling that "never implemented" is the costliest error here.
+    if (TIER_PATTERNS.some((p) => p.test(msg))) return "tier-gated";
+    if (err.code === -32601) return "method-not-found";
+    if (err.code === -32005 || /rate limit|too many/.test(msg)) {
+      return "rate-limited";
+    }
+    if (NOT_SUPPORTED_PATTERNS.some((p) => p.test(msg))) {
+      return "method-not-found";
+    }
+    // No structured signal in the body; fall back to the status.
+    if (r.httpStatus === 401 || r.httpStatus === 403) return "tier-gated";
+    if (r.httpStatus === 429) return "rate-limited";
+    return "error";
+  }
+
+  if (r.httpStatus === 401 || r.httpStatus === 403) return "tier-gated";
+  if (r.httpStatus === 429) return "rate-limited";
+  if (r.httpStatus >= 500) return "server-error";
+
+  // A body that would not parse is still evidence. 1rpc.io refuses non-core
+  // methods with HTTP 401 and the plain-text line "Only core evm requests are
+  // allowed." — no JSON at all. Bailing to invalid-response on the parse
+  // failure alone (as the first draft did, before the status checks above)
+  // reported a clear policy refusal as a malformed response. The status is
+  // consulted first; the raw text is the last resort.
+  if (r.parseError) {
+    const raw = String(r.rawSnippet ?? "").toLowerCase();
+    if (TIER_PATTERNS.some((p) => p.test(raw))) return "tier-gated";
+    if (NOT_SUPPORTED_PATTERNS.some((p) => p.test(raw))) return "method-not-found";
+    return "invalid-response";
+  }
+
+  if (r.body && "result" in r.body) {
+    if (r.body.result === null) return "null-result";
+    // An empty array means the method is supported but this block had nothing
+    // to trace. Worth separating: it answers "is it available?" but carries no
+    // usable size or timing data, and reporting it as a 36-byte trace would
+    // understate cost by orders of magnitude.
+    if (Array.isArray(r.body.result) && r.body.result.length === 0) {
+      return "ok-empty";
+    }
+    return "ok";
+  }
+  return "invalid-response";
+}
+
+// ---------------------------------------------------------------------------
+// 3. Probe one endpoint
+// ---------------------------------------------------------------------------
+
+const TRACE_METHODS = [
+  {
+    name: "debug_traceBlockByNumber",
+    params: (hex) => [hex, { tracer: "callTracer" }],
+  },
+  { name: "trace_block", params: (hex) => [hex] },
+  // Otterscan takes a decimal block number, a page index and a page size.
+  { name: "ots_getBlockTransactions", params: (hex, n) => [n, 0, 25] },
+];
+
+async function probeEvmEndpoint(label, url, expectedChainId) {
+  const record = { label, url, methods: {} };
+
+  // Liveness control. Distinguishes "this method is refused" from "this
+  // endpoint is dead", which is the whole reason the control exists.
+  const live = await rpc(url, "eth_chainId", [], LIVENESS_TIMEOUT_MS);
+  const liveClass = classify(live);
+  record.liveness = {
+    status: liveClass,
+    httpStatus: live.httpStatus,
+    fetchMs: live.fetchMs,
+    error: live.transportError ?? live.body?.error?.message ?? null,
+  };
+
+  if (liveClass !== "ok") {
+    record.skipped = `endpoint not live (${liveClass})`;
+    return record;
+  }
+
+  // Verifying the endpoint is the chain the config claims. A mismatch here is
+  // a finding in its own right, independent of trace support.
+  const actualChainId = Number(live.body.result);
+  record.chainIdReported = actualChainId;
+  record.chainIdMatches = actualChainId === expectedChainId;
+
+  await sleep(REQUEST_DELAY_MS);
+
+  const head = await rpc(url, "eth_blockNumber", [], LIVENESS_TIMEOUT_MS);
+  if (classify(head) !== "ok") {
+    record.skipped = "eth_blockNumber failed; no block to trace";
+    return record;
+  }
+  // Trace an block that actually has transactions in it. A quiet chain serves
+  // empty blocks, and "148 KB on plasma vs 36 bytes on tempo" would compare a
+  // real block against an empty one — the size column is scope item 3, so the
+  // sample has to be comparable or the whole table misleads.
+  let blockNum = Number(head.body.result) - BLOCKS_BEHIND_HEAD;
+  let txCount = 0;
+  let scanned = 0;
+  for (; scanned < BLOCK_SCAN_LIMIT; scanned++) {
+    await sleep(REQUEST_DELAY_MS);
+    const b = await rpc(
+      url,
+      "eth_getBlockByNumber",
+      [`0x${blockNum.toString(16)}`, false],
+      LIVENESS_TIMEOUT_MS,
+    );
+    if (classify(b) !== "ok") break;
+    txCount = b.body.result?.transactions?.length ?? 0;
+    if (txCount > 0) break;
+    blockNum -= 1;
+  }
+  const blockHex = `0x${blockNum.toString(16)}`;
+  record.block = {
+    number: blockNum,
+    hex: blockHex,
+    txCount,
+    blocksScanned: scanned + 1,
+    empty: txCount === 0,
+  };
+  if (txCount === 0) {
+    process.stderr.write(
+      `    (no non-empty block within ${BLOCK_SCAN_LIMIT}; sizes will not be comparable)\n`,
+    );
+  }
+
+  for (const m of TRACE_METHODS) {
+    await sleep(REQUEST_DELAY_MS);
+    let r = await rpc(url, m.name, m.params(blockHex, blockNum));
+    let status = classify(r);
+    let retried = false;
+
+    // One retry, only for failures that describe themselves as transient.
+    // Observed: robinhood-testnet's fallback answered `code 19 "Temporary
+    // internal error. Please retry"` — recording that as a capability verdict
+    // would put a blip in the survey and make the run irreproducible.
+    if (shouldRetry(status, r.body?.error?.message ?? r.transportError)) {
+      await sleep(REQUEST_DELAY_MS * 4);
+      const again = await rpc(url, m.name, m.params(blockHex, blockNum));
+      retried = true;
+      process.stderr.write(`    ${m.name}: ${status} → retry\n`);
+      r = again;
+      status = classify(again);
+    }
+
+    record.methods[m.name] = {
+      retried,
+      status,
+      httpStatus: r.httpStatus ?? null,
+      bytesRaw: r.bytesRaw ?? null,
+      bytesGzip: r.bytesGzip ?? null,
+      fetchMs: r.fetchMs ?? null,
+      parseMs: r.parseMs ?? null,
+      truncated: r.truncated ?? false,
+      resultCount: Array.isArray(r.body?.result) ? r.body.result.length : null,
+      errorCode: r.body?.error?.code ?? null,
+      errorMessage: r.body?.error?.message ?? r.transportError ?? null,
+      rawSnippet: status === "ok" ? null : (r.rawSnippet ?? null),
+    };
+    process.stderr.write(`    ${m.name}: ${status}\n`);
+  }
+  return record;
+}
+
+async function probeSolanaEndpoint(label, url) {
+  const record = { label, url, methods: {}, note: "solana: no debug_trace*" };
+  const live = await rpc(url, "getVersion", [], LIVENESS_TIMEOUT_MS);
+  const liveClass = classify(live);
+  record.liveness = {
+    status: liveClass,
+    httpStatus: live.httpStatus,
+    fetchMs: live.fetchMs,
+    error: live.transportError ?? live.body?.error?.message ?? null,
+  };
+  for (const m of TRACE_METHODS) {
+    record.methods[m.name] = { status: "n/a", note: "non-EVM chain" };
+  }
+  return record;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Report
+// ---------------------------------------------------------------------------
+
+const kb = (n) =>
+  n == null ? "—" : n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`;
+const ms = (n) => (n == null ? "—" : `${n} ms`);
+
+const MARK = {
+  ok: "✅",
+  "ok-empty": "☑️",
+  "too-large": "📦",
+  "method-not-found": "❌",
+  "tier-gated": "🔒",
+  "rate-limited": "⏳",
+  timeout: "⌛",
+  "transport-error": "💥",
+  "server-error": "💥",
+  "invalid-response": "⚠️",
+  "null-result": "∅",
+  error: "⚠️",
+  "n/a": "—",
+};
+const mark = (s) => `${MARK[s] ?? "?"} ${s}`;
+
+/**
+ * The headline the issue actually asks for: which chains are trace triggers
+ * viable on. Computed, not written by hand, so it cannot drift from the table.
+ */
+function summarise(results) {
+  const supported = new Set();
+  const gated = new Set();
+  for (const c of results) {
+    for (const p of c.endpoints) {
+      for (const m of Object.values(p.methods ?? {})) {
+        if (m.status === "ok" || m.status === "ok-empty") supported.add(c.jsonKey);
+        if (m.status === "tier-gated") gated.add(c.jsonKey);
+      }
+      if (p.skipped && p.liveness?.status === "tier-gated") gated.add(c.jsonKey);
+    }
+  }
+  const evmMainnets = results.filter(
+    (c) => c.chainType === "evm" && !c.isTestnet,
+  );
+  const okMainnets = evmMainnets.filter((c) => supported.has(c.jsonKey));
+  const L = ["## Headline", ""];
+  L.push(
+    `**${okMainnets.length} of ${evmMainnets.length} EVM mainnets** serve any trace method on their \`PUBLIC_RPCS\` endpoints: ` +
+      (okMainnets.length
+        ? okMainnets.map((c) => `\`${c.jsonKey}\``).join(", ")
+        : "none") +
+      ".",
+  );
+  L.push("");
+  L.push(
+    `Chains where at least one endpoint refused for credentials or plan (i.e. potentially purchasable): ` +
+      (gated.size ? [...gated].map((k) => `\`${k}\``).join(", ") : "none") +
+      ".",
+  );
+  L.push("");
+  L.push(
+    "**Read this as a lower bound on production, not a verdict on it.** These are the last-resort public defaults, which is what a self-hosted install runs on; the production `CHAIN_RPC_CONFIG` upstreams are not reachable from here and may be paid tiers that do serve traces.",
+  );
+  return L.join("\n");
+}
+
+function buildReport(results, meta) {
+  const L = [];
+  L.push("# Trace-method availability across configured chain upstreams");
+  L.push("");
+  L.push(`Survey for #2247. Generated by \`scripts/trace-probe/probe.mjs\`.`);
+  L.push("");
+  L.push(`- **Run at:** ${meta.startedAt}`);
+  L.push(`- **Config source:** ${meta.configSource}`);
+  L.push(
+    `- **Chains probed:** ${results.length} of ${meta.totalChains} in \`CHAIN_CONFIG\``,
+  );
+  L.push(
+    `- **Endpoints:** \`PUBLIC_RPCS\` defaults only — production \`CHAIN_RPC_CONFIG\` upstreams are in AWS Parameter Store and not reachable from here.`,
+  );
+  L.push(
+    `- **Sampling:** one block per endpoint, walked back up to ${meta.limits.BLOCK_SCAN_LIMIT} blocks to find one with transactions. Sizes scale with transaction count, so compare the Txs column alongside them. A quiet testnet can yield an empty block even after the walk-back; those are marked *(empty)* and are not size datapoints.`,
+  );
+  L.push(
+    `- **Reproducibility:** public endpoints are load-balanced across heterogeneous backends, so a single run is a snapshot, not a guarantee. Transient failures are retried once; re-run to confirm anything surprising.`,
+  );
+  L.push("");
+  L.push("## Legend");
+  L.push("");
+  L.push("| | Meaning |");
+  L.push("|---|---|");
+  L.push("| ✅ `ok` | method answered with trace data |");
+  L.push("| ☑️ `ok-empty` | method answered, but the sampled block was empty — supported, size not measurable |");
+  L.push("| ❌ `method-not-found` | method absent on this endpoint; no plan lifts it |");
+  L.push("| 🔒 `tier-gated` | refused for credentials or plan — purchasable |");
+  L.push("| 📦 `too-large` | answered, but exceeded the response cap |");
+  L.push("| ⚠️ `error` | answered with something we decline to bucket — see verbatim below |");
+  L.push("| — | endpoint skipped; the reason is in parentheses |");
+  L.push("");
+  L.push(summarise(results));
+  L.push("");
+  L.push("## Summary");
+  L.push("");
+  L.push("| Chain | id | Role | Endpoint | `debug_traceBlockByNumber` | `trace_block` | `ots_getBlockTransactions` |");
+  L.push("|---|---|---|---|---|---|---|");
+  for (const c of results) {
+    for (const p of c.endpoints) {
+      // A skipped endpoint is not necessarily a dead one: ankr and drpc
+      // refuse at the liveness check with a credential/plan error, which is a
+      // finding about access, not availability.
+      const cell = (m) =>
+        p?.skipped
+          ? `— *(${p.liveness?.status ?? "skipped"})*`
+          : mark(p?.methods?.[m]?.status ?? "n/a");
+      L.push(
+        `| ${c.jsonKey}${c.isTestnet ? " *(testnet)*" : ""} | ${c.chainId} | ${p.label} | \`${new URL(p.url).host}\` | ${cell("debug_traceBlockByNumber")} | ${cell("trace_block")} | ${cell("ots_getBlockTransactions")} |`,
+      );
+    }
+  }
+  L.push("");
+  L.push("## Cost and size, where a method answered");
+  L.push("");
+  L.push("| Chain | Method | Block | Txs | Raw | Gzip | Fetch | Parse |");
+  L.push("|---|---|---|---|---|---|---|---|");
+  let any = false;
+  for (const c of results) {
+    for (const p of c.endpoints) {
+      for (const [name, m] of Object.entries(p.methods ?? {})) {
+        if (m.status !== "ok" && m.status !== "ok-empty") continue;
+        any = true;
+        L.push(
+          `| ${c.jsonKey} (${p.label}) | \`${name}\` | ${p.block?.number ?? "—"} | ${p.block?.txCount ?? "—"}${p.block?.empty ? " *(empty)*" : ""} | ${kb(m.bytesRaw)} | ${kb(m.bytesGzip)} | ${ms(m.fetchMs)} | ${ms(m.parseMs)} |`,
+        );
+      }
+    }
+  }
+  if (!any) L.push("| — | — | — | — | — | — | — | — |");
+  L.push("");
+  L.push("## Refusals, verbatim");
+  L.push("");
+  L.push(
+    "The distinction between these is the point of the survey: a method that was never implemented, one gated behind a plan, and one that timed out imply different things for #2241.",
+  );
+  L.push("");
+  for (const c of results) {
+    for (const p of c.endpoints) {
+      const bad = Object.entries(p.methods ?? {}).filter(
+        ([, m]) => !["ok", "ok-empty", "n/a"].includes(m.status),
+      );
+      if (!bad.length && !p.skipped) continue;
+      L.push(`**${c.jsonKey}** — ${p.label} (\`${new URL(p.url).host}\`)`);
+      L.push("");
+      if (p.skipped) L.push(`- endpoint skipped: ${p.skipped}`);
+      for (const [name, m] of bad) {
+        const detail = m.errorMessage ? ` — \`${m.errorMessage}\`` : "";
+        const code = m.errorCode != null ? ` (code ${m.errorCode})` : "";
+        L.push(`- \`${name}\`: ${m.status}${code}${detail}`);
+      }
+      L.push("");
+    }
+  }
+  const mismatches = results.flatMap((c) =>
+    c.endpoints
+      .filter((p) => p.chainIdMatches === false)
+      .map((p) => ({ chain: c, endpoint: p })),
+  );
+  if (mismatches.length) {
+    L.push("## ⚠️ chainId mismatches");
+    L.push("");
+    L.push("The endpoint did not report the chain id `CHAIN_CONFIG` maps it to:");
+    L.push("");
+    for (const { chain, endpoint } of mismatches) {
+      L.push(
+        `- **${chain.jsonKey}** (${endpoint.label}, \`${new URL(endpoint.url).host}\`): config says ${chain.chainId}, endpoint reported ${endpoint.chainIdReported}`,
+      );
+    }
+    L.push("");
+  }
+  return L.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Main
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const a = {
+    only: null,
+    mainnets: false,
+    config: null,
+    dryRun: false,
+    out: "./out",
+  };
+  const value = (i, k) => {
+    const v = argv[i];
+    if (v === undefined || v.startsWith("--")) {
+      throw new Error(`${k} needs a value`);
+    }
+    return v;
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--only") {
+      const ids = value(++i, k)
+        .split(",")
+        .map((s) => Number(s.trim()));
+      if (ids.some((n) => !Number.isInteger(n))) {
+        throw new Error("--only takes a comma-separated list of chain ids");
+      }
+      a.only = new Set(ids);
+    } else if (k === "--mainnets") a.mainnets = true;
+    else if (k === "--config") a.config = value(++i, k);
+    else if (k === "--dry-run") a.dryRun = true;
+    else if (k === "--out") a.out = value(++i, k);
+    else throw new Error(`unknown argument: ${k}`);
+  }
+  return a;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const startedAt = new Date().toISOString();
+
+  const source = await loadConfig(args.config);
+  const all = parseChainConfig(source);
+
+  let targets = all;
+  if (args.only) targets = targets.filter((c) => args.only.has(c.chainId));
+  if (args.mainnets) targets = targets.filter((c) => !c.isTestnet);
+
+  // Non-overlapping buckets: solana-devnet is both non-EVM and a testnet, so
+  // reporting "EVM mainnets / testnets / solana" as three counts double-counts
+  // it and the total does not add up.
+  const n = (fn) => all.filter(fn).length;
+  process.stderr.write(
+    `CHAIN_CONFIG: ${all.length} entries = ` +
+      `${n((c) => c.chainType === "evm" && !c.isTestnet)} EVM mainnet + ` +
+      `${n((c) => c.chainType === "evm" && c.isTestnet)} EVM testnet + ` +
+      `${n((c) => c.chainType === "solana" && !c.isTestnet)} solana mainnet + ` +
+      `${n((c) => c.chainType === "solana" && c.isTestnet)} solana devnet\n` +
+      `probing ${targets.length}\n\n`,
+  );
+  if (targets.length === 0) {
+    throw new Error("no chains matched the given filters");
+  }
+
+  if (args.dryRun) {
+    for (const c of targets) {
+      process.stderr.write(
+        `  ${String(c.chainId).padStart(9)} ${c.jsonKey.padEnd(20)} ${c.primary.url}\n`,
+      );
+    }
+    return;
+  }
+
+  const results = [];
+  for (const c of targets) {
+    process.stderr.write(`[${c.chainId}] ${c.jsonKey}\n`);
+    const endpoints = [];
+    const probe =
+      c.chainType === "solana" ? probeSolanaEndpoint : probeEvmEndpoint;
+    endpoints.push(await probe("primary", c.primary.url, c.chainId));
+
+    // Scope item 1 asks about the primary AND fallback upstreams. 17 of 24
+    // chains fall back to a different provider entirely (drpc, ankr, thirdweb,
+    // 1rpc), so trace support genuinely differs between them — surveying only
+    // the primary would answer half the question.
+    if (c.fallback?.url && c.fallback.url !== c.primary.url) {
+      await sleep(REQUEST_DELAY_MS);
+      process.stderr.write(`  fallback:\n`);
+      endpoints.push(await probe("fallback", c.fallback.url, c.chainId));
+    }
+    results.push({ ...c, endpoints });
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  const meta = {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    configSource: args.config ?? CONFIG_URL,
+    totalChains: all.length,
+    limits: {
+      REQUEST_DELAY_MS,
+      REQUEST_TIMEOUT_MS,
+      MAX_RESPONSE_BYTES,
+      BLOCKS_BEHIND_HEAD,
+    },
+  };
+
+  const outDir = resolve(args.out);
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    `${outDir}/results.json`,
+    JSON.stringify({ meta, results }, null, 2),
+  );
+  await writeFile(`${outDir}/report.md`, buildReport(results, meta));
+  process.stderr.write(`\nwrote ${outDir}/results.json and report.md\n`);
+}
+
+// Only run when invoked directly, so the pure functions above stay testable.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    process.stderr.write(`\nfatal: ${err.message}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/trace-method-probe.mjs
+++ b/scripts/trace-method-probe.mjs
@@ -307,7 +307,11 @@ const BLOCK_UNAVAILABLE_PATTERNS = [
 ];
 
 /** Throttling, in the vocabularies observed across drpc, ankr and publicnode. */
-const RATE_LIMIT_PATTERN = /rate.?limit|too many|429|quota|throttl/;
+// `429` is word-anchored: unanchored it matched any message containing those
+// three digits, and this pattern is tested before every other body branch. It
+// would have claimed `block 4291234 not found` and `missing trie node 429a1f0b`
+// as throttling — exactly the messages BLOCK_UNAVAILABLE_PATTERNS exists for.
+const RATE_LIMIT_PATTERN = /rate.?limit|too many|\b429\b|quota|throttl/;
 
 /**
  * Failures that say "ask again" rather than "no". A survey that records a
@@ -327,10 +331,12 @@ export function shouldRetry(status, message) {
   const msg = String(message ?? "");
   return (
     RETRYABLE.has(status) ||
-    // Belt and braces for the ordering fix in classify(): if a throttle still
-    // reaches here labelled tier-gated — an HTTP 403 with no JSON body, say,
-    // where there is no message for the classifier to read — the rate-limit
-    // wording still earns it the retry a real gate would not get.
+    // Unreachable on today's ordering, and kept deliberately. Hoisting
+    // RATE_LIMIT_PATTERN above TIER_PATTERNS in classify() means a message that
+    // would match here was already classified `rate-limited`, and the only other
+    // route to `tier-gated` is the bodiless 401/403, where `message` is
+    // undefined. This is a guard against a future reordering, not a live path;
+    // delete it if the ordering is ever made explicit some other way.
     (status === "tier-gated" && RATE_LIMIT_PATTERN.test(msg.toLowerCase())) ||
     (status === "error" && RETRYABLE_MESSAGE.test(msg))
   );
@@ -463,6 +469,38 @@ async function rpcWithRetry(url, method, params, timeoutMs) {
   return { r: again, status: classify(again), retried: true };
 }
 
+/**
+ * Pick the block to trace from what the walk-back actually observed.
+ *
+ * Separated from the loop because the loop does I/O and this does not, and
+ * because the defect it exists to prevent has now been found twice in the same
+ * place: the scan can end holding a block number it never read. `blockNum` is
+ * decremented after every empty read, so on both non-"found transactions" exits
+ * it points one block past anything verified — a failure mid-walk, and an
+ * exhausted BLOCK_SCAN_LIMIT. Tracing that block records capability findings
+ * for a block nobody fetched.
+ *
+ * @param {{block:number, status:string, txCount:number}[]} reads
+ *        one entry per iteration, in order, including the failing one.
+ * @returns {{sampledBlock:number|null, txCount:number, blocksRead:number,
+ *            readable:boolean, scanEndedOn:string|null}}
+ */
+export function selectSample(reads) {
+  const ok = reads.filter((r) => r.status === "ok");
+  const last = ok.at(-1) ?? null;
+  const ended = reads.at(-1)?.status ?? null;
+  return {
+    sampledBlock: last ? last.block : null,
+    txCount: last ? last.txCount : 0,
+    // Blocks that came back ok - not the loop index, and not the request count:
+    // rpcWithRetry may make two requests for one block, and a failed fetch is
+    // not a read at all.
+    blocksRead: ok.length,
+    readable: ok.length > 0,
+    scanEndedOn: ended === "ok" ? null : ended,
+  };
+}
+
 async function probeEvmEndpoint(label, url, expectedChainId) {
   const record = { label, url, methods: {} };
 
@@ -509,26 +547,23 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
   // real block against an empty one — the size column is scope item 3, so the
   // sample has to be comparable or the whole table misleads.
   let blockNum = Number(head.body.result) - BLOCKS_BEHIND_HEAD;
-  let txCount = 0;
-  let blocksRead = 0;
-  let readable = false;
-  let lastScanStatus = null;
+  const reads = [];
   for (let i = 0; i < BLOCK_SCAN_LIMIT; i++) {
     await sleep(REQUEST_DELAY_MS);
-    blocksRead++;
     const { r: b, status } = await rpcWithRetry(
       url,
       "eth_getBlockByNumber",
       [`0x${blockNum.toString(16)}`, false],
       LIVENESS_TIMEOUT_MS,
     );
-    lastScanStatus = status;
-    if (status !== "ok") break;
-    readable = true;
-    txCount = b.body.result?.transactions?.length ?? 0;
-    if (txCount > 0) break;
+    const txs = status === "ok" ? (b.body.result?.transactions?.length ?? 0) : 0;
+    reads.push({ block: blockNum, status, txCount: txs });
+    if (status !== "ok" || txs > 0) break;
     blockNum -= 1;
   }
+  const { sampledBlock, txCount, blocksRead, readable, scanEndedOn } =
+    selectSample(reads);
+  const lastScanStatus = scanEndedOn ?? "ok";
 
   // Nothing was verified, so nothing is recorded. Previously the loop could
   // break on the very first unreadable block — a 429 on the block fetch, say —
@@ -541,16 +576,19 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
     return record;
   }
 
-  const blockHex = `0x${blockNum.toString(16)}`;
+  const blockHex = `0x${sampledBlock.toString(16)}`;
   record.block = {
-    number: blockNum,
+    number: sampledBlock,
     hex: blockHex,
     txCount,
-    // Requests actually made, not the loop index. `scanned + 1` read 13 when
-    // the loop exhausted a 12-block limit, and 1 when it broke on the first
-    // unreadable block despite zero successful reads.
+    // Blocks that came back `ok`, not the loop index and not the request count:
+    // a retried fetch is one block, and a failed one is none.
     blocksRead,
     empty: txCount === 0,
+    // A scan that ended on a failure still produced a usable sample from an
+    // earlier iteration, but the reader has to be able to tell that the walk
+    // stopped early rather than finding what it wanted.
+    ...(scanEndedOn ? { scanEndedOn } : {}),
   };
   if (txCount === 0) {
     process.stderr.write(
@@ -699,7 +737,8 @@ function buildReport(results, meta) {
   L.push("| `block-unavailable` | the endpoint could not serve the sampled block (behind the tip, or pruned state). A statement about the block, not the method — retried once |");
   L.push("| `too-large` | answered, but exceeded the response cap |");
   L.push("| `error` | answered with something we decline to bucket — see verbatim below |");
-  L.push("| `n/a` | endpoint skipped; the reason is in parentheses |");
+  L.push("| `—` | endpoint skipped; the reason is in parentheses |");
+  L.push("| `n/a` | the method does not apply to this endpoint — non-EVM chains carry no trace surface |");
   L.push("");
   L.push(summarise(results));
   L.push("");

--- a/scripts/trace-method-probe.mjs
+++ b/scripts/trace-method-probe.mjs
@@ -260,12 +260,24 @@ const TIER_PATTERNS = [
   /requires? (a |an )?[\w ]*\b(token|key|account|credential)/,
 ];
 
-/** A refusal no amount of money lifts on this endpoint. */
+/**
+ * A refusal no amount of money lifts on this endpoint.
+ *
+ * Deliberately narrower than the first revision, which also carried
+ * `/not found/` and `/not available|unavailable/`. Both had to go: geth
+ * answers a block it cannot serve with `-32001 "block not found"`,
+ * `-32000 "header not found"` and `"missing trie node ... state is not
+ * available"`, none of which say anything about the method. On a
+ * load-balanced endpoint a backend a block or two behind returns exactly that
+ * for a head-adjacent block, so those patterns wrote "no plan lifts it"
+ * against `plasma-mainnet`, a chain that does implement
+ * `debug_traceBlockByNumber` and that the headline cites as a trace success.
+ * A genuinely absent method always carries `-32601`, which classify() tests
+ * before it reaches these patterns.
+ */
 const NOT_SUPPORTED_PATTERNS = [
   /does not exist/,
-  /not found/,
   /unsupported|not supported/,
-  /not available|unavailable/,
   /disabled|not enabled/,
   // 1rpc.io answers `-32600 "Method trace_block not allowed"` — code -32600 is
   // "invalid request", so without this the verdict falls through to the
@@ -273,6 +285,29 @@ const NOT_SUPPORTED_PATTERNS = [
   // eth-mainnet fallback; tempo says the same thing but with -32601.
   /not allowed|not permitted/,
 ];
+
+/**
+ * The BLOCK is missing, not the method. Retryable: these come from a backend
+ * that is behind the tip or has pruned the state, and on a load-balanced
+ * endpoint the next request may land on one that can serve it.
+ */
+const BLOCK_UNAVAILABLE_PATTERNS = [
+  // `\bblock\b` throughout, never a bare /block/: method names contain the
+  // word. "trace_block not found" is a statement about the method and must not
+  // land here, and `_` is a word character, so the boundary excludes it while
+  // still matching a standalone "block not found".
+  /\bblock\b.{0,24}not found/,
+  /header not found/,
+  /missing trie node/,
+  /state (is )?not available/,
+  /\bblock\b.{0,24}(not available|unavailable)/,
+  // Guards the `/does not exist/` pattern above, which is there for
+  // "Method X does not exist" and must not swallow "block does not exist".
+  /\bblock\b.{0,24}does not exist/,
+];
+
+/** Throttling, in the vocabularies observed across drpc, ankr and publicnode. */
+const RATE_LIMIT_PATTERN = /rate.?limit|too many|429|quota|throttl/;
 
 /**
  * Failures that say "ask again" rather than "no". A survey that records a
@@ -284,13 +319,20 @@ const RETRYABLE = new Set([
   "transport-error",
   "server-error",
   "rate-limited",
+  "block-unavailable",
 ]);
 const RETRYABLE_MESSAGE = /temporary|please retry|try again|internal error/i;
 
-function shouldRetry(status, message) {
+export function shouldRetry(status, message) {
+  const msg = String(message ?? "");
   return (
     RETRYABLE.has(status) ||
-    (status === "error" && RETRYABLE_MESSAGE.test(String(message ?? "")))
+    // Belt and braces for the ordering fix in classify(): if a throttle still
+    // reaches here labelled tier-gated — an HTTP 403 with no JSON body, say,
+    // where there is no message for the classifier to read — the rate-limit
+    // wording still earns it the retry a real gate would not get.
+    (status === "tier-gated" && RATE_LIMIT_PATTERN.test(msg.toLowerCase())) ||
+    (status === "error" && RETRYABLE_MESSAGE.test(msg))
   );
 }
 
@@ -322,12 +364,26 @@ export function classify(r) {
   const err = r.body?.error;
   if (err) {
     const msg = String(err.message ?? "").toLowerCase();
-    // Tier first: "not available on the free plan" matches both vocabularies,
-    // and calling that "never implemented" is the costliest error here.
+    // Rate limit BEFORE tier. drpc and ankr free tiers throttle using exactly
+    // the tier vocabulary ("upgrade", "plan"), and a full run makes roughly
+    // four requests per endpoint across 39 hosts at a fixed spacing, so
+    // meeting one is routine. Testing tier first wrote a transient throttle
+    // into the report's most decision-relevant column as "traces are
+    // purchasable here", with nothing to distinguish it from a real gate. The
+    // cost of this ordering is one-directional: rate-limited is retryable,
+    // tier-gated is not.
+    if (err.code === -32005 || RATE_LIMIT_PATTERN.test(msg)) {
+      return "rate-limited";
+    }
+    // Then tier: "not available on the free plan" matches both the tier and
+    // the not-supported vocabularies, and calling that "never implemented" is
+    // the costliest error here.
     if (TIER_PATTERNS.some((p) => p.test(msg))) return "tier-gated";
     if (err.code === -32601) return "method-not-found";
-    if (err.code === -32005 || /rate limit|too many/.test(msg)) {
-      return "rate-limited";
+    // Ahead of the not-supported patterns: a block this backend cannot serve
+    // is not a statement about the method.
+    if (BLOCK_UNAVAILABLE_PATTERNS.some((p) => p.test(msg))) {
+      return "block-unavailable";
     }
     if (NOT_SUPPORTED_PATTERNS.some((p) => p.test(msg))) {
       return "method-not-found";
@@ -350,7 +406,11 @@ export function classify(r) {
   // consulted first; the raw text is the last resort.
   if (r.parseError) {
     const raw = String(r.rawSnippet ?? "").toLowerCase();
+    if (RATE_LIMIT_PATTERN.test(raw)) return "rate-limited";
     if (TIER_PATTERNS.some((p) => p.test(raw))) return "tier-gated";
+    if (BLOCK_UNAVAILABLE_PATTERNS.some((p) => p.test(raw))) {
+      return "block-unavailable";
+    }
     if (NOT_SUPPORTED_PATTERNS.some((p) => p.test(raw))) return "method-not-found";
     return "invalid-response";
   }
@@ -383,13 +443,37 @@ const TRACE_METHODS = [
   { name: "ots_getBlockTransactions", params: (hex, n) => [n, 0, 25] },
 ];
 
+/**
+ * `rpc` plus the single retry `shouldRetry` licenses.
+ *
+ * The trace-method loop had this inline, but the `eth_chainId` liveness call
+ * and the `eth_blockNumber` head call did not, so a blip on either discarded
+ * all three method findings for that endpoint while the report still claimed
+ * "transient failures are retried once". One helper now backs every call, and
+ * the claim is true.
+ */
+async function rpcWithRetry(url, method, params, timeoutMs) {
+  const first = await rpc(url, method, params, timeoutMs);
+  const status = classify(first);
+  const why = first.body?.error?.message ?? first.transportError;
+  if (!shouldRetry(status, why)) return { r: first, status, retried: false };
+  await sleep(REQUEST_DELAY_MS * 4);
+  process.stderr.write(`    ${method}: ${status} -> retry\n`);
+  const again = await rpc(url, method, params, timeoutMs);
+  return { r: again, status: classify(again), retried: true };
+}
+
 async function probeEvmEndpoint(label, url, expectedChainId) {
   const record = { label, url, methods: {} };
 
   // Liveness control. Distinguishes "this method is refused" from "this
   // endpoint is dead", which is the whole reason the control exists.
-  const live = await rpc(url, "eth_chainId", [], LIVENESS_TIMEOUT_MS);
-  const liveClass = classify(live);
+  const { r: live, status: liveClass } = await rpcWithRetry(
+    url,
+    "eth_chainId",
+    [],
+    LIVENESS_TIMEOUT_MS,
+  );
   record.liveness = {
     status: liveClass,
     httpStatus: live.httpStatus,
@@ -410,9 +494,14 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
 
   await sleep(REQUEST_DELAY_MS);
 
-  const head = await rpc(url, "eth_blockNumber", [], LIVENESS_TIMEOUT_MS);
-  if (classify(head) !== "ok") {
-    record.skipped = "eth_blockNumber failed; no block to trace";
+  const { r: head, status: headStatus } = await rpcWithRetry(
+    url,
+    "eth_blockNumber",
+    [],
+    LIVENESS_TIMEOUT_MS,
+  );
+  if (headStatus !== "ok") {
+    record.skipped = `eth_blockNumber failed (${headStatus}); no block to trace`;
     return record;
   }
   // Trace an block that actually has transactions in it. A quiet chain serves
@@ -421,26 +510,46 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
   // sample has to be comparable or the whole table misleads.
   let blockNum = Number(head.body.result) - BLOCKS_BEHIND_HEAD;
   let txCount = 0;
-  let scanned = 0;
-  for (; scanned < BLOCK_SCAN_LIMIT; scanned++) {
+  let blocksRead = 0;
+  let readable = false;
+  let lastScanStatus = null;
+  for (let i = 0; i < BLOCK_SCAN_LIMIT; i++) {
     await sleep(REQUEST_DELAY_MS);
-    const b = await rpc(
+    blocksRead++;
+    const { r: b, status } = await rpcWithRetry(
       url,
       "eth_getBlockByNumber",
       [`0x${blockNum.toString(16)}`, false],
       LIVENESS_TIMEOUT_MS,
     );
-    if (classify(b) !== "ok") break;
+    lastScanStatus = status;
+    if (status !== "ok") break;
+    readable = true;
     txCount = b.body.result?.transactions?.length ?? 0;
     if (txCount > 0) break;
     blockNum -= 1;
   }
+
+  // Nothing was verified, so nothing is recorded. Previously the loop could
+  // break on the very first unreadable block — a 429 on the block fetch, say —
+  // leaving txCount at 0 and blockNum never advanced, and control fell through
+  // to probe all three trace methods against a block that was never read. The
+  // answers to those probes were then written down as capability findings.
+  if (!readable) {
+    record.skipped = `no readable block (eth_getBlockByNumber: ${lastScanStatus})`;
+    record.block = { number: null, txCount: null, blocksRead, empty: null };
+    return record;
+  }
+
   const blockHex = `0x${blockNum.toString(16)}`;
   record.block = {
     number: blockNum,
     hex: blockHex,
     txCount,
-    blocksScanned: scanned + 1,
+    // Requests actually made, not the loop index. `scanned + 1` read 13 when
+    // the loop exhausted a 12-block limit, and 1 when it broke on the first
+    // unreadable block despite zero successful reads.
+    blocksRead,
     empty: txCount === 0,
   };
   if (txCount === 0) {
@@ -451,22 +560,15 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
 
   for (const m of TRACE_METHODS) {
     await sleep(REQUEST_DELAY_MS);
-    let r = await rpc(url, m.name, m.params(blockHex, blockNum));
-    let status = classify(r);
-    let retried = false;
-
     // One retry, only for failures that describe themselves as transient.
     // Observed: robinhood-testnet's fallback answered `code 19 "Temporary
     // internal error. Please retry"` — recording that as a capability verdict
     // would put a blip in the survey and make the run irreproducible.
-    if (shouldRetry(status, r.body?.error?.message ?? r.transportError)) {
-      await sleep(REQUEST_DELAY_MS * 4);
-      const again = await rpc(url, m.name, m.params(blockHex, blockNum));
-      retried = true;
-      process.stderr.write(`    ${m.name}: ${status} → retry\n`);
-      r = again;
-      status = classify(again);
-    }
+    const { r, status, retried } = await rpcWithRetry(
+      url,
+      m.name,
+      m.params(blockHex, blockNum),
+    );
 
     record.methods[m.name] = {
       retried,
@@ -489,8 +591,12 @@ async function probeEvmEndpoint(label, url, expectedChainId) {
 
 async function probeSolanaEndpoint(label, url) {
   const record = { label, url, methods: {}, note: "solana: no debug_trace*" };
-  const live = await rpc(url, "getVersion", [], LIVENESS_TIMEOUT_MS);
-  const liveClass = classify(live);
+  const { r: live, status: liveClass } = await rpcWithRetry(
+    url,
+    "getVersion",
+    [],
+    LIVENESS_TIMEOUT_MS,
+  );
   record.liveness = {
     status: liveClass,
     httpStatus: live.httpStatus,
@@ -511,22 +617,11 @@ const kb = (n) =>
   n == null ? "—" : n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`;
 const ms = (n) => (n == null ? "—" : `${n} ms`);
 
-const MARK = {
-  ok: "✅",
-  "ok-empty": "☑️",
-  "too-large": "📦",
-  "method-not-found": "❌",
-  "tier-gated": "🔒",
-  "rate-limited": "⏳",
-  timeout: "⌛",
-  "transport-error": "💥",
-  "server-error": "💥",
-  "invalid-response": "⚠️",
-  "null-result": "∅",
-  error: "⚠️",
-  "n/a": "—",
-};
-const mark = (s) => `${MARK[s] ?? "?"} ${s}`;
+// AGENTS.md:42 forbids emoji in code and generated content, and this script
+// writes the report as well as reading it. The status name carries the whole
+// meaning, so it is rendered as code and the legend defines each one, rather
+// than adding a second severity vocabulary that could disagree with it.
+const mark = (s) => `\`${s ?? "n/a"}\``;
 
 /**
  * The headline the issue actually asks for: which chains are trace triggers
@@ -573,7 +668,9 @@ function buildReport(results, meta) {
   const L = [];
   L.push("# Trace-method availability across configured chain upstreams");
   L.push("");
-  L.push(`Survey for #2247. Generated by \`scripts/trace-probe/probe.mjs\`.`);
+  L.push(
+    `Survey for #2247. Generated by \`scripts/trace-method-probe.mjs\`; re-run it to regenerate this file.`,
+  );
   L.push("");
   L.push(`- **Run at:** ${meta.startedAt}`);
   L.push(`- **Config source:** ${meta.configSource}`);
@@ -592,15 +689,17 @@ function buildReport(results, meta) {
   L.push("");
   L.push("## Legend");
   L.push("");
-  L.push("| | Meaning |");
+  L.push("| Status | Meaning |");
   L.push("|---|---|");
-  L.push("| ✅ `ok` | method answered with trace data |");
-  L.push("| ☑️ `ok-empty` | method answered, but the sampled block was empty — supported, size not measurable |");
-  L.push("| ❌ `method-not-found` | method absent on this endpoint; no plan lifts it |");
-  L.push("| 🔒 `tier-gated` | refused for credentials or plan — purchasable |");
-  L.push("| 📦 `too-large` | answered, but exceeded the response cap |");
-  L.push("| ⚠️ `error` | answered with something we decline to bucket — see verbatim below |");
-  L.push("| — | endpoint skipped; the reason is in parentheses |");
+  L.push("| `ok` | method answered with trace data |");
+  L.push("| `ok-empty` | method answered, but the sampled block was empty — supported, size not measurable |");
+  L.push("| `method-not-found` | method absent on this endpoint; no plan lifts it. Reserved for `-32601` and for wording that names the *method*; a block the backend could not serve is `block-unavailable` instead |");
+  L.push("| `tier-gated` | refused for credentials or plan — purchasable |");
+  L.push("| `rate-limited` | throttled. Retried once and still throttled; says nothing about availability, so re-run before reading anything into it |");
+  L.push("| `block-unavailable` | the endpoint could not serve the sampled block (behind the tip, or pruned state). A statement about the block, not the method — retried once |");
+  L.push("| `too-large` | answered, but exceeded the response cap |");
+  L.push("| `error` | answered with something we decline to bucket — see verbatim below |");
+  L.push("| `n/a` | endpoint skipped; the reason is in parentheses |");
   L.push("");
   L.push(summarise(results));
   L.push("");
@@ -670,7 +769,7 @@ function buildReport(results, meta) {
       .map((p) => ({ chain: c, endpoint: p })),
   );
   if (mismatches.length) {
-    L.push("## ⚠️ chainId mismatches");
+    L.push("## chainId mismatches");
     L.push("");
     L.push("The endpoint did not report the chain id `CHAIN_CONFIG` maps it to:");
     L.push("");
@@ -789,6 +888,9 @@ async function main() {
       REQUEST_TIMEOUT_MS,
       MAX_RESPONSE_BYTES,
       BLOCKS_BEHIND_HEAD,
+      // buildReport reads this for the Sampling line; without it every
+      // generated report said "walked back up to undefined blocks".
+      BLOCK_SCAN_LIMIT,
     },
   };
 

--- a/scripts/trace-method-probe.test.mjs
+++ b/scripts/trace-method-probe.test.mjs
@@ -1,0 +1,304 @@
+/**
+ * QA for probe.mjs — the two pure functions.
+ *
+ * classify() is the piece the whole survey rests on: if it mislabels a tier
+ * gate as "not supported", #2241 gets scoped against a wrong answer. Live
+ * probing only exercises whatever the network happened to return today, so the
+ * refusal shapes are pinned here instead.
+ *
+ *   node --test scripts/trace-method-probe.test.mjs
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { classify, parseChainConfig } from "./trace-method-probe.mjs";
+
+// Point at the repo's own config: the parser must keep working against the
+// real file, not a vendored snapshot that can silently go stale.
+const CONFIG =
+  process.env.RPC_CONFIG_PATH ??
+  new URL("../lib/rpc/rpc-config.ts", import.meta.url).pathname;
+
+// --- classify ---------------------------------------------------------------
+
+// Default to a NON-empty result: `result: []` is its own classification
+// (ok-empty), so using it as the generic "success" fixture would test the
+// wrong branch.
+const ok = (over = {}) => ({
+  httpStatus: 200,
+  body: { result: [{ type: "CALL" }] },
+  ...over,
+});
+const rpcErr = (code, message, over = {}) => ({
+  httpStatus: 200,
+  body: { error: { code, message } },
+  ...over,
+});
+
+test("ok when a result is present", () => {
+  assert.equal(classify(ok()), "ok");
+  assert.equal(classify(ok({ body: { result: "0x1" } })), "ok");
+});
+
+test("null result is distinct from ok", () => {
+  // Some nodes answer trace_block with null for an empty/unknown block. That
+  // is not the same as supporting it with data, and not the same as refusing.
+  assert.equal(classify(ok({ body: { result: null } })), "null-result");
+});
+
+test("standard JSON-RPC method-not-found", () => {
+  assert.equal(classify(rpcErr(-32601, "the method does not exist")), "method-not-found");
+});
+
+test("method refusals phrased as prose, not as -32601", () => {
+  for (const msg of [
+    "debug_traceBlockByNumber is not supported",
+    "method not available on this endpoint",
+    "trace_block is disabled",
+    "Method not found",
+    "endpoint unavailable for this method",
+    "ots_getBlockTransactions not enabled",
+  ]) {
+    assert.equal(classify(rpcErr(-32000, msg)), "method-not-found", msg);
+  }
+});
+
+test("tier gates, by status and by message", () => {
+  assert.equal(classify({ httpStatus: 401 }), "tier-gated");
+  assert.equal(classify({ httpStatus: 403 }), "tier-gated");
+  for (const msg of [
+    "This method requires a paid plan",
+    "upgrade your plan to access trace methods",
+    "api key required",
+    "unauthorized",
+    "access denied for this tier",
+  ]) {
+    assert.equal(classify(rpcErr(-32000, msg)), "tier-gated", msg);
+  }
+});
+
+test("a tier gate outranks the not-supported wording when both appear", () => {
+  // Providers commonly say "not available on your plan". Reading that as
+  // "never implemented" is the single most damaging misclassification here:
+  // it would tell #2241 a chain cannot do traces when in fact it can be paid for.
+  assert.equal(
+    classify(rpcErr(-32000, "trace_block is not available on the free plan")),
+    "tier-gated",
+  );
+});
+
+// Observed responses, captured 2026-09-03. Both are HTTP 403 and mean opposite
+// things; the first draft of classify() got Base backwards by reading the
+// status before the body. These are the regression.
+test("REAL: base mainnet — 403 + -32601 is absence, not a paywall", () => {
+  assert.equal(
+    classify({
+      httpStatus: 403,
+      body: { error: { code: -32601, message: "rpc method is unsupported" } },
+    }),
+    "method-not-found",
+  );
+});
+
+test("REAL: eth publicnode — 403 + -32602 archive token is a paywall", () => {
+  assert.equal(
+    classify({
+      httpStatus: 403,
+      body: {
+        error: {
+          code: -32602,
+          message:
+            "Archive requests require a personal token. Get one at: https://www.allnodes.com/publicnode",
+        },
+      },
+    }),
+    "tier-gated",
+  );
+});
+
+test("REAL: publicnode absent-method wording", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: {
+        error: {
+          code: -32601,
+          message:
+            "the method debug_traceBlockByNumber does not exist/is not available",
+        },
+      },
+    }),
+    "method-not-found",
+  );
+});
+
+test("rate limits are not mistaken for refusals", () => {
+  assert.equal(classify({ httpStatus: 429 }), "rate-limited");
+  assert.equal(classify(rpcErr(-32005, "limit exceeded")), "rate-limited");
+  assert.equal(classify(rpcErr(-32000, "too many requests")), "rate-limited");
+});
+
+test("transport failures keep timeout separate from everything else", () => {
+  assert.equal(classify({ transportError: "timeout" }), "timeout");
+  assert.equal(classify({ transportError: "ECONNREFUSED" }), "transport-error");
+});
+
+test("truncation is a size finding, not a malformed response", () => {
+  // Ordering matters: truncated bodies never parse, so if this branch came
+  // after the parseError check it would be reported as invalid-response and
+  // the size result — scope item 3 — would be lost.
+  assert.equal(
+    classify({ httpStatus: 200, truncated: true, parseError: "Unexpected end of JSON input" }),
+    "too-large",
+  );
+});
+
+test("malformed and server errors stay distinguishable", () => {
+  assert.equal(classify({ httpStatus: 200, parseError: "Unexpected token <" }), "invalid-response");
+  assert.equal(classify({ httpStatus: 502, body: null }), "server-error");
+  assert.equal(classify({ httpStatus: 200, body: {} }), "invalid-response");
+});
+
+test("an unrecognised RPC error is surfaced, not silently bucketed", () => {
+  assert.equal(classify(rpcErr(-32000, "something we have never seen")), "error");
+});
+
+// --- parseChainConfig -------------------------------------------------------
+
+test("parses the real rpc-config.ts", async (t) => {
+  let source;
+  try {
+    source = await readFile(CONFIG, "utf8");
+  } catch {
+    t.skip(`no config at ${CONFIG} — set RPC_CONFIG_PATH`);
+    return;
+  }
+  const chains = parseChainConfig(source);
+
+  assert.ok(chains.length >= 20, `expected 20+ chains, got ${chains.length}`);
+  assert.ok(chains.every((c) => Number.isInteger(c.chainId)));
+  assert.ok(chains.every((c) => c.primary?.url?.startsWith("http")));
+
+  const byId = new Map(chains.map((c) => [c.chainId, c]));
+  assert.equal(byId.get(1)?.jsonKey, "eth-mainnet");
+  assert.equal(byId.get(8453)?.jsonKey, "base-mainnet");
+  assert.equal(byId.get(101)?.chainType, "solana");
+  assert.equal(byId.get(1)?.chainType, "evm");
+  assert.equal(byId.get(11155111)?.isTestnet, true);
+  assert.equal(byId.get(1)?.isTestnet, false);
+
+  // Buckets must partition, or the run-summary counts lie.
+  const sum =
+    chains.filter((c) => c.chainType === "evm" && !c.isTestnet).length +
+    chains.filter((c) => c.chainType === "evm" && c.isTestnet).length +
+    chains.filter((c) => c.chainType === "solana" && !c.isTestnet).length +
+    chains.filter((c) => c.chainType === "solana" && c.isTestnet).length;
+  assert.equal(sum, chains.length, "chain buckets must partition the set");
+
+  assert.equal(new Set(chains.map((c) => c.chainId)).size, chains.length);
+});
+
+test("throws loudly rather than surveying a partial config", () => {
+  assert.throws(() => parseChainConfig("nothing here"), /PUBLIC_RPCS block not found/);
+  assert.throws(
+    () => parseChainConfig('export const PUBLIC_RPCS = {\n  A: "https://x",\n};\n'),
+    /CHAIN_CONFIG block not found/,
+  );
+});
+
+test("throws when a chain resolves to no URL", () => {
+  const src = [
+    'export const PUBLIC_RPCS = {',
+    '  KNOWN: "https://known.example",',
+    '};',
+    '',
+    'export const CHAIN_CONFIG: Record<number, ChainConfigEntry> = {',
+    '  1: {',
+    '    jsonKey: "eth-mainnet",',
+    '    publicDefault: PUBLIC_RPCS.MISSING,',
+    '  },',
+    '};',
+  ].join("\n");
+  assert.throws(() => parseChainConfig(src), /no publicDefault URL resolved/);
+});
+
+test("empty array result is supported-but-unmeasured, not a size datapoint", () => {
+  // Observed on tempo-mainnet: the method answered with `result: []` on an
+  // empty block — 36 bytes. Reporting that as "ok" alongside plasma's 149 KB
+  // would put two incomparable numbers in the same size column.
+  assert.equal(classify({ httpStatus: 200, body: { result: [] } }), "ok-empty");
+  assert.equal(classify({ httpStatus: 200, body: { result: [{ x: 1 }] } }), "ok");
+});
+
+test("REAL: 1rpc.io — -32600 'not allowed' is absence, not unclassified", () => {
+  // Observed on the eth-mainnet fallback. Code -32600 is "invalid request",
+  // so only the wording identifies this as an absent method.
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: { error: { code: -32600, message: "Method trace_block not allowed" } },
+    }),
+    "method-not-found",
+  );
+});
+
+test("REAL: ankr free tier gates at the liveness check", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: {
+        error: {
+          code: -32600,
+          message:
+            "Unauthorized: You must authenticate your request with an API key. Create an account on https://www.ankr.com/rpc/ and generate your personal API key for free.",
+        },
+      },
+    }),
+    "tier-gated",
+  );
+});
+
+test("REAL: drpc free-plan chain gate", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: {
+        error: {
+          code: 12,
+          message: "chain is not available on free plan, please upgrade to paid plan",
+        },
+      },
+    }),
+    "tier-gated",
+  );
+});
+
+test("REAL: 1rpc.io — non-JSON 401 policy refusal is a gate, not malformed", () => {
+  // Observed on the eth-mainnet fallback for ots_getBlockTransactions: HTTP 401
+  // with a plain-text body and no JSON at all. Checking parseError before the
+  // status (the first draft) reported this as invalid-response.
+  assert.equal(
+    classify({
+      httpStatus: 401,
+      parseError: "Unexpected token O in JSON at position 0",
+      rawSnippet: "Only core evm requests are allowed.",
+    }),
+    "tier-gated",
+  );
+});
+
+test("non-JSON 200 body is still read for a verdict before giving up", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      parseError: "Unexpected token <",
+      rawSnippet: "<html>method not supported</html>",
+    }),
+    "method-not-found",
+  );
+  assert.equal(
+    classify({ httpStatus: 200, parseError: "Unexpected token <", rawSnippet: "<html>502</html>" }),
+    "invalid-response",
+  );
+});

--- a/scripts/trace-method-probe.test.mjs
+++ b/scripts/trace-method-probe.test.mjs
@@ -19,6 +19,7 @@ import { readFile } from "node:fs/promises";
 import {
   classify,
   parseChainConfig,
+  selectSample,
   shouldRetry,
 } from "./trace-method-probe.mjs";
 
@@ -388,5 +389,108 @@ test("non-JSON 200 body is still read for a verdict before giving up", () => {
   assert.equal(
     classify({ httpStatus: 200, parseError: "Unexpected token <", rawSnippet: "<html>502</html>" }),
     "invalid-response",
+  );
+});
+
+// --- selectSample -------------------------------------------------------
+// The defect these pin was found twice in the same walk-back loop: the scan can
+// finish holding a block number it never read, because blockNum is decremented
+// after every empty read. Both non-"found transactions" exits reach that state.
+
+test("selectSample traces the last block that was actually read, not the next candidate", () => {
+  // B reads ok and is empty -> the loop steps to B-1; B-1 is throttled.
+  // The block to trace is B. Tracing B-1 would record capability findings for
+  // a block no request ever returned.
+  const out = selectSample([
+    { block: 100, status: "ok", txCount: 0 },
+    { block: 99, status: "rate-limited", txCount: 0 },
+  ]);
+  assert.equal(out.sampledBlock, 100);
+  assert.equal(out.readable, true);
+  assert.equal(out.txCount, 0);
+});
+
+test("selectSample reports the status the scan ended on when it ended on a failure", () => {
+  const out = selectSample([
+    { block: 100, status: "ok", txCount: 0 },
+    { block: 99, status: "rate-limited", txCount: 0 },
+  ]);
+  assert.equal(out.scanEndedOn, "rate-limited");
+});
+
+test("selectSample leaves scanEndedOn null when the walk ended cleanly", () => {
+  const out = selectSample([{ block: 100, status: "ok", txCount: 7 }]);
+  assert.equal(out.scanEndedOn, null);
+  assert.equal(out.sampledBlock, 100);
+  assert.equal(out.txCount, 7);
+});
+
+test("selectSample does not trace past the end of an exhausted scan", () => {
+  // Every read succeeded and every block was empty. The loop leaves blockNum at
+  // 97; the last block actually read is 98.
+  const out = selectSample([
+    { block: 100, status: "ok", txCount: 0 },
+    { block: 99, status: "ok", txCount: 0 },
+    { block: 98, status: "ok", txCount: 0 },
+  ]);
+  assert.equal(out.sampledBlock, 98);
+  assert.equal(out.blocksRead, 3);
+});
+
+test("selectSample counts blocks read, never attempts", () => {
+  // A failed fetch is not a read. blocksRead used to be incremented before the
+  // call, so a first-iteration failure recorded 1 despite zero successful reads.
+  const out = selectSample([{ block: 100, status: "rate-limited", txCount: 0 }]);
+  assert.equal(out.blocksRead, 0);
+  assert.equal(out.readable, false);
+  assert.equal(out.sampledBlock, null);
+});
+
+// --- the 429 digit coincidence -----------------------------------------
+// RATE_LIMIT_PATTERN is tested before every other body branch, so an unanchored
+// `429` pre-empted the bucket that block-unavailable messages belong in.
+
+test("a block number containing 429 is block-unavailable, not throttling", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: { error: { code: -32000, message: "block 4291234 not found" } },
+    }),
+    "block-unavailable",
+  );
+});
+
+test("a trie-node hash starting 429 is not throttling", () => {
+  assert.notEqual(
+    classify({
+      httpStatus: 200,
+      body: {
+        error: {
+          code: -32000,
+          message: "missing trie node 429a1f0b (path ) state is not available",
+        },
+      },
+    }),
+    "rate-limited",
+  );
+});
+
+test("a request id containing 429 is not throttling", () => {
+  assert.notEqual(
+    classify({
+      httpStatus: 200,
+      body: { error: { code: -32000, message: "request id 42917: unauthorized" } },
+    }),
+    "rate-limited",
+  );
+});
+
+test("a real 429 in a message body is still throttling", () => {
+  assert.equal(
+    classify({
+      httpStatus: 200,
+      body: { error: { code: -32000, message: "429 Too Many Requests" } },
+    }),
+    "rate-limited",
   );
 });

--- a/scripts/trace-method-probe.test.mjs
+++ b/scripts/trace-method-probe.test.mjs
@@ -1,18 +1,26 @@
 /**
- * QA for probe.mjs — the two pure functions.
+ * QA for the pure functions in trace-method-probe.mjs.
  *
  * classify() is the piece the whole survey rests on: if it mislabels a tier
  * gate as "not supported", #2241 gets scoped against a wrong answer. Live
  * probing only exercises whatever the network happened to return today, so the
  * refusal shapes are pinned here instead.
  *
- *   node --test scripts/trace-method-probe.test.mjs
+ * HOW THIS RUNS: `pnpm test:trace-probe`, or `node --test` directly. It is
+ * deliberately outside vitest — `vitest.config.mts` matches only `.ts`/`.tsx`,
+ * and this file tests a dependency-free `.mjs` research script that is not part
+ * of the application build. The package script exists so the cases are executed
+ * rather than being assertions someone has to remember to run.
  */
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { classify, parseChainConfig } from "./trace-method-probe.mjs";
+import {
+  classify,
+  parseChainConfig,
+  shouldRetry,
+} from "./trace-method-probe.mjs";
 
 // Point at the repo's own config: the parser must keep working against the
 // real file, not a vendored snapshot that can silently go stale.
@@ -54,14 +62,65 @@ test("standard JSON-RPC method-not-found", () => {
 test("method refusals phrased as prose, not as -32601", () => {
   for (const msg of [
     "debug_traceBlockByNumber is not supported",
-    "method not available on this endpoint",
     "trace_block is disabled",
-    "Method not found",
-    "endpoint unavailable for this method",
     "ots_getBlockTransactions not enabled",
+    "Method trace_block not allowed",
   ]) {
     assert.equal(classify(rpcErr(-32000, msg)), "method-not-found", msg);
   }
+});
+
+test("ambiguous 'not found' / 'not available' prose is surfaced, not bucketed", () => {
+  // These three used to be asserted as method-not-found, which is what put
+  // plasma-mainnet in the report as "no plan lifts it" while it was in fact
+  // answering debug_traceBlockByNumber: the same words are how geth reports a
+  // block it cannot serve. The patterns are gone, so an ambiguous refusal that
+  // carries no -32601 now lands in `error` and is printed verbatim in the
+  // report for a human to judge.
+  //
+  // This is a deliberate trade. An unclassified refusal costs a reader one
+  // line of prose; a wrong capability verdict is what #2241 gets scoped
+  // against. Anything genuinely absent still carries -32601, covered above.
+  for (const msg of [
+    "method not available on this endpoint",
+    "Method not found",
+    "endpoint unavailable for this method",
+    // Also pins the other direction: the block bucket uses `\\bblock\\b`, so a
+    // method name ending in "_block" does not get read as a missing block.
+    "trace_block not found",
+  ]) {
+    assert.equal(classify(rpcErr(-32000, msg)), "error", msg);
+  }
+});
+
+test("REAL: a lagging backend reports the BLOCK, not the method", () => {
+  // rpc.plasma.to is load-balanced; a backend a block or two behind the tip
+  // answers this for the head-minus-5 block the probe picks. Plasma does
+  // implement debug_traceBlockByNumber and the headline cites it as a trace
+  // success, so bucketing this as method-not-found -- which is not retryable --
+  // wrote a permanent verdict from a transient condition.
+  for (const [code, msg] of [
+    [-32001, "block not found"],
+    [-32000, "header not found"],
+    [-32000, "missing trie node abc123 (path ) state is not available"],
+    [-32000, "block 0x12ab is not available"],
+    [-32000, "block does not exist"],
+  ]) {
+    assert.equal(classify(rpcErr(code, msg)), "block-unavailable", msg);
+  }
+});
+
+test("block-unavailable is retryable so the probe can ask again", () => {
+  assert.equal(shouldRetry("block-unavailable", "block not found"), true);
+  // The contrast that makes the bucket worth having: a real absence is final.
+  assert.equal(shouldRetry("method-not-found", "no such method"), false);
+});
+
+test("'does not exist' still reads as absence when it names the method", () => {
+  assert.equal(
+    classify(rpcErr(-32000, "the method trace_block does not exist")),
+    "method-not-found",
+  );
 });
 
 test("tier gates, by status and by message", () => {
@@ -137,6 +196,35 @@ test("rate limits are not mistaken for refusals", () => {
   assert.equal(classify({ httpStatus: 429 }), "rate-limited");
   assert.equal(classify(rpcErr(-32005, "limit exceeded")), "rate-limited");
   assert.equal(classify(rpcErr(-32000, "too many requests")), "rate-limited");
+});
+
+test("a throttle worded as a tier gate is a throttle", () => {
+  // drpc and ankr free tiers throttle in exactly the tier vocabulary. The tier
+  // test used to run first, so a transient throttle was written into the
+  // report's most decision-relevant column as "traces are purchasable here",
+  // with no retry and nothing to tell it apart from a real gate. A full run is
+  // roughly four requests per endpoint across 39 hosts, so meeting one is
+  // routine, not exotic.
+  for (const msg of [
+    "rate limit exceeded for your plan, upgrade for more requests",
+    "You have exceeded the free tier rate-limit. Upgrade your plan.",
+    "monthly quota exceeded - upgrade required",
+    "request throttled; upgrade your api key tier",
+  ]) {
+    assert.equal(classify(rpcErr(-32000, msg)), "rate-limited", msg);
+  }
+});
+
+test("a tier gate with no throttle wording is still a tier gate", () => {
+  // The other direction of the same ordering, so hoisting the rate-limit test
+  // cannot quietly swallow real paywalls.
+  for (const msg of [
+    "This method requires a paid plan",
+    "Archive requests require a personal token",
+    "upgrade to access trace methods",
+  ]) {
+    assert.equal(classify(rpcErr(-32000, msg)), "tier-gated", msg);
+  }
 });
 
 test("transport failures keep timeout separate from everything else", () => {


### PR DESCRIPTION
## Issue

Refs #2247. **Not a competing survey** — #2273 is the survey, and I am not
duplicating it. This is only the probe that keeps its table checkable.

## How this happened

@tenk-earn and I picked up #2247 within five minutes of each other and, without
knowing it, probed overlapping windows the same morning. Their survey landed
first and it is the better document on the axis I explicitly punted: the
commercial provider tier matrix (Alchemy / Infura / QuickNode / Ankr / dRPC with
actual CU and credit costs) is exactly what scope item 2 asked for, and I had
deferred it to a maintainer. Their Aetherlay check is also more thorough than
mine — they ran a recursive tree scan where I checked two paths.

So rather than file a second table, this PR is the part that does not overlap.
If you would rather fold it into #2273, or not take it at all, say so and I will
close it — the survey question is answered either way.

## Why a tool rather than a second table

Our two independent runs agree on the headline (plasma and tempo serve traces,
the established EVM mainnets do not) and disagree on one number in a way that is
worth keeping:

| plasma-mainnet, 5-tx block | `debug_traceBlockByNumber` | `trace_block` | `ots_getBlockTransactions` |
|---|---|---|---|
| #2273 | 63 KiB | 101 KiB | 7.5 KiB |
| this probe | 348 KB | 562 KB | 7.5 KB |

The `ots_` figures match almost exactly, and that is the tell. `ots_` scales with
transaction **count**; trace size scales with a block's internal **call depth**,
which varies several-fold between blocks holding the same number of
transactions.

Neither measurement is wrong. The conclusion is that **a single sampled block
under-determines the cost envelope** #2241 is trying to estimate — which is
precisely the number that decides whether full-block tracing is affordable.
Re-running is the cheap way to bound it, and that needs a tool.

## What it does

Parses the chain list out of `lib/rpc/rpc-config.ts` at run time instead of
hand-copying it, then probes `debug_traceBlockByNumber`, `trace_block` and
`ots_getBlockTransactions` against **both** the `publicDefault` and the
`publicFallback` of every entry — 41 endpoints, 102 probes — recording the
verbatim response body, raw and gzipped size, fetch and parse time.

```bash
node scripts/trace-method-probe.mjs --dry-run    # resolve targets, no requests
node scripts/trace-method-probe.mjs --mainnets   # EVM mainnets only
node scripts/trace-method-probe.mjs              # everything (~4 min)
node --test scripts/trace-method-probe.test.mjs  # 23 tests
```

Probing fallbacks systematically turned up cases the primary alone would miss:
`op-sepolia`, `0g-mainnet` and `robinhood-testnet` each answered a trace method
on their **fallback** while refusing it on their primary.

## Classification is the load-bearing part

HTTP status alone decides nothing — two endpoints return **HTTP 403** meaning
opposite things:

| Endpoint | Body | Verdict |
|---|---|---|
| `mainnet.base.org` | `-32601 "rpc method is unsupported"` | absent; no plan lifts it |
| `ethereum-rpc.publicnode.com` | `-32602 "Archive requests require a personal token"` | purchasable |

So a structured JSON-RPC error outranks the HTTP status, and within the body a
tier signal outranks absent-method wording. Reading *"not available on the free
plan"* as "never implemented" would tell #2241 a chain cannot trace when it can
be paid for — the costliest mistake available here. Every shape above was
observed live and is pinned as a regression test.

Four classifier defects were found this way, by live responses contradicting the
code, and fixed before this PR: status read before body, `-32600 "not allowed"`
falling through unclassified, a non-JSON 401 policy refusal reported as
malformed, and empty blocks measured as though they were trace sizes.

## Placement and cost to you

`scripts/` is excluded by `biome.jsonc`, and `tsconfig.json` includes
`.ts`/`.tsx`/`.mts` but not `.mjs` — so this adds nothing to either gate. No
dependencies, no app or database access, no credentials, no runtime code path
touched.

Tests run against the repository's own `lib/rpc/rpc-config.ts` rather than a
vendored snapshot, so config drift fails the test instead of quietly skewing a
future run. That matters here: `CHAIN_CONFIG` has 24 entries today, while #2239
says "22 entries / 11 mainnets" and #2240 says "10 EVM mainnets" — it has
already drifted once.

Politeness, since these are free third-party endpoints: strictly sequential,
750 ms between every request, one block sampled per endpoint, and a single retry
reserved for failures that describe themselves as transient.

## How it was verified

- `node --test scripts/trace-method-probe.test.mjs` — **23 passed**, against the
  repo's own config
- Full sweep: 24 chains, 41 endpoints, 102 probes, ~4 minutes

**I have not run `pnpm check` or `pnpm type-check`.** This repo needs Node 24+,
Postgres 16+ and Docker per `CONTRIBUTING.md`, which I have not set up. Both
files sit outside those gates by construction as described above, but I would
rather say so than tick two boxes I did not verify.

I have the full `results.json` (verbatim body for all 102 probes) and the
fallback-coverage rows if either is useful to #2273 — happy to post them there
instead.
