### PR TITLE
fix(event-tracker): replace fixed 0-10s dispatch jitter with a per-chain token bucket

### DIFF
--- a/.github/workflows/pr-checks-events.yml
+++ b/.github/workflows/pr-checks-events.yml
@@ -55,9 +55,6 @@ jobs:
     # (anvil/redis/localstack stuck, or vitest deadlock) worth surfacing
     # as failure rather than burning the default 6h GHA budget.
     timeout-minutes: 15
-    # staging env carries LOCALSTACK_AUTH_TOKEN (the localstack image now
-    # requires it even for community SQS use). Mirrors e2e-tests-ephemeral.
-    environment: staging
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-events-deps
@@ -71,10 +68,9 @@ jobs:
         # Bring up only the services events tests need (anvil, localstack,
         # redis). --wait blocks until healthchecks pass. Excludes test-app /
         # test-dispatcher / test-executor — heavy main-app stack the events
-        # tests don't touch. LOCALSTACK_AUTH_TOKEN is required by the
-        # current localstack/localstack:latest image even for SQS-only use.
-        env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        # tests don't touch. No secrets: test-localstack is pinned to a
+        # LocalStack release that serves community SQS without a licence, so
+        # this job runs identically on a fork, where GitHub passes none.
         run: docker compose --profile test up -d --wait test-anvil test-localstack test-redis
       - name: Run integration tests
         working-directory: keeperhub-events

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -718,18 +718,22 @@ services:
       - test
 
   test-localstack:
-    image: localstack/localstack:latest
+    # Pinned, and deliberately not `latest`. LocalStack's CalVer line (the
+    # 2026.* tags `latest` now points at) refuses to start without a valid
+    # LOCALSTACK_AUTH_TOKEN even for community SQS - it exits 55 on "License
+    # activation failed". That made this service unusable on pull requests
+    # from forks, which GitHub does not pass secrets to, so the events
+    # integration job could never pass for an outside contributor. 4.14.0 is
+    # the last release that serves SQS with no credentials at all. These
+    # tests only need community SQS, so the token is not passed here in any
+    # environment: fork runs, team branches and local dev all behave alike.
+    image: localstack/localstack:4.14.0
     container_name: keeperhub-test-localstack
     ports:
       - "4567:4566"
     environment:
       - SERVICES=sqs
       - DEBUG=0
-      # Recent localstack/localstack:latest builds require an auth token
-      # even for community-edition use; without it the container exits 55.
-      # CI passes the team token from GH secrets; local dev needs the var
-      # set in the host shell or .env to use the test profile.
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
       interval: 10s

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -19,6 +19,7 @@ import type {
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { formatError } from "./format-error";
+import type { TokenBucketPacer } from "./pacer";
 
 /**
  * EventListener encapsulates a single workflow's contract-event listener.
@@ -96,9 +97,22 @@ export interface EventListenerOptions {
   providerManager: ChainProviderManager;
 
   /**
+   * Optional per-chain pacer shared by every listener on the same chain.
+   * When set, `pacer.take()` is awaited before forwarding a matched event to
+   * SQS, replacing the fixed random jitter: a lone event forwards
+   * immediately (the bucket holds tokens), a large simultaneous batch is
+   * paced at the bucket's drain rate. When unset the legacy
+   * `jitterMs`/`DEFAULT_JITTER_MS` behaviour applies.
+   */
+  pacer?: TokenBucketPacer;
+
+  /**
    * Maximum jitter applied before forwarding a matched event to SQS.
    * Spreads downstream load when many events fire simultaneously. Tests
    * should pass 0 to keep runs deterministic.
+   *
+   * Ignored when `pacer` is set; kept for the legacy path and for tests of
+   * the jitter branch itself.
    */
   jitterMs?: number;
 }
@@ -197,9 +211,17 @@ export class EventListener {
         return;
       }
 
-      const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
-      if (maxJitter > 0) {
-        await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+      // Pace the dispatch. With a pacer (the production path, see registry)
+      // a lone event forwards immediately and a large batch drains at the
+      // per-chain rate. Without one, keep the legacy random jitter so the
+      // load-spreading property survives for direct/unit constructions.
+      if (this.opts.pacer) {
+        await this.opts.pacer.take();
+      } else {
+        const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
+        if (maxJitter > 0) {
+          await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+        }
       }
 
       // Dedup is best-effort. If the read throws we fall through and

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -19,7 +19,9 @@ import type {
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { formatError } from "./format-error";
+import type { InFlightTracker } from "./in-flight";
 import type { TokenBucketPacer } from "./pacer";
+import { abortableSleep } from "./shutdown";
 
 /**
  * EventListener encapsulates a single workflow's contract-event listener.
@@ -107,6 +109,23 @@ export interface EventListenerOptions {
   pacer?: TokenBucketPacer;
 
   /**
+   * Optional registry-wide tracker for in-flight `onLog` promises. When set,
+   * every dispatch is registered with it so `ListenerRegistry.stopAll` can
+   * wait for handlers that are mid-flight at SIGTERM. Without it a parked or
+   * dispatching event dies with the process: it has no SQS message and no
+   * phantom row yet, and the provider manager keeps no cursor to replay it.
+   */
+  inFlight?: InFlightTracker;
+
+  /**
+   * Optional registry-wide shutdown signal. Once aborted the dispatch stops
+   * parking - both the pacer and the jitter below return immediately - so the
+   * drain that follows costs the dispatch rather than the remaining pace.
+   * Aborting does not cancel an event; it forwards it now.
+   */
+  shutdownSignal?: AbortSignal;
+
+  /**
    * Maximum jitter applied before forwarding a matched event to SQS.
    * Spreads downstream load when many events fire simultaneously. Tests
    * should pass 0 to keep runs deterministic.
@@ -155,7 +174,14 @@ export class EventListener {
       fallbackWssUrl: this.opts.fallbackWssUrl,
       address: this.opts.contractAddress,
       topic0: eventFragment.topicHash,
-      handler: (log) => this.onLog(log),
+      // Registered with the tracker so shutdown can wait for it. `onLog`
+      // swallows its own errors, so the tracked promise never rejects.
+      handler: (log) => {
+        const dispatch = this.onLog(log);
+        return this.opts.inFlight
+          ? this.opts.inFlight.track(dispatch)
+          : dispatch;
+      },
     });
     this.started = true;
     logger.log(
@@ -220,7 +246,10 @@ export class EventListener {
       } else {
         const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
         if (maxJitter > 0) {
-          await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+          await abortableSleep(
+            Math.random() * maxJitter,
+            this.opts.shutdownSignal,
+          );
         }
       }
 

--- a/keeperhub-events/event-tracker/src/listener/in-flight.ts
+++ b/keeperhub-events/event-tracker/src/listener/in-flight.ts
@@ -1,0 +1,52 @@
+/**
+ * Tracks the tracker's in-flight `onLog` handlers so shutdown can wait for
+ * them. Without a drain, SIGTERM exits mid-dispatch: the matched event has
+ * not reached SQS and has no phantom row behind it, and nothing replays it.
+ * `lastProcessedBlock` lives on the in-memory `ChainEntry` and a fresh
+ * process resumes at `headBlock - 1`, so a killed handler is a trigger that
+ * never fires and never retries.
+ *
+ * This is a copy of `keeperhub-executor/lib/in-flight.ts`, kept in sync by
+ * hand. `@techops/events-tracker` is a standalone package (`rootDir: "."`,
+ * `include: ["src/**", "lib/**"]`) and cannot resolve modules from the root
+ * context, so the executor's class is not importable here.
+ */
+export class InFlightTracker {
+  private readonly pending = new Set<Promise<unknown>>();
+
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /** Register a handler promise; it leaves the set once it settles either way. */
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.pending.add(promise);
+    const remove = (): void => {
+      this.pending.delete(promise);
+    };
+    promise.then(remove, remove);
+    return promise;
+  }
+
+  /**
+   * Resolve true once every tracked promise has settled, including any tracked
+   * while waiting, or false when timeoutMs elapses first (work is still running
+   * and will be cut off by the exit that follows).
+   */
+  drain(timeoutMs: number): Promise<boolean> {
+    if (this.pending.size === 0) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      const settleAll = async (): Promise<void> => {
+        while (this.pending.size > 0) {
+          await Promise.allSettled([...this.pending]);
+        }
+        clearTimeout(timer);
+        resolve(true);
+      };
+      settleAll();
+    });
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/pacer.ts
+++ b/keeperhub-events/event-tracker/src/listener/pacer.ts
@@ -1,3 +1,5 @@
+import { abortableSleep } from "./shutdown";
+
 /**
  * Per-chain token bucket used to pace event dispatch to SQS.
  *
@@ -34,14 +36,22 @@ export class TokenBucketPacer {
   private readonly maxTokens: number;
   private readonly refillPerMs: number;
   private lastRefill: number;
+  private readonly signal?: AbortSignal;
 
   /**
    * @param drainRate - tokens (events) released per second when contended.
    * @param capacity - maximum burst the bucket holds. Defaults to the drain
    *   rate so a single event never waits (it takes one of the available
    *   tokens) while a burst is still smoothed to the configured rate.
+   * @param signal - shutdown signal. Once aborted the bucket stops pacing
+   *   and every `take()` returns immediately, parked callers included. See
+   *   `release` below.
    */
-  constructor(drainRate: number, capacity: number = drainRate) {
+  constructor(
+    drainRate: number,
+    capacity: number = drainRate,
+    signal?: AbortSignal,
+  ) {
     if (!Number.isFinite(drainRate) || drainRate <= 0) {
       throw new Error(
         `TokenBucketPacer: drainRate must be > 0, got ${drainRate}`,
@@ -56,6 +66,7 @@ export class TokenBucketPacer {
     this.maxTokens = capacity;
     this.refillPerMs = drainRate / 1000;
     this.lastRefill = Date.now();
+    this.signal = signal;
   }
 
   /**
@@ -69,6 +80,17 @@ export class TokenBucketPacer {
    * large batch, minus the unconditional mean.
    */
   async take(): Promise<void> {
+    // Release: once shutdown has begun the bucket stops pacing entirely.
+    // Waiting out the drain rate is not an option there - the drain that
+    // follows has a fixed budget (SHUTDOWN_DRAIN_TIMEOUT_MS) and covers only
+    // `budget * drainRate` events, so a burst larger than that would have its
+    // tail killed at exit with no row, no queue entry and no replay. Bursting
+    // the backlog into SQS instead makes the drain cost the dispatch, not the
+    // pacing, and SQS absorbs the burst.
+    if (this.signal?.aborted) {
+      return;
+    }
+
     // Refill from wall-clock so contention state survives between calls and
     // is shared correctly across listeners on the same chain.
     const now = Date.now();
@@ -90,7 +112,7 @@ export class TokenBucketPacer {
     // refills from the new wall-clock and consumes). Bounded by the drain
     // rate, never unbounded.
     const waitMs = Math.ceil((1 - this.tokens) / this.refillPerMs);
-    await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 1000)));
+    await abortableSleep(Math.min(waitMs, 1000), this.signal);
     await this.take();
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/pacer.ts
+++ b/keeperhub-events/event-tracker/src/listener/pacer.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-chain token bucket used to pace event dispatch to SQS.
+ *
+ * Replaces the fixed 0-10s random jitter (`DEFAULT_JITTER_MS`) that every
+ * event-triggered execution paid unconditionally (issue #2290). The jitter
+ * spread downstream load when a block matched many subscriptions, but it cost
+ * a mean 5s on every event, including a single match on an otherwise idle
+ * chain.
+ *
+ * A token bucket keeps the load-spreading property while making the delay
+ * scale with actual contention:
+ * - a single match takes a token that is already available and forwards
+ *   immediately (no fixed mean delay);
+ * - a large simultaneous batch drains at the configured rate, so downstream
+ *   sees the same smoothed arrival the jitter produced, without the arbitrary
+ *   reordering (a bucket preserves arrival order; per-event random sleeps do
+ *   not).
+ *
+ * Backpressure: `take()` never queues. When the bucket is empty the caller
+ * waits (a bounded sleep) and retries, so a burst larger than the drain rate
+ * is paced rather than dropped or buffered without bound. The wait loop is
+ * deliberately a sleep-poll rather than a condition queue: dispatch is
+ * fire-and-forget per log and the bucket is contended by at most the number of
+ * matched logs in one drain pass, so a wait queue would add machinery without
+ * changing the outcome.
+ *
+ * The bucket is created once per chain and shared by every listener on that
+ * chain, which is what makes the pacing global per chain rather than
+ * per-workflow (a single workflow spiking would otherwise pace only itself and
+ * the downstream spike would remain).
+ */
+export class TokenBucketPacer {
+  private tokens: number;
+  private readonly maxTokens: number;
+  private readonly refillPerMs: number;
+  private lastRefill: number;
+
+  /**
+   * @param drainRate - tokens (events) released per second when contended.
+   * @param capacity - maximum burst the bucket holds. Defaults to the drain
+   *   rate so a single event never waits (it takes one of the available
+   *   tokens) while a burst is still smoothed to the configured rate.
+   */
+  constructor(drainRate: number, capacity: number = drainRate) {
+    if (!Number.isFinite(drainRate) || drainRate <= 0) {
+      throw new Error(
+        `TokenBucketPacer: drainRate must be > 0, got ${drainRate}`,
+      );
+    }
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error(
+        `TokenBucketPacer: capacity must be > 0, got ${capacity}`,
+      );
+    }
+    this.tokens = capacity;
+    this.maxTokens = capacity;
+    this.refillPerMs = drainRate / 1000;
+    this.lastRefill = Date.now();
+  }
+
+  /**
+   * Refills the bucket from elapsed time, then waits (if necessary) until a
+   * token is available and consumes it.
+   *
+   * A single event when the bucket is full returns without waiting. Under a
+   * burst the wait is bounded by how long the drain rate needs to release the
+   * next token, so total latency for the tail of a large batch is
+   * `batchSize / drainRate` — the same smoothed arrival the old jitter gave a
+   * large batch, minus the unconditional mean.
+   */
+  async take(): Promise<void> {
+    // Refill from wall-clock so contention state survives between calls and
+    // is shared correctly across listeners on the same chain.
+    const now = Date.now();
+    const elapsed = now - this.lastRefill;
+    if (elapsed > 0) {
+      this.tokens = Math.min(
+        this.maxTokens,
+        this.tokens + elapsed * this.refillPerMs,
+      );
+      this.lastRefill = now;
+    }
+
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+
+    // Bucket empty: wait for the next token, then recurse (the recursive call
+    // refills from the new wall-clock and consumes). Bounded by the drain
+    // rate, never unbounded.
+    const waitMs = Math.ceil((1 - this.tokens) / this.refillPerMs);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 1000)));
+    await this.take();
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -5,7 +5,9 @@ import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
 import { formatError } from "./format-error";
+import { InFlightTracker } from "./in-flight";
 import { TokenBucketPacer } from "./pacer";
+import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "./shutdown";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -73,6 +75,13 @@ export class ListenerRegistry {
   private readonly deps: RegistryDeps;
   /** One pacer per chain, shared by every listener on that chain. */
   private readonly pacers = new Map<number, TokenBucketPacer>();
+  /** In-flight `onLog` dispatches across every listener, drained by stopAll. */
+  private readonly inFlight = new InFlightTracker();
+  /**
+   * Aborted by `stopAll` to stop every parked dispatch. Terminal: a registry
+   * that has been stopped is not restarted, the process exits behind it.
+   */
+  private readonly shutdown = new AbortController();
 
   /** Events released per second per chain when a batch contends the bucket. */
   private static readonly DRAIN_RATE_PER_SEC = 50;
@@ -85,7 +94,11 @@ export class ListenerRegistry {
   private pacerFor(chainId: number): TokenBucketPacer {
     let pacer = this.pacers.get(chainId);
     if (!pacer) {
-      pacer = new TokenBucketPacer(ListenerRegistry.DRAIN_RATE_PER_SEC);
+      pacer = new TokenBucketPacer(
+        ListenerRegistry.DRAIN_RATE_PER_SEC,
+        undefined,
+        this.shutdown.signal,
+      );
       this.pacers.set(chainId, pacer);
     }
     return pacer;
@@ -116,6 +129,8 @@ export class ListenerRegistry {
       sqs: this.deps.sqs,
       sqsQueueUrl: this.deps.sqsQueueUrl,
       pacer: this.pacerFor(reg.chainId),
+      inFlight: this.inFlight,
+      shutdownSignal: this.shutdown.signal,
     });
     try {
       await listener.start();
@@ -162,10 +177,42 @@ export class ListenerRegistry {
     return this.entries.size;
   }
 
+  /**
+   * Terminal teardown, called from the SIGTERM path.
+   *
+   * Order is load-bearing. Unsubscribing first removes each listener from the
+   * provider manager's subscriber set, so no further log can start a handler
+   * while an already-dispatched one keeps its captured reference. Aborting
+   * next releases every parked dispatch, which is what keeps the drain inside
+   * its budget: waiting out the pace instead would cover only
+   * `SHUTDOWN_DRAIN_TIMEOUT_MS * drainRate` events and kill the rest. The
+   * drain then waits for the sends themselves.
+   *
+   * Bounded rather than unbounded on purpose: a drain that outlives the K8s
+   * grace period is SIGKILLed with nothing logged. On timeout the remaining
+   * handlers are lost exactly as they are without a drain, but the count is
+   * on the record.
+   */
   async stopAll(): Promise<void> {
     for (const entry of this.entries.values()) {
       entry.listener.stop();
     }
+    this.shutdown.abort();
+
+    const outstanding = this.inFlight.size;
+    if (outstanding > 0) {
+      logger.log(
+        `[ListenerRegistry] draining ${outstanding} in-flight dispatch(es) (up to ${SHUTDOWN_DRAIN_TIMEOUT_MS}ms)`,
+      );
+    }
+    const drained = await this.inFlight.drain(SHUTDOWN_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      logger.error(
+        `[ListenerRegistry] drain timed out with ${this.inFlight.size} dispatch(es) unfinished; those events are lost`,
+      );
+    }
+
     this.entries.clear();
+    this.pacers.clear();
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -5,6 +5,7 @@ import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
 import { formatError } from "./format-error";
+import { TokenBucketPacer } from "./pacer";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -70,9 +71,24 @@ interface RegistryEntry {
 export class ListenerRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
   private readonly deps: RegistryDeps;
+  /** One pacer per chain, shared by every listener on that chain. */
+  private readonly pacers = new Map<number, TokenBucketPacer>();
+
+  /** Events released per second per chain when a batch contends the bucket. */
+  private static readonly DRAIN_RATE_PER_SEC = 50;
 
   constructor(deps: RegistryDeps) {
     this.deps = deps;
+  }
+
+  /** Returns the shared pacer for a chain, creating it on first use. */
+  private pacerFor(chainId: number): TokenBucketPacer {
+    let pacer = this.pacers.get(chainId);
+    if (!pacer) {
+      pacer = new TokenBucketPacer(ListenerRegistry.DRAIN_RATE_PER_SEC);
+      this.pacers.set(chainId, pacer);
+    }
+    return pacer;
   }
 
   /**
@@ -99,6 +115,7 @@ export class ListenerRegistry {
       dedup: this.deps.dedup,
       sqs: this.deps.sqs,
       sqsQueueUrl: this.deps.sqsQueueUrl,
+      pacer: this.pacerFor(reg.chainId),
     });
     try {
       await listener.start();

--- a/keeperhub-events/event-tracker/src/listener/shutdown.ts
+++ b/keeperhub-events/event-tracker/src/listener/shutdown.ts
@@ -12,13 +12,21 @@
  * How long `stopAll` waits for in-flight handlers before giving up and
  * letting the process exit.
  *
- * Mirrors `SHUTDOWN_TIMEOUT_MS` in `lib/workflow/executor/runner-constants.ts`
- * (25s inside the K8s 30s default grace period), duplicated because this
- * package cannot import from the root context. The buffer matters: a drain
- * that outlives the grace period is SIGKILLed with nothing logged, which is
- * the failure this drain exists to remove.
+ * Sized against the 30s K8s default grace period, not copied from the
+ * executor's 25s: this process still has to tear down the provider manager
+ * (a WSS close per chain) and the health server after the drain returns, and
+ * a drain that outlives the grace period is SIGKILLed with nothing logged -
+ * the exact failure this drain exists to remove.
+ *
+ * 20s is chosen to cover one dispatch stuck on the internal API. A
+ * `createPhantomExecution` that gets no answer spends 3 attempts at
+ * `REQUEST_TIMEOUT_MS = 5_000` plus `RETRY_DELAYS_MS = [500, 1_000]` before
+ * giving up - 16.5s (`lib/phantom.ts`). Nothing under the grace period can
+ * also cover the send-failure path, where `failPhantomExecution` runs the
+ * same ladder again; that case times out and is logged, which is the
+ * designed outcome rather than a gap.
  */
-export const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+export const SHUTDOWN_DRAIN_TIMEOUT_MS = 20_000;
 
 /**
  * Sleeps for `ms`, or returns early when `signal` aborts.

--- a/keeperhub-events/event-tracker/src/listener/shutdown.ts
+++ b/keeperhub-events/event-tracker/src/listener/shutdown.ts
@@ -1,0 +1,58 @@
+/**
+ * Shutdown-time primitives shared by the dispatch path.
+ *
+ * A matched event parks before it is forwarded to SQS - on the pacer under
+ * contention, on the legacy jitter otherwise. That park is the window in
+ * which SIGTERM loses the event outright, so shutdown does two things to it:
+ * it stops the park (this module's signal) and then waits for the handlers
+ * to finish dispatching (`InFlightTracker`).
+ */
+
+/**
+ * How long `stopAll` waits for in-flight handlers before giving up and
+ * letting the process exit.
+ *
+ * Mirrors `SHUTDOWN_TIMEOUT_MS` in `lib/workflow/executor/runner-constants.ts`
+ * (25s inside the K8s 30s default grace period), duplicated because this
+ * package cannot import from the root context. The buffer matters: a drain
+ * that outlives the grace period is SIGKILLed with nothing logged, which is
+ * the failure this drain exists to remove.
+ */
+export const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+
+/**
+ * Sleeps for `ms`, or returns early when `signal` aborts.
+ *
+ * Resolves in both cases - it never rejects. An abort here means "stop
+ * waiting and dispatch now", not "cancel this event". That is the right
+ * trade at shutdown: pacing exists to keep a spike off SQS and the phantom
+ * execution API, and a burst into SQS is recoverable where a dropped trigger
+ * is not. Because it resolves rather than throws, callers need no
+ * abort-specific branch and a parked event follows its normal path straight
+ * through to the send.
+ */
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    // `onAbort` closes over `timer` before it is declared. Safe: the listener
+    // is registered after the timer is assigned, so the handle always exists
+    // by the time abort can fire.
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -518,6 +518,39 @@ describe("EventListener", () => {
       expect(sqs.send.mock.calls.length).toBe(11);
     });
 
+    it("releases a jittered dispatch immediately when shutdown aborts", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      const controller = new AbortController();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          // No pacer: this is the legacy jitter branch, which is what the
+          // deployed tracker runs until this PR's pacer reaches it.
+          jitterMs: 10_000,
+          shutdownSignal: controller.signal,
+        }),
+      );
+      await listener.start();
+
+      const started = Date.now();
+      const dispatch = providerMock.capturedHandler!(
+        makeLog({
+          txHash: `0x${"c".repeat(64)}`,
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      controller.abort();
+      await dispatch;
+
+      // Abort forwards the event now rather than cancelling it: the send
+      // still happens, it just does not wait out the remaining jitter.
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+      expect(Date.now() - started).toBeLessThan(500);
+    });
+
     it("applies jitter up to the configured cap before forwarding", async () => {
       const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
       vi.useFakeTimers();

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -16,6 +16,7 @@ import {
   EventListener,
   type EventListenerOptions,
 } from "../../src/listener/event-listener";
+import { TokenBucketPacer } from "../../src/listener/pacer";
 
 // KEEP-693: stub the phantom helpers so the listener does not call the internal
 // API. Default (no id) keeps existing SQS-path tests on the id-less path.
@@ -436,11 +437,88 @@ describe("EventListener", () => {
       expect(sqs.send).toHaveBeenCalledTimes(1);
     });
 
+    it("uses the shared pacer (lone event forwards immediately) instead of jitter", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      // A fresh bucket is full, so the first take() does not wait: a lone
+      // matched event on an idle chain must not pay the old fixed delay.
+      const pacer = new TokenBucketPacer(1000);
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          pacer,
+        }),
+      );
+      await listener.start();
+
+      const started = Date.now();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash:
+            "0x9999000000000000000000000000000000000000000000000000000000000000",
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+      // A full token bucket returns immediately (well under the old 0-10s
+      // jitter cap).
+      expect(Date.now() - started).toBeLessThan(200);
+    });
+
+    it("paces a burst through the shared pacer rather than a per-event sleep", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      // Slow drain rate so the pacing effect is measurable with real timers.
+      const pacer = new TokenBucketPacer(10); // 1 token per 100ms
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          pacer,
+        }),
+      );
+      await listener.start();
+
+      // Drain the initial burst (capacity == drain rate == 10).
+      const drain = async () => {
+        for (let i = 0; i < 10; i++) {
+          await providerMock.capturedHandler!(
+            makeLog({
+              txHash: `0x${"a".repeat(60)}${i.toString(16).padStart(4, "0")}`,
+              sender: SENDER,
+              value: 1n,
+            }),
+          );
+        }
+      };
+      const started = Date.now();
+      await drain();
+      const burstElapsed = Date.now() - started;
+      // First 10 = bucket capacity, no waiting expected.
+      expect(burstElapsed).toBeLessThan(500);
+
+      // Next event must wait for the drain rate (100ms per token).
+      const pacedStart = Date.now();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash: `0x${"b".repeat(64)}`,
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      const pacedElapsed = Date.now() - pacedStart;
+      // The bucket is empty after the 10-token burst, so the 11th event must
+      // wait ~1 drain interval (100ms at 10/s). Allow generous slack for timer
+      // granularity — the point is it waited (vs the burst's ~0ms), not the
+      // exact millisecond.
+      expect(pacedElapsed).toBeGreaterThanOrEqual(50);
+      expect(pacedElapsed).toBeLessThan(500);
+      expect(sqs.send.mock.calls.length).toBe(11);
+    });
+
     it("applies jitter up to the configured cap before forwarding", async () => {
-      // Pin Math.random() to 1 so the jitter is exactly the cap, and use
-      // fake timers so the test does not actually wait. The goal is to
-      // verify the jitter branch executes and respects the cap; precise
-      // timing is out of scope.
       const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
       vi.useFakeTimers();
       try {

--- a/keeperhub-events/event-tracker/tests/unit/in-flight.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/in-flight.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InFlightTracker } from "../../src/listener/in-flight";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve: () => void = () => undefined;
+  let reject: (reason: unknown) => void = () => undefined;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("InFlightTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drains immediately when nothing is in flight", async () => {
+    await expect(new InFlightTracker().drain(25_000)).resolves.toBe(true);
+  });
+
+  it("returns the tracked promise unchanged and forgets it once it settles", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+
+    const tracked = tracker.track(work.promise);
+
+    expect(tracked).toBe(work.promise);
+    expect(tracker.size).toBe(1);
+    work.resolve();
+    await tracked;
+    expect(tracker.size).toBe(0);
+  });
+
+  it("forgets a rejected promise too, without adding a rejection of its own", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+    const tracked = tracker.track(work.promise);
+
+    work.reject(new Error("boom"));
+
+    await expect(tracked).rejects.toThrow("boom");
+    expect(tracker.size).toBe(0);
+  });
+
+  it("waits for every in-flight handler and reports a clean drain", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const second = deferred();
+    tracker.track(first.promise);
+    tracker.track(second.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+    expect(tracker.size).toBe(1);
+
+    second.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+
+  it("gives up once the bound elapses while work is still running", async () => {
+    const tracker = new InFlightTracker();
+    const stuck = deferred();
+    tracker.track(stuck.promise);
+
+    const drained = tracker.drain(25_000);
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(tracker.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(drained).resolves.toBe(false);
+    // The handler is still running; the caller exits knowing it was cut off.
+    expect(tracker.size).toBe(1);
+    stuck.resolve();
+  });
+
+  it("also waits for a handler tracked after the drain began", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const late = deferred();
+    tracker.track(first.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+    tracker.track(late.promise);
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+
+    late.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -75,4 +75,37 @@ describe("TokenBucketPacer", () => {
     expect(() => new TokenBucketPacer(0)).toThrow(/drainRate/);
     expect(() => new TokenBucketPacer(-5)).toThrow(/drainRate/);
   });
+
+  it("stops pacing once the shutdown signal aborts, releasing a parked take", async () => {
+    const controller = new AbortController();
+    const drainRate = 10; // 1 token per 100ms
+    const pacer = new TokenBucketPacer(drainRate, undefined, controller.signal);
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // Bucket empty: this take would otherwise wait ~100ms for the next token.
+    const started = Date.now();
+    const parked = pacer.take();
+    controller.abort();
+    await parked;
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it("keeps letting takes through after abort, so a whole backlog bursts", async () => {
+    const controller = new AbortController();
+    const pacer = new TokenBucketPacer(10, undefined, controller.signal);
+    for (let i = 0; i < 10; i++) {
+      await pacer.take();
+    }
+    controller.abort();
+
+    // 100 events at 10/s would be 10s of pacing. After abort they cost nothing:
+    // the drain that follows pays for the sends, not for the remaining pace.
+    const started = Date.now();
+    for (let i = 0; i < 100; i++) {
+      await pacer.take();
+    }
+    expect(Date.now() - started).toBeLessThan(100);
+  });
 });

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenBucketPacer } from "../../src/listener/pacer";
+
+describe("TokenBucketPacer", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lets a lone event through immediately when the bucket is full", async () => {
+    const pacer = new TokenBucketPacer(50);
+    const started = Date.now();
+    await pacer.take();
+    // A full bucket holds `capacity` (= drain rate) tokens, so the first take
+    // consumes one without waiting.
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it("paces a large burst at the drain rate", async () => {
+    const drainRate = 100; // tokens/sec -> 10ms per token
+    const pacer = new TokenBucketPacer(drainRate);
+
+    // Drain the initial burst (capacity == drainRate) instantly.
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // After the burst, each further take must wait ~1/rate.
+    const started = Date.now();
+    for (let i = 0; i < 5; i++) {
+      await pacer.take();
+    }
+    const elapsed = Date.now() - started;
+    // 5 tokens at 100/s = ~50ms, allow generous timer slack both ways.
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("refills over wall-clock time (idle bucket recovers)", async () => {
+    const pacer = new TokenBucketPacer(100); // 1 token per 10ms
+    for (let i = 0; i < 100; i++) {
+      await pacer.take();
+    }
+
+    // Bucket is now empty. Wait ~50ms -> ~5 tokens refilled.
+    await new Promise((r) => setTimeout(r, 60));
+    const started = Date.now();
+    // 5 tokens should be available without waiting.
+    for (let i = 0; i < 5; i++) {
+      await pacer.take();
+    }
+    expect(Date.now() - started).toBeLessThan(100);
+  });
+
+  it("shares one bucket across consumers on the same chain (contention is global)", async () => {
+    const drainRate = 100;
+    const pacer = new TokenBucketPacer(drainRate);
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // Two consumers taking concurrently still drain at the shared rate.
+    const started = Date.now();
+    await Promise.all([
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+    ]);
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeGreaterThanOrEqual(40); // ~5 tokens / 100 per sec
+  });
+
+  it("rejects a non-positive drain rate", () => {
+    expect(() => new TokenBucketPacer(0)).toThrow(/drainRate/);
+    expect(() => new TokenBucketPacer(-5)).toThrow(/drainRate/);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -78,34 +78,47 @@ describe("TokenBucketPacer", () => {
 
   it("stops pacing once the shutdown signal aborts, releasing a parked take", async () => {
     const controller = new AbortController();
-    const drainRate = 10; // 1 token per 100ms
-    const pacer = new TokenBucketPacer(drainRate, undefined, controller.signal);
-    for (let i = 0; i < drainRate; i++) {
-      await pacer.take();
-    }
+    // 1 token/sec, capacity 1. A slow rate keeps the assertions honest: the
+    // single warm-up take cannot refill a meaningful fraction of a token, so
+    // the bucket is genuinely empty below and the test cannot pass by
+    // accident on a loaded runner.
+    const pacer = new TokenBucketPacer(1, 1, controller.signal);
+    await pacer.take();
 
-    // Bucket empty: this take would otherwise wait ~100ms for the next token.
-    const started = Date.now();
     const parked = pacer.take();
+    let settled = false;
+    parked.then(() => {
+      settled = true;
+    });
+
+    // Prove it is actually parked before aborting; otherwise this test would
+    // pass whether or not abort does anything.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(settled).toBe(false);
+
+    const started = Date.now();
     controller.abort();
     await parked;
-    expect(Date.now() - started).toBeLessThan(50);
+    expect(settled).toBe(true);
+    // Would have been ~1s of remaining pace.
+    expect(Date.now() - started).toBeLessThan(200);
   });
 
   it("keeps letting takes through after abort, so a whole backlog bursts", async () => {
     const controller = new AbortController();
-    const pacer = new TokenBucketPacer(10, undefined, controller.signal);
-    for (let i = 0; i < 10; i++) {
-      await pacer.take();
-    }
+    const pacer = new TokenBucketPacer(1, 1, controller.signal);
+    await pacer.take();
     controller.abort();
 
-    // 100 events at 10/s would be 10s of pacing. After abort they cost nothing:
-    // the drain that follows pays for the sends, not for the remaining pace.
+    // At 1 token/sec these 100 takes would be ~100s of pacing. After abort
+    // they cost nothing: the drain that follows pays for the sends, not for
+    // the remaining pace. The bound is deliberately loose - two orders of
+    // magnitude below the paced cost is proof enough, and a tight floor
+    // would only buy flakes on a loaded runner.
     const started = Date.now();
     for (let i = 0; i < 100; i++) {
       await pacer.take();
     }
-    expect(Date.now() - started).toBeLessThan(100);
+    expect(Date.now() - started).toBeLessThan(2_000);
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/registry.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/registry.test.ts
@@ -1,5 +1,8 @@
 import type { SQSClient } from "@aws-sdk/client-sqs";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ethers } from "ethers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../lib/utils/logger";
+import { getInterface } from "../../src/chains/interface-cache";
 import type {
   ChainProviderManager,
   SubscribeOptions,
@@ -11,6 +14,7 @@ import {
   ListenerRegistry,
   type WorkflowRegistration,
 } from "../../src/listener/registry";
+import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "../../src/listener/shutdown";
 
 const RAW_EVENTS_ABI: AbiEvent[] = [
   {
@@ -77,6 +81,33 @@ function makeDeps(): {
     sqs: sqs as unknown as SQSClient,
     sqsQueueUrl: "https://sqs.test/queue",
   };
+}
+
+function makeLog(txHash: string): ethers.Log {
+  const iface = getInterface(EVENTS_ABI_STRINGS);
+  const { topics, data } = iface.encodeEventLog("Emitted", [
+    "0x2222222222222222222222222222222222222222",
+    1n,
+  ]);
+  return {
+    topics,
+    data,
+    address: "0x1111111111111111111111111111111111111111",
+    blockNumber: 100,
+    blockHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    transactionHash: txHash,
+    transactionIndex: 0,
+    index: 0,
+  } as unknown as ethers.Log;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe("ListenerRegistry", () => {
@@ -175,6 +206,80 @@ describe("ListenerRegistry", () => {
       registry.remove("wf-1");
       await registry.add(makeWorkflow("wf-1", { configHash: "second" }));
       expect(registry.getConfigHash("wf-1")).toBe("second");
+    });
+  });
+
+  describe("shutdown drain", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    /**
+     * Parks the handler inside the dedup read, which sits after the pace and
+     * before any SQS or phantom call. That is the same in-flight state a
+     * SIGTERM would catch, without the test needing the internal API.
+     */
+    async function dispatchAndPark(): Promise<{
+      release: (alreadyProcessed: boolean) => void;
+    }> {
+      const gate = deferred<boolean>();
+      (deps.dedup.isProcessed as ReturnType<typeof vi.fn>).mockReturnValue(
+        gate.promise,
+      );
+      await registry.add(makeWorkflow("wf-1"));
+      const { handler } = deps.subscribeToLogs.mock
+        .calls[0][0] as SubscribeOptions;
+      void handler(makeLog(`0x${"a".repeat(64)}`));
+      // Let the handler run up to the dedup await.
+      await Promise.resolve();
+      await Promise.resolve();
+      return { release: gate.resolve };
+    }
+
+    it("waits for an in-flight dispatch before returning", async () => {
+      const { release } = await dispatchAndPark();
+
+      let stopped = false;
+      const stopping = registry.stopAll().then(() => {
+        stopped = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      // The listener is already unsubscribed, but the handler that was
+      // mid-flight when the signal arrived has not finished.
+      expect(deps.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(stopped).toBe(false);
+
+      release(true);
+      await stopping;
+      expect(stopped).toBe(true);
+    });
+
+    it("gives up at the drain bound and records what it could not finish", async () => {
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      // Parked and never released: the handler outlives the budget.
+      await dispatchAndPark();
+      vi.useFakeTimers();
+
+      const stopping = registry.stopAll();
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_DRAIN_TIMEOUT_MS);
+      await stopping;
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("drain timed out"),
+      );
+      expect(registry.size()).toBe(0);
+    });
+
+    it("clears the registry once drained", async () => {
+      const { release } = await dispatchAndPark();
+      const stopping = registry.stopAll();
+      release(true);
+      await stopping;
+      expect(registry.size()).toBe(0);
+      expect(registry.ids()).toEqual([]);
     });
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/shutdown.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/shutdown.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { abortableSleep } from "../../src/listener/shutdown";
+
+describe("abortableSleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sleeps the full interval when nothing aborts", async () => {
+    let settled = false;
+    const sleep = abortableSleep(5_000).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await sleep;
+    expect(settled).toBe(true);
+  });
+
+  it("returns immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await abortableSleep(10_000, controller.signal);
+    // Nothing was scheduled, so the sleep cannot be holding a timer open.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns early when the signal aborts mid-sleep, and clears its timer", async () => {
+    const controller = new AbortController();
+    let settled = false;
+    const sleep = abortableSleep(10_000, controller.signal).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toBe(false);
+
+    controller.abort();
+    await sleep;
+    expect(settled).toBe(true);
+    // The pending timer is cleared rather than left to fire into a resolved
+    // promise and hold the event loop open past the drain.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resolves rather than rejecting on abort, so callers need no abort branch", async () => {
+    const controller = new AbortController();
+    const sleep = abortableSleep(10_000, controller.signal);
+    controller.abort();
+    await expect(sleep).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #2290 (accepted).

## What
Every event-triggered execution paid a uniformly random 0-10s sleep (mean 5s) before its event was forwarded to SQS, whether it was the only match on an idle chain or one of five hundred. The load-spreading intent is real, but the cost was unconditional and it reordered events within a block arbitrarily (each listener slept independently).

Replaces the per-listener random sleep with a per-chain TokenBucketPacer shared by every listener on the chain (created in ListenerRegistry, keyed by chainId):
- a lone event takes a token from the full bucket and forwards immediately (no fixed mean delay);
- a large simultaneous batch drains at the configured rate (50/s), preserving the smoothing the jitter provided, in arrival order rather than randomly;
- backpressure is bounded: take() waits for the next token instead of queueing without limit.

The legacy jitter path is kept for direct/unit constructions without a pacer, and the dedup identity (workflowId, txHash) is untouched per the issue.

## Verification
New pacer unit tests (TokenBucketPacer) plus event-listener tests proving a lone event is immediate and a burst is paced. Full event-tracker unit suite: 204 passed. Package typecheck and lint clean.

The issue asks to measure the stage locally if #2289 has not landed; these are unit-level timing proofs of the mechanism (immediate single vs paced burst) rather than production stage timings.