### PR TITLE
docs: add ID glossary and cross-link headless onboarding with the verified-transaction guide

### DIFF
--- a/docs/api/headless-onboarding.md
+++ b/docs/api/headless-onboarding.md
@@ -252,6 +252,25 @@ simulate with the same body you intend to send, then send it once with an
 `Idempotency-Key` so an interrupted client can retry without double-executing,
 then poll `GET /api/execute/{executionId}/status`.
 
+### The IDs in this flow
+
+The responses you read in this section use four different identifiers. They
+are not interchangeable:
+
+| Term | Where it comes from | What it identifies |
+|---|---|---|
+| Workflow ID | `POST /api/workflows/create` or `GET /api/workflows` | The workflow definition itself — its nodes and edges. Stable across every run of that workflow. |
+| Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route), or `POST /api/workflows/{workflowId}/execute` | One attempt to run something. `exec_…` when the run is a workflow; the direct-execution routes return an opaque id. Polled via `GET /api/execute/{executionId}/status`. |
+| `transactionHash` | The status response once a broadcast lands | The onchain transaction. One execution can contain several (approve + action), and an execution that never broadcasts has none. |
+| `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` — a convenience, not a separate identifier. |
+
+The rule that keeps them straight: an execution is **one attempt**, a workflow
+is **the definition**, and a transaction is **what actually landed onchain**.
+A `202 Accepted` means KeeperHub queued an execution — it does not mean a
+transaction exists yet. See
+[Zero to a Verified Onchain Transaction](/guides/first-verified-transaction)
+for the full walkthrough of confirming the transaction actually landed.
+
 ## 6. Your first transaction should move zero
 
 A brand-new organization wallet holds nothing, so a first run with a non-zero

--- a/docs/api/headless-onboarding.md
+++ b/docs/api/headless-onboarding.md
@@ -260,14 +260,14 @@ are not interchangeable:
 | Term | Where it comes from | What it identifies |
 |---|---|---|
 | Workflow ID | `POST /api/workflows/create` or `GET /api/workflows` | The workflow definition itself — its nodes and edges. Stable across every run of that workflow. |
-| Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route), or `POST /api/workflows/{workflowId}/execute` | One attempt to run something. `exec_…` when the run is a workflow; the direct-execution routes return an opaque id. Polled via `GET /api/execute/{executionId}/status`. |
+| Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route), or `POST /api/workflows/{workflowId}/execute` | One attempt to run something. Both the workflow route and the direct-execution routes return the same kind of value: an opaque 21-character nanoid with no distinguishing prefix. Polled via `GET /api/execute/{executionId}/status`. |
 | `transactionHash` | The status response once a broadcast lands | The onchain transaction. One execution can contain several (approve + action), and an execution that never broadcasts has none. |
 | `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` — a convenience, not a separate identifier. |
 
 The rule that keeps them straight: an execution is **one attempt**, a workflow
 is **the definition**, and a transaction is **what actually landed onchain**.
-A `202 Accepted` means KeeperHub queued an execution — it does not mean a
-transaction exists yet. See
+A queued execution (one the server has accepted and is yet to run) does not
+mean a transaction exists yet. See
 [Zero to a Verified Onchain Transaction](/guides/first-verified-transaction)
 for the full walkthrough of confirming the transaction actually landed.
 

--- a/docs/api/headless-onboarding.md
+++ b/docs/api/headless-onboarding.md
@@ -254,12 +254,12 @@ then poll `GET /api/execute/{executionId}/status`.
 
 ### The IDs in the direct-execution flow
 
-The responses in this section use three identifiers. They are not interchangeable:
+The identifiers in this flow are not interchangeable:
 
 | Term | Where it comes from | What it identifies |
 |---|---|---|
 | Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route) | One attempt to run something: an opaque 21-character nanoid with no distinguishing prefix. Polled via `GET /api/execute/{executionId}/status`. |
-| `transactionHash` | The status response once a broadcast lands | The onchain transaction this execution sent. A direct execution that broadcasts has one primary hash (in `transactionHash`); a multi-step execution records each step under `receipts`. An execution that never broadcasts has neither. |
+| `transactionHash` | The status response once a broadcast lands | The onchain transaction this execution sent. A direct execution that broadcasts has exactly one: the status response carries it in `transactionHash`, and `receipts` holds its verification result (status, block, gas) once the chain has answered. An execution that never broadcasts leaves `receipts` as an empty array. |
 | `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` - a convenience, not a separate identifier. |
 
 The rule that keeps them straight: an execution is **one attempt**, and a
@@ -268,9 +268,10 @@ server has accepted and is yet to run) does not mean a transaction exists yet.
 See [Zero to a Verified Onchain Transaction](/guides/first-verified-transaction)
 for the full walkthrough of confirming the transaction actually landed.
 
-(Workflow executions are a separate surface: they have their own id source and
-poll `/api/workflows/executions/{executionId}/status` rather than the
-direct-execution route above.)
+(Workflow executions are a separate surface: their ids come from the same
+`generateId()` and are indistinguishable by shape from a direct-execution id -
+what differs is the poll route, `/api/workflows/executions/{executionId}/status`
+rather than the direct-execution route above.)
 
 ## 6. Your first transaction should move zero
 

--- a/docs/api/headless-onboarding.md
+++ b/docs/api/headless-onboarding.md
@@ -252,24 +252,25 @@ simulate with the same body you intend to send, then send it once with an
 `Idempotency-Key` so an interrupted client can retry without double-executing,
 then poll `GET /api/execute/{executionId}/status`.
 
-### The IDs in this flow
+### The IDs in the direct-execution flow
 
-The responses you read in this section use four different identifiers. They
-are not interchangeable:
+The responses in this section use three identifiers. They are not interchangeable:
 
 | Term | Where it comes from | What it identifies |
 |---|---|---|
-| Workflow ID | `POST /api/workflows/create` or `GET /api/workflows` | The workflow definition itself — its nodes and edges. Stable across every run of that workflow. |
-| Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route), or `POST /api/workflows/{workflowId}/execute` | One attempt to run something. Both the workflow route and the direct-execution routes return the same kind of value: an opaque 21-character nanoid with no distinguishing prefix. Polled via `GET /api/execute/{executionId}/status`. |
-| `transactionHash` | The status response once a broadcast lands | The onchain transaction. One execution can contain several (approve + action), and an execution that never broadcasts has none. |
-| `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` — a convenience, not a separate identifier. |
+| Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route) | One attempt to run something: an opaque 21-character nanoid with no distinguishing prefix. Polled via `GET /api/execute/{executionId}/status`. |
+| `transactionHash` | The status response once a broadcast lands | The onchain transaction this execution sent. A direct execution that broadcasts has one primary hash (in `transactionHash`); a multi-step execution records each step under `receipts`. An execution that never broadcasts has neither. |
+| `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` - a convenience, not a separate identifier. |
 
-The rule that keeps them straight: an execution is **one attempt**, a workflow
-is **the definition**, and a transaction is **what actually landed onchain**.
-A queued execution (one the server has accepted and is yet to run) does not
-mean a transaction exists yet. See
-[Zero to a Verified Onchain Transaction](/guides/first-verified-transaction)
+The rule that keeps them straight: an execution is **one attempt**, and a
+transaction is **what actually landed onchain**. A queued execution (one the
+server has accepted and is yet to run) does not mean a transaction exists yet.
+See [Zero to a Verified Onchain Transaction](/guides/first-verified-transaction)
 for the full walkthrough of confirming the transaction actually landed.
+
+(Workflow executions are a separate surface: they have their own id source and
+poll `/api/workflows/executions/{executionId}/status` rather than the
+direct-execution route above.)
 
 ## 6. Your first transaction should move zero
 

--- a/docs/api/headless-onboarding.md
+++ b/docs/api/headless-onboarding.md
@@ -259,7 +259,7 @@ The identifiers in this flow are not interchangeable:
 | Term | Where it comes from | What it identifies |
 |---|---|---|
 | Execution ID (`executionId`) | `POST /api/execute/transfer` (or any direct-execution route) | One attempt to run something: an opaque 21-character nanoid with no distinguishing prefix. Polled via `GET /api/execute/{executionId}/status`. |
-| `transactionHash` | The status response once a broadcast lands | The onchain transaction this execution sent. A direct execution that broadcasts has exactly one: the status response carries it in `transactionHash`, and `receipts` holds its verification result (status, block, gas) once the chain has answered. An execution that never broadcasts leaves `receipts` as an empty array. |
+| `transactionHash` | The status response once it is broadcast | The onchain transaction this execution sent. A direct execution that broadcasts has exactly one: the status response carries it in `transactionHash`, and `receipts` holds its verification result (status, block, gas) as of settle time - the chain may not have answered yet, in which case the entry records `timeout` or `not_found` and the execution stays non-terminal. An execution that never broadcasts leaves `receipts` as an empty array. |
 | `transactionLink` | The same status response | A block-explorer URL for that `transactionHash` - a convenience, not a separate identifier. |
 
 The rule that keeps them straight: an execution is **one attempt**, and a

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -147,7 +147,11 @@ Change nothing else between the dry run and the broadcast, so the transaction yo
 inspected is the transaction you send. The key must name the *work*, not the attempt, so
 a retry reuses it: see [Choosing a stable key](/api/direct-execution#choosing-a-stable-key).
 
-Save the returned `executionId`.
+Save the returned `executionId`. If the terms in this flow are not yet
+familiar — what an execution is versus the workflow that defined it versus the
+transaction that lands onchain — the
+[Headless and Agent Onboarding](/api/headless-onboarding#the-ids-in-this-flow)
+glossary defines all four identifiers in one table.
 
 ## 8. Verify
 

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -148,10 +148,10 @@ inspected is the transaction you send. The key must name the *work*, not the att
 a retry reuses it: see [Choosing a stable key](/api/direct-execution#choosing-a-stable-key).
 
 Save the returned `executionId`. If the terms in this flow are not yet
-familiar — what an execution is versus the workflow that defined it versus the
-transaction that lands onchain — the
-[Headless and Agent Onboarding](/api/headless-onboarding#the-ids-in-this-flow)
-glossary defines all four identifiers in one table.
+familiar — what an execution is versus the transaction that lands onchain —
+the
+[Headless and Agent Onboarding](/api/headless-onboarding#the-ids-in-the-direct-execution-flow)
+glossary defines them in one table.
 
 ## 8. Verify
 


### PR DESCRIPTION
Fixes #2062 (accepted, maintainer-narrowed scope).

## What
Per suisuss accepted comment on #2062 ("Scoped to the glossary and the cross-links, this is accepted work"):
- Adds a single ID glossary table (workflow ID, execution ID, transactionHash, transactionLink) to the headless onboarding guide, where a headless reader first meets executionId/transactionHash.
- Cross-links the two onboarding docs to each other: headless-onboarding now points to the verified-transaction guide; the verified-transaction guide now points to the glossary anchor.

The architecture diagram is deliberately not added (maintainer said it drifts from the table).

## Test
Docs-only change. Markdown table well-formed; heading anchor unique; both /api/ and /guides/ link targets resolve to existing files.