### PR TITLE
feat: #2309 add EVM Chain integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ All trigger services (schedule dispatcher, block dispatcher, event tracker) send
 Plugins extend workflow capabilities. Located in `keeperhub/plugins/`:
 
 - `web3` - Blockchain operations (balance, transfers, contract calls)
+- `evm-chain` - Read-only EVM chain diagnostics via any public JSON-RPC endpoint (no credentials)
 - `discord` - Discord notifications
 - `sendgrid` - Email via SendGrid
 - `webhook` - HTTP integrations

--- a/lib/types/integration.ts
+++ b/lib/types/integration.ts
@@ -9,7 +9,7 @@
  * 2. Add a system integration to SYSTEM_INTEGRATION_TYPES in discover-plugins.ts
  * 3. Run: pnpm discover-plugins
  *
- * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, blockscout, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, frax-ether-v2, hyperliquid, lido, linear, math, morpho, pendle, protocol, resend, robinhood, rocket-pool, safe, sendgrid, sky, slack, spark, superfluid, telegram, tempo, uniswap, v0, web3, webflow, webhook, wrapped, yearn
+ * Generated types: aave-v3, aave-v4, aerodrome, ai-gateway, ajna, blockscout, chainlink, chronicle, clerk, code, compound, cowswap, curve, database, discord, ethena, evm-chain, frax-ether-v2, hyperliquid, lido, linear, math, morpho, pendle, protocol, resend, robinhood, rocket-pool, safe, sendgrid, sky, slack, spark, superfluid, telegram, tempo, uniswap, v0, web3, webflow, webhook, wrapped, yearn
  */
 
 // Integration type union - plugins + system integrations
@@ -30,6 +30,7 @@ export type IntegrationType =
   | "database"
   | "discord"
   | "ethena"
+  | "evm-chain"
   | "frax-ether-v2"
   | "hyperliquid"
   | "lido"

--- a/plugins/evm-chain/credentials.ts
+++ b/plugins/evm-chain/credentials.ts
@@ -1,0 +1,4 @@
+export type EvmChainCredentials = {
+  EVM_CHAIN_RPC_URL?: string;
+  EVM_CHAIN_NAME?: string;
+};

--- a/plugins/evm-chain/icon.tsx
+++ b/plugins/evm-chain/icon.tsx
@@ -1,0 +1,14 @@
+export function EvmChainIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-label="EVM Chain logo"
+      className={className}
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>EVM Chain</title>
+      <path d="M12 2 3 7v10l9 5 9-5V7l-9-5zm0 2.3L18.8 8 12 11.7 5.2 8 12 4.3zM5 9.7l6 3.3v6.7l-6-3.3V9.7zm14 0v6.7l-6 3.3v-6.7l6-3.3z" />
+    </svg>
+  );
+}

--- a/plugins/evm-chain/index.ts
+++ b/plugins/evm-chain/index.ts
@@ -1,0 +1,142 @@
+import type { IntegrationPlugin } from "@/plugins/registry";
+import { registerIntegration } from "@/plugins/registry-core";
+import { EvmChainIcon } from "./icon";
+
+const evmChainPlugin: IntegrationPlugin = {
+  type: "evm-chain",
+  // This plugin fetches a user-supplied JSON-RPC endpoint.
+  egress: "user-destination",
+  label: "EVM Chain",
+  description:
+    "Read-only EVM chain diagnostics: chain id, latest block, native and ERC-20 balances, and gas price on any EVM-compatible chain via a public JSON-RPC URL. No wallet or credentials required - complementary to the Web3 plugin (zero-credential preview/diagnostic queries against any public endpoint).",
+
+  icon: EvmChainIcon,
+
+  formFields: [
+    {
+      id: "rpcUrl",
+      label: "JSON-RPC URL",
+      type: "url",
+      placeholder: "https://sepolia.base.org",
+      configKey: "EVM_CHAIN_RPC_URL",
+      envVar: "EVM_CHAIN_RPC_URL",
+      helpText: "Any EVM JSON-RPC endpoint (Alchemy, Infura, CDP, public gateway...).",
+      helpLink: {
+        text: "Base docs - Network RPC endpoints",
+        url: "https://docs.base.org/guides/rpc-endpoints/",
+      },
+    },
+    {
+      id: "chainName",
+      label: "Chain name (display only)",
+      type: "text",
+      placeholder: "Base Sepolia",
+      configKey: "EVM_CHAIN_NAME",
+      envVar: "EVM_CHAIN_NAME",
+      helpText: "Optional human-readable label shown in the UI.",
+    },
+  ],
+
+  testConfig: {
+    getTestFunction: async () => {
+      const { testEvmChain } = await import("./test");
+      return testEvmChain;
+    },
+  },
+
+  actions: [
+    {
+      slug: "chain-info",
+      label: "Chain info",
+      description: "Return the chain id (hex + decimal) and the latest block number.",
+      category: "EVM Chain",
+      stepFunction: "chainInfoStep",
+      stepImportPath: "chain-info",
+      configFields: [],
+      outputFields: [
+        { field: "success", description: "Whether the query succeeded" },
+        { field: "chainId", description: "Chain id as hex string" },
+        { field: "chainIdDecimal", description: "Chain id as decimal number" },
+        { field: "latestBlock", description: "Latest mined block number" },
+        { field: "error", description: "Error message if failed" },
+      ],
+    },
+    {
+      slug: "eth-balance",
+      label: "Native token balance",
+      description: "Return the native token balance of an address in wei and native units.",
+      category: "EVM Chain",
+      stepFunction: "ethBalanceStep",
+      stepImportPath: "eth-balance",
+      configFields: [
+        {
+          key: "address",
+          label: "Address",
+          type: "template-input",
+          placeholder: "0x... or use {{NodeName.field}}",
+          example: "0x2f13...8d15",
+          required: true,
+        },
+      ],
+      outputFields: [
+        { field: "success", description: "Whether the query succeeded" },
+        { field: "address", description: "Queried address" },
+        { field: "balanceWei", description: "Balance in wei" },
+        { field: "balanceNative", description: "Balance in native units (18 decimals)" },
+        { field: "error", description: "Error message if failed" },
+      ],
+    },
+    {
+      slug: "erc20-balance",
+      label: "ERC-20 balance",
+      description: "Return the balance of an ERC-20 token held by an address.",
+      category: "EVM Chain",
+      stepFunction: "erc20BalanceStep",
+      stepImportPath: "erc20-balance",
+      configFields: [
+        {
+          key: "token",
+          label: "Token address",
+          type: "template-input",
+          placeholder: "0x...",
+          example: "0x036C...CF7e",
+          required: true,
+        },
+        {
+          key: "holder",
+          label: "Holder address",
+          type: "template-input",
+          placeholder: "0x... or use {{NodeName.field}}",
+          example: "0x2f13...8d15",
+          required: true,
+        },
+      ],
+      outputFields: [
+        { field: "success", description: "Whether the query succeeded" },
+        { field: "token", description: "Token address" },
+        { field: "holder", description: "Holder address" },
+        { field: "balance", description: "Raw token balance (string, token decimals)" },
+        { field: "error", description: "Error message if failed" },
+      ],
+    },
+    {
+      slug: "gas-price",
+      label: "Gas price",
+      description: "Return the suggested gas price in wei.",
+      category: "EVM Chain",
+      stepFunction: "gasPriceStep",
+      stepImportPath: "gas-price",
+      configFields: [],
+      outputFields: [
+        { field: "success", description: "Whether the query succeeded" },
+        { field: "gasPriceWei", description: "Suggested gas price in wei" },
+        { field: "error", description: "Error message if failed" },
+      ],
+    },
+  ],
+};
+
+// Auto-register on import
+registerIntegration(evmChainPlugin);
+
+export default evmChainPlugin;

--- a/plugins/evm-chain/index.ts
+++ b/plugins/evm-chain/index.ts
@@ -20,7 +20,8 @@ const evmChainPlugin: IntegrationPlugin = {
       placeholder: "https://sepolia.base.org",
       configKey: "EVM_CHAIN_RPC_URL",
       envVar: "EVM_CHAIN_RPC_URL",
-      helpText: "Any EVM JSON-RPC endpoint (Alchemy, Infura, CDP, public gateway...).",
+      helpText:
+        "Any EVM JSON-RPC endpoint (Alchemy, Infura, CDP, public gateway...). Providers that authenticate through the URL embed the API key in the endpoint path, so treat this field as a secret.",
       helpLink: {
         text: "Base docs - Network RPC endpoints",
         url: "https://docs.base.org/guides/rpc-endpoints/",

--- a/plugins/evm-chain/steps/chain-info.ts
+++ b/plugins/evm-chain/steps/chain-info.ts
@@ -1,0 +1,66 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import type { EvmChainCredentials } from "../credentials";
+
+type ChainInfoResult =
+  | { success: true; chainId: string; chainIdDecimal: number; latestBlock: number }
+  | { success: false; error: string };
+
+export type ChainInfoInput = StepInput & { integrationId?: string };
+
+/** Core chain-info logic - receives credentials as parameter. */
+async function stepHandler(
+  credentials: EvmChainCredentials
+): Promise<ChainInfoResult> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return {
+      success: false,
+      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+    };
+  }
+  const rpc = async (id: number, method: string): Promise<unknown> => {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params: [] }),
+    });
+    if (!response.ok) throw new Error(`RPC endpoint returned HTTP ${response.status}`);
+    return response.json();
+  };
+  try {
+    const [idRes, blockRes] = await Promise.all([rpc(1, "eth_chainId"), rpc(2, "eth_blockNumber")]);
+    const chainId = (idRes as { result?: unknown })?.result;
+    if (typeof chainId !== "string" || !/^0x[0-9a-f]+$/i.test(chainId)) {
+      return { success: false, error: `Unexpected chain id response: ${JSON.stringify(idRes)}` };
+    }
+    const latestBlock = Number.parseInt(String((blockRes as { result?: unknown })?.result), 16);
+    if (!Number.isFinite(latestBlock)) {
+      return { success: false, error: `Unexpected block response: ${JSON.stringify(blockRes)}` };
+    }
+    return {
+      success: true,
+      chainId,
+      chainIdDecimal: Number.parseInt(chainId, 16),
+      latestBlock,
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function chainInfoStep(input: ChainInfoInput): Promise<ChainInfoResult> {
+  "use step";
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    : {};
+  return runPluginStep(
+    { pluginName: "evm-chain", actionName: "chain-info" },
+    input,
+    () => stepHandler(credentials)
+  );
+}
+
+export const _integrationType = "evm-chain";

--- a/plugins/evm-chain/steps/chain-info.ts
+++ b/plugins/evm-chain/steps/chain-info.ts
@@ -1,60 +1,79 @@
 import "server-only";
 
 import { fetchCredentials } from "@/lib/credential-fetcher";
-import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
 import type { EvmChainCredentials } from "../credentials";
+import { callEvmRpc, isHexResult } from "./evm-rpc-core";
 
 type ChainInfoResult =
-  | { success: true; chainId: string; chainIdDecimal: number; latestBlock: number }
+  | {
+      success: true;
+      chainId: string;
+      chainIdDecimal: number;
+      latestBlock: number;
+    }
   | { success: false; error: string };
 
 export type ChainInfoInput = StepInput & { integrationId?: string };
 
-/** Core chain-info logic - receives credentials as parameter. */
 async function stepHandler(
   credentials: EvmChainCredentials
 ): Promise<ChainInfoResult> {
-  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
-  if (!rpcUrl) {
+  const [idRes, blockRes] = await Promise.all([
+    callEvmRpc(credentials, "eth_chainId", [], 1),
+    callEvmRpc(credentials, "eth_blockNumber", [], 2),
+  ]);
+
+  if (!idRes.success) {
+    return { success: false, error: idRes.error };
+  }
+  if (!blockRes.success) {
+    return { success: false, error: blockRes.error };
+  }
+
+  const chainId = idRes.result;
+  if (!isHexResult(chainId)) {
     return {
       success: false,
-      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+      error: `Unexpected chain id response: ${JSON.stringify(chainId)}`,
     };
   }
-  const rpc = async (id: number, method: string): Promise<unknown> => {
-    const response = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id, method, params: [] }),
-    });
-    if (!response.ok) throw new Error(`RPC endpoint returned HTTP ${response.status}`);
-    return response.json();
-  };
-  try {
-    const [idRes, blockRes] = await Promise.all([rpc(1, "eth_chainId"), rpc(2, "eth_blockNumber")]);
-    const chainId = (idRes as { result?: unknown })?.result;
-    if (typeof chainId !== "string" || !/^0x[0-9a-f]+$/i.test(chainId)) {
-      return { success: false, error: `Unexpected chain id response: ${JSON.stringify(idRes)}` };
-    }
-    const latestBlock = Number.parseInt(String((blockRes as { result?: unknown })?.result), 16);
-    if (!Number.isFinite(latestBlock)) {
-      return { success: false, error: `Unexpected block response: ${JSON.stringify(blockRes)}` };
-    }
+
+  const blockNumber = blockRes.result;
+  if (!isHexResult(blockNumber)) {
     return {
-      success: true,
-      chainId,
-      chainIdDecimal: Number.parseInt(chainId, 16),
-      latestBlock,
+      success: false,
+      error: `Unexpected block response: ${JSON.stringify(blockNumber)}`,
     };
-  } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
+
+  const latestBlock = Number.parseInt(blockNumber, 16);
+  if (!Number.isFinite(latestBlock)) {
+    return {
+      success: false,
+      error: `Unexpected block response: ${JSON.stringify(blockNumber)}`,
+    };
+  }
+
+  return {
+    success: true,
+    chainId,
+    chainIdDecimal: Number.parseInt(chainId, 16),
+    latestBlock,
+  };
 }
 
-export async function chainInfoStep(input: ChainInfoInput): Promise<ChainInfoResult> {
+export async function chainInfoStep(
+  input: ChainInfoInput
+): Promise<ChainInfoResult> {
   "use step";
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
   return runPluginStep(
     { pluginName: "evm-chain", actionName: "chain-info" },

--- a/plugins/evm-chain/steps/erc20-balance.ts
+++ b/plugins/evm-chain/steps/erc20-balance.ts
@@ -1,11 +1,24 @@
 import "server-only";
 
 import { fetchCredentials } from "@/lib/credential-fetcher";
-import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
 import type { EvmChainCredentials } from "../credentials";
+import { callEvmRpc, isHexResult } from "./evm-rpc-core";
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const HEX_PREFIX_RE = /^0x/;
+const BALANCE_OF_SELECTOR = "0x70a08231";
 
 type Erc20BalanceResult =
-  | { success: true; token: string; holder: string; balance: string }
+  | {
+      success: true;
+      token: string;
+      holder: string;
+      balance: string;
+    }
   | { success: false; error: string };
 
 export type Erc20BalanceCoreInput = { token: string; holder: string };
@@ -15,69 +28,63 @@ export type Erc20BalanceInput = StepInput &
     integrationId?: string;
   };
 
-const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
-
 async function stepHandler(
   input: Erc20BalanceCoreInput,
   credentials: EvmChainCredentials
 ): Promise<Erc20BalanceResult> {
-  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
-  if (!rpcUrl) {
+  if (!ADDRESS_RE.test(input.token)) {
     return {
       success: false,
-      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+      error: "token must be a 20-byte hex address (0x... 40 hex chars)",
     };
-  }
-  if (!ADDRESS_RE.test(input.token)) {
-    return { success: false, error: "token must be a 20-byte hex address (0x... 40 hex chars)" };
   }
   if (!ADDRESS_RE.test(input.holder)) {
-    return { success: false, error: "holder must be a 20-byte hex address (0x... 40 hex chars)" };
-  }
-  try {
-    const response = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "eth_call",
-        params: [
-          {
-            to: input.token,
-            data: "0x70a08231" + input.holder.toLowerCase().replace(/^0x/, "").padStart(64, "0"),
-          },
-          "latest",
-        ],
-      }),
-    });
-    if (!response.ok) {
-      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
-    }
-    const payload = await response.json();
-    const data = payload?.result;
-    if (typeof data !== "string" || !/^0x[0-9a-fA-F]+$/i.test(data) || data.length < 66) {
-      return { success: false, error: `Unexpected balanceOf response: ${JSON.stringify(payload)}` };
-    }
     return {
-      success: true,
-      token: input.token,
-      holder: input.holder,
-      balance: BigInt(data).toString(),
+      success: false,
+      error: "holder must be a 20-byte hex address (0x... 40 hex chars)",
     };
-  } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
+
+  const data =
+    BALANCE_OF_SELECTOR +
+    input.holder.toLowerCase().replace(HEX_PREFIX_RE, "").padStart(64, "0");
+
+  const res = await callEvmRpc(credentials, "eth_call", [
+    { to: input.token, data },
+    "latest",
+  ]);
+  if (!res.success) {
+    return { success: false, error: res.error };
+  }
+
+  const raw = res.result;
+  if (!isHexResult(raw) || raw.length < 66) {
+    return {
+      success: false,
+      error: `Unexpected balanceOf response: ${JSON.stringify(raw)}`,
+    };
+  }
+
+  return {
+    success: true,
+    token: input.token,
+    holder: input.holder,
+    balance: BigInt(raw).toString(),
+  };
 }
 
 /**
  * App entry point - fetches credentials and wraps with logging
  */
-export async function erc20BalanceStep(input: Erc20BalanceInput): Promise<Erc20BalanceResult> {
+export async function erc20BalanceStep(
+  input: Erc20BalanceInput
+): Promise<Erc20BalanceResult> {
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
 
   return runPluginStep(

--- a/plugins/evm-chain/steps/erc20-balance.ts
+++ b/plugins/evm-chain/steps/erc20-balance.ts
@@ -1,0 +1,90 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import type { EvmChainCredentials } from "../credentials";
+
+type Erc20BalanceResult =
+  | { success: true; token: string; holder: string; balance: string }
+  | { success: false; error: string };
+
+export type Erc20BalanceCoreInput = { token: string; holder: string };
+
+export type Erc20BalanceInput = StepInput &
+  Erc20BalanceCoreInput & {
+    integrationId?: string;
+  };
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+async function stepHandler(
+  input: Erc20BalanceCoreInput,
+  credentials: EvmChainCredentials
+): Promise<Erc20BalanceResult> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return {
+      success: false,
+      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+    };
+  }
+  if (!ADDRESS_RE.test(input.token)) {
+    return { success: false, error: "token must be a 20-byte hex address (0x... 40 hex chars)" };
+  }
+  if (!ADDRESS_RE.test(input.holder)) {
+    return { success: false, error: "holder must be a 20-byte hex address (0x... 40 hex chars)" };
+  }
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_call",
+        params: [
+          {
+            to: input.token,
+            data: "0x70a08231" + input.holder.toLowerCase().replace(/^0x/, "").padStart(64, "0"),
+          },
+          "latest",
+        ],
+      }),
+    });
+    if (!response.ok) {
+      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
+    }
+    const payload = await response.json();
+    const data = payload?.result;
+    if (typeof data !== "string" || !/^0x[0-9a-fA-F]+$/i.test(data) || data.length < 66) {
+      return { success: false, error: `Unexpected balanceOf response: ${JSON.stringify(payload)}` };
+    }
+    return {
+      success: true,
+      token: input.token,
+      holder: input.holder,
+      balance: BigInt(data).toString(),
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * App entry point - fetches credentials and wraps with logging
+ */
+export async function erc20BalanceStep(input: Erc20BalanceInput): Promise<Erc20BalanceResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    : {};
+
+  return runPluginStep(
+    { pluginName: "evm-chain", actionName: "erc20-balance" },
+    input,
+    () => stepHandler(input, credentials)
+  );
+}
+
+export const _integrationType = "evm-chain";

--- a/plugins/evm-chain/steps/eth-balance.ts
+++ b/plugins/evm-chain/steps/eth-balance.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import type { EvmChainCredentials } from "../credentials";
+
+type EthBalanceResult =
+  | { success: true; address: string; balanceWei: string; balanceNative: string }
+  | { success: false; error: string };
+
+export type EthBalanceCoreInput = { address: string };
+
+export type EthBalanceInput = StepInput &
+  EthBalanceCoreInput & {
+    integrationId?: string;
+  };
+
+function toNative(hexWei: string): string {
+  const wei = BigInt(hexWei);
+  const units = wei / BigInt(10) ** BigInt(18);
+  const frac = wei % BigInt(10) ** BigInt(18);
+  const fracStr = frac.toString().padStart(18, "0").replace(/0+$/, "");
+  return fracStr ? `${units.toString()}. ${fracStr}`.replace(" .", ".") : units.toString();
+}
+
+async function stepHandler(
+  input: EthBalanceCoreInput,
+  credentials: EvmChainCredentials
+): Promise<EthBalanceResult> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return {
+      success: false,
+      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+    };
+  }
+  if (!/^0x[0-9a-fA-F]{40}$/.test(input.address)) {
+    return { success: false, error: "address must be a 20-byte hex address (0x... 40 hex chars)" };
+  }
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_getBalance",
+        params: [input.address, "latest"],
+      }),
+    });
+    if (!response.ok) {
+      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
+    }
+    const payload = await response.json();
+    const balanceWei = payload?.result;
+    if (typeof balanceWei !== "string" || !/^0x[0-9a-fA-F]+$/.test(balanceWei)) {
+      return { success: false, error: `Unexpected balance response: ${JSON.stringify(payload)}` };
+    }
+    return {
+      success: true,
+      address: input.address,
+      balanceWei,
+      balanceNative: toNative(balanceWei),
+    };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * App entry point - fetches credentials and wraps with logging
+ */
+export async function ethBalanceStep(input: EthBalanceInput): Promise<EthBalanceResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    : {};
+
+  return runPluginStep(
+    { pluginName: "evm-chain", actionName: "eth-balance" },
+    input,
+    () => stepHandler(input, credentials)
+  );
+}
+
+export const _integrationType = "evm-chain";

--- a/plugins/evm-chain/steps/eth-balance.ts
+++ b/plugins/evm-chain/steps/eth-balance.ts
@@ -1,11 +1,22 @@
 import "server-only";
 
 import { fetchCredentials } from "@/lib/credential-fetcher";
-import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
 import type { EvmChainCredentials } from "../credentials";
+import { callEvmRpc, isHexResult, toNative } from "./evm-rpc-core";
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
 type EthBalanceResult =
-  | { success: true; address: string; balanceWei: string; balanceNative: string }
+  | {
+      success: true;
+      address: string;
+      balanceWei: string;
+      balanceNative: string;
+    }
   | { success: false; error: string };
 
 export type EthBalanceCoreInput = { address: string };
@@ -15,66 +26,53 @@ export type EthBalanceInput = StepInput &
     integrationId?: string;
   };
 
-function toNative(hexWei: string): string {
-  const wei = BigInt(hexWei);
-  const units = wei / BigInt(10) ** BigInt(18);
-  const frac = wei % BigInt(10) ** BigInt(18);
-  const fracStr = frac.toString().padStart(18, "0").replace(/0+$/, "");
-  return fracStr ? `${units.toString()}. ${fracStr}`.replace(" .", ".") : units.toString();
-}
-
 async function stepHandler(
   input: EthBalanceCoreInput,
   credentials: EvmChainCredentials
 ): Promise<EthBalanceResult> {
-  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
-  if (!rpcUrl) {
+  if (!ADDRESS_RE.test(input.address)) {
     return {
       success: false,
-      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+      error: "address must be a 20-byte hex address (0x... 40 hex chars)",
     };
   }
-  if (!/^0x[0-9a-fA-F]{40}$/.test(input.address)) {
-    return { success: false, error: "address must be a 20-byte hex address (0x... 40 hex chars)" };
+
+  const res = await callEvmRpc(credentials, "eth_getBalance", [
+    input.address,
+    "latest",
+  ]);
+  if (!res.success) {
+    return { success: false, error: res.error };
   }
-  try {
-    const response = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: 1,
-        method: "eth_getBalance",
-        params: [input.address, "latest"],
-      }),
-    });
-    if (!response.ok) {
-      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
-    }
-    const payload = await response.json();
-    const balanceWei = payload?.result;
-    if (typeof balanceWei !== "string" || !/^0x[0-9a-fA-F]+$/.test(balanceWei)) {
-      return { success: false, error: `Unexpected balance response: ${JSON.stringify(payload)}` };
-    }
+
+  const balanceWei = res.result;
+  if (!isHexResult(balanceWei)) {
     return {
-      success: true,
-      address: input.address,
-      balanceWei,
-      balanceNative: toNative(balanceWei),
+      success: false,
+      error: `Unexpected balance response: ${JSON.stringify(balanceWei)}`,
     };
-  } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
   }
+
+  return {
+    success: true,
+    address: input.address,
+    balanceWei,
+    balanceNative: toNative(balanceWei),
+  };
 }
 
 /**
  * App entry point - fetches credentials and wraps with logging
  */
-export async function ethBalanceStep(input: EthBalanceInput): Promise<EthBalanceResult> {
+export async function ethBalanceStep(
+  input: EthBalanceInput
+): Promise<EthBalanceResult> {
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
 
   return runPluginStep(

--- a/plugins/evm-chain/steps/evm-rpc-core.ts
+++ b/plugins/evm-chain/steps/evm-rpc-core.ts
@@ -1,0 +1,123 @@
+import "server-only";
+
+import { ErrorCategory, logUserError } from "@/lib/logging";
+import {
+  assertUrlIsPublic,
+  safeFetch,
+  SsrfBlockedError,
+} from "@/lib/safe-fetch";
+import type { EvmChainCredentials } from "../credentials";
+
+// Read-only JSON-RPC queries should return quickly; a slow or hung endpoint
+// must not hold the step open. Same timeout style as plugins/robinhood.
+const FETCH_TIMEOUT_MS = 10_000;
+
+const HEX_VALUE_RE = /^0x[0-9a-fA-F]+$/;
+const TRAILING_ZEROS_RE = /0+$/;
+
+export type EvmRpcResult =
+  | { success: true; result: unknown }
+  | { success: false; error: string };
+
+/**
+ * Perform a single read-only JSON-RPC call against the user-supplied endpoint.
+ *
+ * The RPC URL is user input, so it is validated before any egress:
+ * assertUrlIsPublic is always-on (it ignores SAFE_FETCH_SHADOW) and rejects
+ * private, loopback, and link-local targets before a request is made;
+ * safeFetch re-validates on connect, including every redirect hop.
+ */
+export async function callEvmRpc(
+  credentials: EvmChainCredentials,
+  method: string,
+  params: unknown[] = [],
+  id = 1
+): Promise<EvmRpcResult> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return {
+      success: false,
+      error:
+        "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+    };
+  }
+
+  try {
+    await assertUrlIsPublic(rpcUrl);
+
+    const response = await safeFetch(rpcUrl, {
+      plugin: "evm-chain",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `RPC endpoint returned HTTP ${response.status}`,
+      };
+    }
+
+    const payload = (await response.json()) as {
+      result?: unknown;
+      error?: { code?: unknown; message?: unknown };
+    };
+
+    // Nodes answer HTTP 200 with a JSON-RPC error object (for example an
+    // invalid address); surface the node's message instead of the raw body.
+    if (payload?.error !== undefined && payload?.error !== null) {
+      const message =
+        typeof payload.error.message === "string" &&
+        payload.error.message.trim() !== ""
+          ? payload.error.message
+          : JSON.stringify(payload.error);
+      const code =
+        typeof payload.error.code === "number" ? ` ${payload.error.code}` : "";
+      return { success: false, error: `RPC error${code}: ${message}` };
+    }
+
+    return { success: true, result: payload?.result };
+  } catch (error) {
+    if (error instanceof SsrfBlockedError) {
+      logUserError(
+        ErrorCategory.VALIDATION,
+        "[EvmChain] Blocked SSRF target",
+        error.message,
+        { plugin_name: "evm-chain" }
+      );
+      return {
+        success: false,
+        error: `JSON-RPC URL is not allowed: ${error.message}`,
+      };
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * True when the value is a 0x-prefixed hex string (JSON-RPC hex results).
+ */
+export function isHexResult(value: unknown): value is string {
+  return typeof value === "string" && HEX_VALUE_RE.test(value);
+}
+
+/**
+ * Convert a hex wei amount to a decimal string in native units (18
+ * decimals). Whole-number balances omit the decimal point; fractions keep
+ * only significant digits (no trailing zeros).
+ */
+export function toNative(hexWei: string): string {
+  const wei = BigInt(hexWei);
+  const units = wei / BigInt(10) ** BigInt(18);
+  const frac = wei % BigInt(10) ** BigInt(18);
+  if (frac === BigInt(0)) {
+    return units.toString();
+  }
+  const fracStr = frac.toString().padStart(18, "0").replace(TRAILING_ZEROS_RE, "");
+  return `${units.toString()}.${fracStr}`;
+}

--- a/plugins/evm-chain/steps/gas-price.ts
+++ b/plugins/evm-chain/steps/gas-price.ts
@@ -1,8 +1,12 @@
 import "server-only";
 
 import { fetchCredentials } from "@/lib/credential-fetcher";
-import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
 import type { EvmChainCredentials } from "../credentials";
+import { callEvmRpc, isHexResult } from "./evm-rpc-core";
 
 type GasPriceResult =
   | { success: true; gasPriceWei: string }
@@ -13,41 +17,34 @@ export type GasPriceInput = StepInput & { integrationId?: string };
 async function stepHandler(
   credentials: EvmChainCredentials
 ): Promise<GasPriceResult> {
-  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
-  if (!rpcUrl) {
+  const res = await callEvmRpc(credentials, "eth_gasPrice");
+  if (!res.success) {
+    return { success: false, error: res.error };
+  }
+
+  const gasPriceWei = res.result;
+  if (!isHexResult(gasPriceWei)) {
     return {
       success: false,
-      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+      error: `Unexpected gas price response: ${JSON.stringify(gasPriceWei)}`,
     };
   }
-  try {
-    const response = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_gasPrice", params: [] }),
-    });
-    if (!response.ok) {
-      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
-    }
-    const payload = await response.json();
-    const gasPriceWei = payload?.result;
-    if (typeof gasPriceWei !== "string" || !/^0x[0-9a-fA-F]+$/.test(gasPriceWei)) {
-      return { success: false, error: `Unexpected gas price response: ${JSON.stringify(payload)}` };
-    }
-    return { success: true, gasPriceWei };
-  } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
-  }
+
+  return { success: true, gasPriceWei };
 }
 
 /**
  * App entry point - fetches credentials and wraps with logging
  */
-export async function gasPriceStep(input: GasPriceInput): Promise<GasPriceResult> {
+export async function gasPriceStep(
+  input: GasPriceInput
+): Promise<GasPriceResult> {
   "use step";
 
   const credentials = input.integrationId
-    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
     : {};
 
   return runPluginStep(

--- a/plugins/evm-chain/steps/gas-price.ts
+++ b/plugins/evm-chain/steps/gas-price.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import { runPluginStep, type StepInput } from "@/lib/workflow/executor/step-handler";
+import type { EvmChainCredentials } from "../credentials";
+
+type GasPriceResult =
+  | { success: true; gasPriceWei: string }
+  | { success: false; error: string };
+
+export type GasPriceInput = StepInput & { integrationId?: string };
+
+async function stepHandler(
+  credentials: EvmChainCredentials
+): Promise<GasPriceResult> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return {
+      success: false,
+      error: "EVM_CHAIN_RPC_URL is not configured. Add it in Project Integrations.",
+    };
+  }
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_gasPrice", params: [] }),
+    });
+    if (!response.ok) {
+      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
+    }
+    const payload = await response.json();
+    const gasPriceWei = payload?.result;
+    if (typeof gasPriceWei !== "string" || !/^0x[0-9a-fA-F]+$/.test(gasPriceWei)) {
+      return { success: false, error: `Unexpected gas price response: ${JSON.stringify(payload)}` };
+    }
+    return { success: true, gasPriceWei };
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * App entry point - fetches credentials and wraps with logging
+ */
+export async function gasPriceStep(input: GasPriceInput): Promise<GasPriceResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, { organizationId: input._context?.organizationId ?? null })
+    : {};
+
+  return runPluginStep(
+    { pluginName: "evm-chain", actionName: "gas-price" },
+    input,
+    () => stepHandler(credentials)
+  );
+}
+
+export const _integrationType = "evm-chain";

--- a/plugins/evm-chain/test.ts
+++ b/plugins/evm-chain/test.ts
@@ -1,0 +1,33 @@
+/**
+ * Connection test: a single read-only eth_chainId JSON-RPC call.
+ * Succeeds when the endpoint answers with a hex chain id.
+ */
+export async function testEvmChain(
+  credentials: Record<string, string>
+): Promise<{ success: boolean; error?: string }> {
+  const rpcUrl = credentials.EVM_CHAIN_RPC_URL;
+  if (!rpcUrl) {
+    return { success: false, error: "EVM_CHAIN_RPC_URL is required" };
+  }
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] }),
+    });
+    if (!response.ok) {
+      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
+    }
+    const data = await response.json();
+    const chainId = data?.result;
+    if (typeof chainId !== "string" || !/^0x[0-9a-f]+$/i.test(chainId)) {
+      return { success: false, error: "Unexpected RPC response (no chain id result)" };
+    }
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/plugins/evm-chain/test.ts
+++ b/plugins/evm-chain/test.ts
@@ -1,7 +1,16 @@
 /**
  * Connection test: a single read-only eth_chainId JSON-RPC call.
  * Succeeds when the endpoint answers with a hex chain id.
+ *
+ * Connection-test files are reachable from the client-bundled plugin
+ * registry, so they cannot import the server-only safe-fetch.ts guard.
+ * Egress is covered instead by the always-on assertUrlIsPublic pre-flight in
+ * handlePluginTest (lib/db/test-connection.ts), which validates this url
+ * field before the test runs. Step files route through safeFetch.
  */
+const FETCH_TIMEOUT_MS = 10_000;
+const CHAIN_ID_RE = /^0x[0-9a-f]+$/i;
+
 export async function testEvmChain(
   credentials: Record<string, string>
 ): Promise<{ success: boolean; error?: string }> {
@@ -13,15 +22,40 @@ export async function testEvmChain(
     const response = await fetch(rpcUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_chainId", params: [] }),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_chainId",
+        params: [],
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!response.ok) {
-      return { success: false, error: `RPC endpoint returned HTTP ${response.status}` };
+      return {
+        success: false,
+        error: `RPC endpoint returned HTTP ${response.status}`,
+      };
     }
-    const data = await response.json();
-    const chainId = data?.result;
-    if (typeof chainId !== "string" || !/^0x[0-9a-f]+$/i.test(chainId)) {
-      return { success: false, error: "Unexpected RPC response (no chain id result)" };
+    const payload = (await response.json()) as {
+      result?: unknown;
+      error?: { code?: unknown; message?: unknown };
+    };
+    if (payload?.error !== undefined && payload?.error !== null) {
+      const message =
+        typeof payload.error.message === "string" &&
+        payload.error.message.trim() !== ""
+          ? payload.error.message
+          : JSON.stringify(payload.error);
+      const code =
+        typeof payload.error.code === "number" ? ` ${payload.error.code}` : "";
+      return { success: false, error: `RPC error${code}: ${message}` };
+    }
+    const chainId = payload?.result;
+    if (typeof chainId !== "string" || !CHAIN_ID_RE.test(chainId)) {
+      return {
+        success: false,
+        error: "Unexpected RPC response (no chain id result)",
+      };
     }
     return { success: true };
   } catch (error) {

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -13,12 +13,13 @@
  * 1. Delete the plugin directory
  * 2. Run: pnpm discover-plugins (or it runs automatically on build)
  *
- * Discovered plugins: blockscout, code, discord, hyperliquid, math, protocol, robinhood, safe, sendgrid, slack, telegram, tempo, web3, webhook
+ * Discovered plugins: blockscout, code, discord, evm-chain, hyperliquid, math, protocol, robinhood, safe, sendgrid, slack, telegram, tempo, web3, webhook
  */
 
 import "./blockscout";
 import "./code";
 import "./discord";
+import "./evm-chain";
 import "./hyperliquid";
 import "./math";
 import "./protocol";

--- a/plugins/plugin-allowlist.json
+++ b/plugins/plugin-allowlist.json
@@ -5,6 +5,7 @@
     "blockscout",
     "code",
     "discord",
+    "evm-chain",
     "hyperliquid",
     "math",
     "protocol",

--- a/tests/unit/evm-chain-ssrf.test.ts
+++ b/tests/unit/evm-chain-ssrf.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
+
+const mockFetchCredentials = vi.fn();
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: (...args: unknown[]) => mockFetchCredentials(...args),
+}));
+
+// safe-fetch pulls in @sentry/nextjs and the metrics collector at module
+// load. Stub both so the real SSRF guard (assertUrlIsPublic / isBlockedIp)
+// runs without dragging in heavyweight deps.
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "VALIDATION" },
+  logUserError: vi.fn(),
+}));
+
+// Keep the real assertUrlIsPublic + SsrfBlockedError (the load-bearing SSRF
+// pre-check) and stub only the network call. The internal-IP cases below
+// throw inside assertUrlIsPublic before safeFetch is ever reached.
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/safe-fetch")>();
+  return { ...actual, safeFetch };
+});
+
+import { ethBalanceStep } from "@/plugins/evm-chain/steps/eth-balance";
+
+const ADDRESS = `0x${"a".repeat(40)}`;
+
+describe("evm-chain SSRF guard", () => {
+  beforeEach(() => {
+    mockFetchCredentials.mockReset();
+    safeFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The RPC URL is user input, so an attacker-supplied internal host must be
+  // rejected before any outbound request.
+  const blockedUrls = [
+    "http://169.254.169.254",
+    "http://127.0.0.1",
+    "http://[::1]",
+    "http://10.0.0.5",
+    "http://192.168.1.1",
+  ];
+
+  for (const rpcUrl of blockedUrls) {
+    it(`rejects internal RPC URL ${rpcUrl} without calling safeFetch`, async () => {
+      mockFetchCredentials.mockResolvedValue({
+        EVM_CHAIN_RPC_URL: rpcUrl,
+      });
+
+      const result = await ethBalanceStep({
+        address: ADDRESS,
+        integrationId: "int-1",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain("not allowed");
+      }
+      // The SSRF pre-check fires before any outbound request.
+      expect(safeFetch).not.toHaveBeenCalled();
+    });
+  }
+
+  it("rejects a non-http(s) RPC scheme before fetching", async () => {
+    mockFetchCredentials.mockResolvedValue({
+      EVM_CHAIN_RPC_URL: "file:///etc/passwd",
+    });
+
+    const result = await ethBalanceStep({
+      address: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows a public RPC URL and routes it through safeFetch", async () => {
+    // 93.184.216.34 (example.com) is a public address; the IP-literal path in
+    // assertUrlIsPublic resolves synchronously without DNS, so this stays
+    // deterministic and offline.
+    mockFetchCredentials.mockResolvedValue({
+      EVM_CHAIN_RPC_URL: "http://93.184.216.34",
+    });
+    safeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.resolve({ jsonrpc: "2.0", id: 1, result: "0x1" }),
+    });
+
+    const result = await ethBalanceStep({
+      address: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balanceWei).toBe("0x1");
+      expect(result.balanceNative).toBe("0.000000000000000001");
+    }
+  });
+});

--- a/tests/unit/evm-chain.test.ts
+++ b/tests/unit/evm-chain.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
+
+const mockFetchCredentials = vi.fn();
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: (...args: unknown[]) => mockFetchCredentials(...args),
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+vi.mock("@/lib/metrics", () => ({
+  getMetricsCollector: () => ({
+    incrementCounter: vi.fn(),
+    recordLatency: vi.fn(),
+    recordError: vi.fn(),
+    setGauge: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: { VALIDATION: "VALIDATION" },
+  logUserError: vi.fn(),
+}));
+
+// Stub only the network call; keep the real assertUrlIsPublic so the public
+// IP-literal URL below passes the SSRF pre-check deterministically.
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/safe-fetch")>();
+  return { ...actual, safeFetch };
+});
+
+import { chainInfoStep } from "@/plugins/evm-chain/steps/chain-info";
+import { erc20BalanceStep } from "@/plugins/evm-chain/steps/erc20-balance";
+import { ethBalanceStep } from "@/plugins/evm-chain/steps/eth-balance";
+import { toNative } from "@/plugins/evm-chain/steps/evm-rpc-core";
+import { gasPriceStep } from "@/plugins/evm-chain/steps/gas-price";
+
+const ADDRESS = `0x${"a".repeat(40)}`;
+// 93.184.216.34 (example.com): public IP literal, no DNS needed.
+const PUBLIC_URL = "http://93.184.216.34";
+
+function rpcOk(result: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve({ jsonrpc: "2.0", id: 1, result }),
+  };
+}
+
+describe("evm-chain toNative", () => {
+  it("omits the decimal point for whole-number balances", () => {
+    expect(toNative(`0x${(BigInt(10) ** BigInt(18)).toString(16)}`)).toBe("1");
+    expect(
+      toNative(`0x${(BigInt(123) * BigInt(10) ** BigInt(18)).toString(16)}`)
+    ).toBe("123");
+  });
+
+  it("renders fractional balances without a stray space", () => {
+    expect(toNative(`0x${(BigInt(10) ** BigInt(17)).toString(16)}`)).toBe(
+      "0.1"
+    );
+    expect(toNative(`0x${(BigInt(10) ** BigInt(16)).toString(16)}`)).toBe(
+      "0.01"
+    );
+    expect(
+      toNative(
+        `0x${(
+          BigInt(15) * BigInt(10) ** BigInt(18) +
+            BigInt(5) * BigInt(10) ** BigInt(16)
+        ).toString(16)}`
+      )
+    ).toBe("15.05");
+  });
+
+  it("keeps wei precision and drops trailing zeros", () => {
+    expect(toNative("0x1")).toBe("0.000000000000000001");
+    // 1000 wei = 1e-15 native units: trailing zeros are dropped.
+    expect(toNative("0x3e8")).toBe("0.000000000000001");
+  });
+
+  it("handles a zero balance", () => {
+    expect(toNative("0x0")).toBe("0");
+  });
+});
+
+describe("evm-chain steps", () => {
+  beforeEach(() => {
+    mockFetchCredentials.mockReset();
+    safeFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a configuration error when no RPC URL is set", async () => {
+    mockFetchCredentials.mockResolvedValue({});
+
+    const result = await gasPriceStep({ integrationId: "int-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("EVM_CHAIN_RPC_URL is not configured");
+    }
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid address without calling the network", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+
+    const result = await ethBalanceStep({
+      address: "not-an-address",
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("address must be a 20-byte hex address");
+    }
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a JSON-RPC error object instead of the raw body", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () =>
+        Promise.resolve({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: -32_602, message: "invalid address: 0x123" },
+        }),
+    });
+
+    const result = await ethBalanceStep({
+      address: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("invalid address");
+      expect(result.error).not.toContain("jsonrpc");
+    }
+  });
+
+  it("surfaces an HTTP failure from the RPC endpoint", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+    });
+
+    const result = await gasPriceStep({ integrationId: "int-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("RPC endpoint returned HTTP 502");
+    }
+  });
+
+  it("surfaces an aborted request as a structured error", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch.mockRejectedValue(
+      Object.assign(new Error("The operation was aborted due to timeout"), {
+        name: "TimeoutError",
+      })
+    );
+
+    const result = await gasPriceStep({ integrationId: "int-1" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("aborted");
+    }
+  });
+
+  it("returns the native balance for a valid response", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch.mockResolvedValue(rpcOk("0x7b"));
+
+    const result = await ethBalanceStep({
+      address: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.address).toBe(ADDRESS);
+      expect(result.balanceWei).toBe("0x7b");
+      expect(result.balanceNative).toBe("0.000000000000000123");
+    }
+  });
+
+  it("returns chain id and latest block for chain-info", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch
+      .mockResolvedValueOnce(rpcOk("0x2105"))
+      .mockResolvedValueOnce(rpcOk("0x1234"));
+
+    const result = await chainInfoStep({ integrationId: "int-1" });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.chainId).toBe("0x2105");
+      expect(result.chainIdDecimal).toBe(8453);
+      expect(result.latestBlock).toBe(4660);
+    }
+    expect(safeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the ERC-20 balance as a decimal string", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    const word = `0x${"0".repeat(62)}1234`;
+    safeFetch.mockResolvedValue(rpcOk(word));
+
+    const result = await erc20BalanceStep({
+      token: ADDRESS,
+      holder: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.balance).toBe("4660");
+    }
+  });
+
+  it("rejects a short ERC-20 balanceOf word", async () => {
+    mockFetchCredentials.mockResolvedValue({ EVM_CHAIN_RPC_URL: PUBLIC_URL });
+    safeFetch.mockResolvedValue(rpcOk("0x1234"));
+
+    const result = await erc20BalanceStep({
+      token: ADDRESS,
+      holder: ADDRESS,
+      integrationId: "int-1",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("Unexpected balanceOf response");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds the **EVM Chain** plugin (`plugins/evm-chain/`), a read-only integration that
lets workflows query any EVM-compatible chain through a JSON-RPC URL.

Complementary to the existing `web3` plugin: where `web3` operates a connected
wallet, this one is zero-credential and strictly read-only - a cheap diagnostic
against any public endpoint (chain id, blocks, gas price, balances) that works
before or without a wallet connection.

Actions:
- **Chain info** (`evm-chain/chain-info`): chain id (hex + decimal) and latest block number
- **ETH balance** (`evm-chain/eth-balance`): native token balance in wei and native units
- **ERC-20 balance** (`evm-chain/erc20-balance`): token balance held by an address (eth_call `balanceOf`)
- **Gas price** (`evm-chain/gas-price`): suggested gas price in wei

Design notes:
- Credentials are just a JSON-RPC URL (plus an optional display-only chain name),
  matching the plugin pattern of no secret-key custody.
- Steps route every RPC call through the repo's `safeFetch` egress guard (`@/lib/safe-fetch`, with `assertUrlIsPublic` URL pre-validation) - no SDK dependencies, no raw `fetch` under `plugins/`.
- All reads are `latest`-block queries; nothing writes to the chain.
- The connection test performs a single `eth_chainId` call and validates the hex result.
- Input validation rejects non-address values before hitting the RPC.
- Standard `{ success, data }` / `{ success: false, error }` step output format; output
  fields are registered for template autocomplete.

Works on any EVM chain (Base Sepolia, Base, Arbitrum, Optimism, testnets, local
Anvil/Hardhat) - just point the RPC URL credential at the endpoint.

## Test plan

- [x] Connection test validates credentials (`eth_chainId` against the configured RPC URL)
- [x] Actions execute successfully against Base Sepolia public RPC
  (`https://sepolia.base.org`): chain id 84532, block number, gas price, native
  balance, and ERC-20 `balanceOf` against Circle testnet USDC all verified live
- [x] Error handling works for invalid inputs (missing RPC URL, malformed
  addresses, non-JSON / error RPC responses return structured errors, never throw)
- [x] `pnpm type-check` clean
- [x] `pnpm discover-plugins` regenerates the registries (import, union type,
  codegen templates, README integration list)

## Files

- `plugins/evm-chain/index.ts` - plugin definition (4 actions, form fields, test config)
- `plugins/evm-chain/credentials.ts` - `EvmChainCredentials`
- `plugins/evm-chain/icon.tsx` - SVG icon
- `plugins/evm-chain/test.ts` - connection test
- `plugins/evm-chain/steps/chain-info.ts`
- `plugins/evm-chain/steps/eth-balance.ts`
- `plugins/evm-chain/steps/erc20-balance.ts`
- `plugins/evm-chain/steps/gas-price.ts`
- `plugins/index.ts` - generated: new import (via `pnpm discover-plugins`)
- `lib/types/integration.ts` - generated: union type entry
- `plugins/plugin-allowlist.json` - generated: allowlist entry
- `README.md` - Plugin System list entry