### PR TITLE
docs: scope the simulate preflight to tools that support it

### DIFF
--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -73,7 +73,10 @@ four above. Treat anything other than `success` as a failure. Checking only for 
 ## 4. Write onchain, safely
 
 For a one-off transfer or contract call with no workflow around it, use the direct execution
-tools: `execute_transfer`, `execute_contract_call`, `execute_protocol_action`.
+tools: `execute_transfer`, `execute_contract_call`, `execute_check_and_execute`. The protocol
+action tool (`execute_protocol_action`) has no dry run today — it executes the action when
+called — so preflight it with a read (`search_protocol_actions`, or a view call against the
+protocol) rather than a `simulate: true` pass, which it does not accept.
 
 Always preflight:
 

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -73,12 +73,15 @@ four above. Treat anything other than `success` as a failure. Checking only for 
 ## 4. Write onchain, safely
 
 For a one-off onchain action with no workflow around it, use the direct execution
-tools: `execute_transfer`, `execute_contract_call`, `execute_check_and_execute`. The protocol
-action tool (`execute_protocol_action`) has no dry run today — it executes the action when
-called — so preflight it with a read (`search_protocol_actions`, or a view call against the
-protocol) rather than a `simulate: true` pass, which it does not accept.
+tools: `execute_transfer`, `execute_contract_call`, `execute_check_and_execute`, and
+`execute_protocol_action`. The first three take a `simulate` flag. `execute_protocol_action`
+has no dry run - it executes the action when called and accepts no `simulate` flag - so
+treat it as a broadcast and make the call itself the smallest possible step. Where the
+protocol exposes a read action (for example a `chronicle/eth-usd-read` or
+`morpho/get-position` actionType), calling that first returns current state, but it cannot
+tell you whether a particular write will revert; there is no substitute for a dry run here.
 
-Always preflight:
+Always preflight the three simulate-capable tools:
 
 1. Call the tool with `simulate: true`.
 2. Continue only when the result reports `success: true` and `wouldRevert: false`.
@@ -87,6 +90,9 @@ Always preflight:
    the number of seconds in the `X-Poll-Interval-Hint` response header between polls; `0` means
    the execution is terminal and you can stop.
 5. Keep `transactionLink` from the terminal response as the onchain proof.
+
+`execute_protocol_action` is not in that loop: it has no simulate step, so call it once with
+an `idempotency_key` and poll step 4 onward.
 
 **Simulation is EVM-only.** On Solana mainnet (`101`) and devnet (`103`), a `simulate: true` call
 resolves with `isError: true` rather than throwing. Parse the JSON in `content[0].text` and stop

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -75,7 +75,8 @@ four above. Treat anything other than `success` as a failure. Checking only for 
 For a one-off onchain action with no workflow around it, use the direct execution
 tools: `execute_transfer`, `execute_contract_call`, `execute_check_and_execute`, and
 `execute_protocol_action`. The first three take a `simulate` flag. `execute_protocol_action`
-has no dry run - it executes the action when called and accepts no `simulate` flag - so
+has no dry run - it executes the action when called and silently ignores a
+`simulate` flag if one is passed (it does not stop the broadcast) - so
 treat it as a broadcast and make the call itself the smallest possible step. Where the
 protocol exposes a read action (for example a `chronicle/eth-usd-read` or
 `morpho/get-position` actionType), calling that first returns current state, but it cannot

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -72,7 +72,7 @@ four above. Treat anything other than `success` as a failure. Checking only for 
 
 ## 4. Write onchain, safely
 
-For a one-off transfer or contract call with no workflow around it, use the direct execution
+For a one-off onchain action with no workflow around it, use the direct execution
 tools: `execute_transfer`, `execute_contract_call`, `execute_check_and_execute`. The protocol
 action tool (`execute_protocol_action`) has no dry run today — it executes the action when
 called — so preflight it with a read (`search_protocol_actions`, or a view call against the

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -93,7 +93,10 @@ Always preflight the three simulate-capable tools:
 5. Keep `transactionLink` from the terminal response as the onchain proof.
 
 `execute_protocol_action` is not in that loop: it has no simulate step, so call it once with
-an `idempotency_key` and poll step 4 onward.
+an `idempotency_key` and treat its response as the terminal result. For a write action the
+call returns the outcome directly - `transactionHash` and `transactionLink` on success, the
+error on failure - and there is no `executionId` to poll afterwards. (A read actionType
+returns the read value instead, as above.)
 
 **Simulation is EVM-only.** On Solana mainnet (`101`) and devnet (`103`), a `simulate: true` call
 resolves with `isError: true` rather than throwing. Parse the JSON in `content[0].text` and stop

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -98,7 +98,8 @@ Confirm, in order:
 Three direct-execution tools take a `simulate` flag: `execute_transfer`,
 `execute_contract_call`, and `execute_check_and_execute`. Simulating estimates gas and
 catches reverts without signing or broadcasting. `execute_protocol_action` has no dry run:
-it executes the action when called and accepts no `simulate` flag. A protocol read action
+it executes the action when called and silently ignores a `simulate` flag if
+one is passed (it does not stop the broadcast). A protocol read action
 (for example a `chronicle/eth-usd-read` actionType) returns current state but cannot predict
 whether a particular write will revert. For example:
 

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -95,10 +95,12 @@ Confirm, in order:
 
 ## 6. Simulate
 
-Every EVM direct-execution write tool (`execute_transfer`, `execute_contract_call`,
-`execute_check_and_execute`) takes a `simulate` flag that estimates gas and catches
-reverts without signing or broadcasting. Simulation is EVM-only: on Solana chains
-`simulate` is rejected, and a Solana transfer broadcasts directly. For example:
+Three direct-execution tools take a `simulate` flag: `execute_transfer`,
+`execute_contract_call`, and `execute_check_and_execute`. Simulating estimates gas and
+catches reverts without signing or broadcasting. `execute_protocol_action` has no dry run:
+it executes the action when called and accepts no `simulate` flag. A protocol read action
+(for example a `chronicle/eth-usd-read` actionType) returns current state but cannot predict
+whether a particular write will revert. For example:
 
 ```json
 {
@@ -112,6 +114,10 @@ reverts without signing or broadcasting. Simulation is EVM-only: on Solana chain
 
 `simulate` must be the JSON boolean `true`. The string `"true"` is rejected, deliberately,
 so a typo cannot fall through to a real broadcast.
+
+Simulation is EVM-only. Over MCP, on a known Solana chain a `simulate: true` request errors
+with `simulation_unsupported_chain` and sends nothing; a Solana transfer sent without
+`simulate` broadcasts directly, so there is no dry run to fall back on there.
 
 A deterministic dry-run failure answers HTTP 400 with `wouldRevert: true`. Classify the
 body by a string `code` first, then by `failureKind`: `insufficient_balance` is an

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -95,7 +95,8 @@ Confirm, in order:
 
 ## 6. Simulate
 
-Every execute tool and endpoint takes a `simulate` flag that estimates gas and catches
+Every direct-execution write tool (`execute_transfer`, `execute_contract_call`,
+`execute_check_and_execute`) takes a `simulate` flag that estimates gas and catches
 reverts without signing or broadcasting:
 
 ```json

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -95,9 +95,10 @@ Confirm, in order:
 
 ## 6. Simulate
 
-Every direct-execution write tool (`execute_transfer`, `execute_contract_call`,
+Every EVM direct-execution write tool (`execute_transfer`, `execute_contract_call`,
 `execute_check_and_execute`) takes a `simulate` flag that estimates gas and catches
-reverts without signing or broadcasting:
+reverts without signing or broadcasting. Simulation is EVM-only: on Solana chains
+`simulate` is rejected, and a Solana transfer broadcasts directly. For example:
 
 ```json
 {

--- a/docs/guides/first-verified-transaction.md
+++ b/docs/guides/first-verified-transaction.md
@@ -96,10 +96,12 @@ Confirm, in order:
 ## 6. Simulate
 
 Three direct-execution tools take a `simulate` flag: `execute_transfer`,
-`execute_contract_call`, and `execute_check_and_execute`. Simulating estimates gas and
-catches reverts without signing or broadcasting. `execute_protocol_action` has no dry run:
-it executes the action when called and silently ignores a `simulate` flag if
-one is passed (it does not stop the broadcast). A protocol read action
+`execute_contract_call`, and `execute_check_and_execute`, and so do their HTTP routes
+(`POST /api/execute/transfer`, `/contract-call`, and `/check-and-execute`). Simulating
+estimates gas and catches reverts without signing or broadcasting. `execute_protocol_action`
+has no dry run: it executes the action when called and silently ignores a `simulate` flag if
+one is passed (it does not stop the broadcast) - the same is true of its HTTP route,
+`POST /api/execute/{protocol}/{action}`. A protocol read action
 (for example a `chronicle/eth-usd-read` actionType) returns current state but cannot predict
 whether a particular write will revert. For example:
 


### PR DESCRIPTION
Fixes #2097 (docs half — the code half, the missing idempotency_key on execute_protocol_action, already landed on staging).

## What
execute_protocol_action has no dry run today (its schema accepts no simulate flag), but two guides told callers to preflight it with simulate: true and continue only on wouldRevert: false — a caller following them would broadcast a real transaction.

- docs/getting-started/agent.md: scope the preflight list to the direct-execution tools that implement simulate (execute_transfer, execute_contract_call, execute_check_and_execute) and state plainly that execute_protocol_action executes when called, suggesting a read-based preflight instead.
- docs/guides/first-verified-transaction.md: correct the uniform "every execute tool and endpoint takes a simulate flag" claim.

The issue scoped this half as independent of the #2004 simulate-uniformity decision.