### PR TITLE
fix: KEEP-1305 bound app-pool statements and exempt the migrator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@
 #   DATABASE_URL=postgresql://postgres:postgres@localhost:5433/keeperhub
 DATABASE_URL=
 
+# Per-statement cap on the main application connection pool, in milliseconds.
+# Leave empty to use the built-in 30000. It bounds one statement, not a request,
+# so a handler that issues many short queries is unaffected. Raise it only to
+# unblock a slow read path - a migration opts out through its own connection
+# string instead (KEEP-1305).
+APP_STATEMENT_TIMEOUT_MS=
+
 # better-auth signing key. Generate with: openssl rand -hex 32
 BETTER_AUTH_SECRET=
 

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -25,6 +25,14 @@ app:
       type: parameterStore
       name: workflow-postgres-url
       parameter_name: /eks/techops-prod/keeperhub/db-url
+    # KEEP-1305: the request-path statement_timeout for the lib/db pool. The
+    # code defaults to the same 30000, so this entry exists to make the value
+    # visible in the deploy config and to let an operator raise it without a
+    # rebuild. The CronJobs run as HTTP calls into these pods, so it bounds
+    # their statements too. The RDS parameter group holds the 120s backstop.
+    APP_STATEMENT_TIMEOUT_MS:
+      type: kv
+      value: "30000"
     CHAIN_RPC_CONFIG:
       type: parameterStore
       name: chain-rpc-config
@@ -170,6 +178,33 @@ app:
         args:
           - |
             set -e
+            # KEEP-1305: this container opts out of the request-path
+            # statement_timeout. A migration file runs as one transaction and its
+            # DDL can wait far longer than 30s for a lock, so the 30s app-pool cap
+            # and the 120s RDS parameter-group cap would abort it mid-deploy.
+            # lock_timeout replaces the cap that statement_timeout=0 removes: a
+            # migration that cannot take its lock fails the deploy instead of
+            # wedging every reader on the table behind a pending
+            # AccessExclusiveLock. 60s outlasts a normal app statement (capped at
+            # 30s) and still gives up well before an operator psql session does.
+            #
+            # Both settings go on the URL as bare parameters. Verified 2026-09-03
+            # against Postgres 17 that this is the only form that both reaches the
+            # server through BOTH drivers - drizzle-kit and world-postgres use
+            # `pg`, the tsx seed and backfill use `postgres.js` - and overrides the
+            # pool-level connection option lib/db sets. The `options=-c ...` form
+            # loses to that pool option and silently leaves the 30s cap in place,
+            # and PGOPTIONS reaches `pg` only.
+            if [ -z "${DATABASE_URL:-}" ]; then
+              echo "[deploy] DATABASE_URL is empty, refusing to migrate" >&2
+              exit 1
+            fi
+            case "$DATABASE_URL" in
+              *\?*) MIGRATOR_URL="${DATABASE_URL}&statement_timeout=0&lock_timeout=60000" ;;
+              *)    MIGRATOR_URL="${DATABASE_URL}?statement_timeout=0&lock_timeout=60000" ;;
+            esac
+            export DATABASE_URL="$MIGRATOR_URL"
+            export WORKFLOW_POSTGRES_URL="$MIGRATOR_URL"
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
             # Called by path, not through the `bootstrap` bin: .npmrc public-hoists

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -25,6 +25,14 @@ app:
       type: parameterStore
       name: workflow-postgres-url
       parameter_name: /eks/techops-staging/keeperhub/db-url
+    # KEEP-1305: the request-path statement_timeout for the lib/db pool. The
+    # code defaults to the same 30000, so this entry exists to make the value
+    # visible in the deploy config and to let an operator raise it without a
+    # rebuild. The CronJobs run as HTTP calls into these pods, so it bounds
+    # their statements too. The RDS parameter group holds the 120s backstop.
+    APP_STATEMENT_TIMEOUT_MS:
+      type: kv
+      value: "30000"
     CHAIN_RPC_CONFIG:
       type: parameterStore
       name: chain-rpc-config
@@ -119,6 +127,33 @@ app:
         args:
           - |
             set -e
+            # KEEP-1305: this container opts out of the request-path
+            # statement_timeout. A migration file runs as one transaction and its
+            # DDL can wait far longer than 30s for a lock, so the 30s app-pool cap
+            # and the 120s RDS parameter-group cap would abort it mid-deploy.
+            # lock_timeout replaces the cap that statement_timeout=0 removes: a
+            # migration that cannot take its lock fails the deploy instead of
+            # wedging every reader on the table behind a pending
+            # AccessExclusiveLock. 60s outlasts a normal app statement (capped at
+            # 30s) and still gives up well before an operator psql session does.
+            #
+            # Both settings go on the URL as bare parameters. Verified 2026-09-03
+            # against Postgres 17 that this is the only form that both reaches the
+            # server through BOTH drivers - drizzle-kit and world-postgres use
+            # `pg`, the tsx seed and backfill use `postgres.js` - and overrides the
+            # pool-level connection option lib/db sets. The `options=-c ...` form
+            # loses to that pool option and silently leaves the 30s cap in place,
+            # and PGOPTIONS reaches `pg` only.
+            if [ -z "${DATABASE_URL:-}" ]; then
+              echo "[deploy] DATABASE_URL is empty, refusing to migrate" >&2
+              exit 1
+            fi
+            case "$DATABASE_URL" in
+              *\?*) MIGRATOR_URL="${DATABASE_URL}&statement_timeout=0&lock_timeout=60000" ;;
+              *)    MIGRATOR_URL="${DATABASE_URL}?statement_timeout=0&lock_timeout=60000" ;;
+            esac
+            export DATABASE_URL="$MIGRATOR_URL"
+            export WORKFLOW_POSTGRES_URL="$MIGRATOR_URL"
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
             # Called by path, not through the `bootstrap` bin: .npmrc public-hoists

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -90,9 +90,47 @@ const globalForDb = globalThis as unknown as {
   metricsDb: PostgresJsDatabase<typeof schema> | undefined;
 };
 
+// statement_timeout is set once on every app-pool connection (not per query).
+// It bounds a single statement, not a request and not a job, so a handler that
+// issues many short queries is unaffected. Before KEEP-1305 this pool had no
+// bound at all: on 2026-09-02 about 40 analytics queries each ran for more than
+// an hour on the 2-vCPU prod instance and starved the dispatchers, which page
+// off the same database.
+//
+// 30s matches what keeperhub-executor/index.ts and
+// keeperhub-executor/workflow-runner.ts already set on their own pools, so
+// every request-shaped pool now carries the same bound.
+//
+// Two things this value reaches that are not obvious. The CronJobs (reaper,
+// reconciler, digest, the billing and security scans) do not open their own
+// connections - they are signed HTTP calls into these same pods, so their SQL
+// runs on this pool. And the workflow runner imports lib/db transitively for
+// step logging, so runner pods use this pool too, not only their own.
+//
+// The RDS parameter group holds a 120s backstop for everything that shares the
+// keeperhub role, including migrations and operator psql sessions. This value
+// is the tighter request-path bound and must stay below it. The migrator opts
+// out through statement_timeout on its DSN, so raising this number is never the
+// way to make a migration pass.
+//
+// Override with APP_STATEMENT_TIMEOUT_MS. A cancelled statement surfaces as
+// Postgres 57014.
+const parsedAppTimeoutMs = Number.parseInt(
+  process.env.APP_STATEMENT_TIMEOUT_MS ?? "",
+  10
+);
+const APP_STATEMENT_TIMEOUT_MS =
+  Number.isFinite(parsedAppTimeoutMs) && parsedAppTimeoutMs > 0
+    ? parsedAppTimeoutMs
+    : 30_000;
+
 // For queries - reuse connection in development
 const queryClient =
-  globalForDb.queryClient ?? postgres(connectionString, { max: 10 });
+  globalForDb.queryClient ??
+  postgres(connectionString, {
+    max: 10,
+    connection: { statement_timeout: APP_STATEMENT_TIMEOUT_MS },
+  });
 export const db = globalForDb.db ?? drizzle(queryClient, { schema });
 
 // Dedicated pool for the /api/metrics/db scrape aggregations. The collector

--- a/tests/unit/db-pool-statement-timeout.test.ts
+++ b/tests/unit/db-pool-statement-timeout.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The app pool carries a per-statement timeout (KEEP-1305).
+ *
+ * Before this, lib/db's main pool had no bound at all, and on 2026-09-02 about
+ * 40 analytics queries each ran for more than an hour on prod. The CronJobs are
+ * signed HTTP calls into the same pods, so they share this pool, and the
+ * workflow runner reaches it transitively for step logging. That makes the
+ * option below the single request-path bound for almost every query the
+ * platform issues, which is worth asserting against the real module rather
+ * than against a hand-written copy of the config.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type PoolOptions = {
+  max?: number;
+  connection?: { statement_timeout?: number };
+};
+
+const postgresMock = vi.fn<
+  (url: string, options?: PoolOptions) => { end: () => void }
+>(() => ({
+  end: vi.fn(),
+}));
+
+vi.mock("postgres", () => ({ default: postgresMock }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: vi.fn(() => ({})) }));
+
+/**
+ * Re-import lib/db under the current env and return the pool option objects.
+ *
+ * tests/setup.ts mocks "@/lib/db" for every suite, so this has to reach past
+ * that mock with importActual to get the real module. The "postgres" mock above
+ * still applies, so no connection is opened.
+ */
+async function loadPoolOptions(): Promise<PoolOptions[]> {
+  postgresMock.mockClear();
+  // lib/db parks its clients on globalThis outside production so HMR does not
+  // exhaust connections. vi.resetModules() clears the module registry but not
+  // globalThis, so without this the second load reuses the first pool and never
+  // calls postgres() again.
+  for (const key of ["queryClient", "db", "metricsClient", "metricsDb"]) {
+    delete (globalThis as unknown as Record<string, unknown>)[key];
+  }
+  await vi.importActual("@/lib/db");
+  return postgresMock.mock.calls.map((call) => call[1] ?? {});
+}
+
+/** The main query pool is the only one built with max: 10. */
+function queryPool(options: PoolOptions[]): PoolOptions {
+  const pool = options.find((o) => o.max === 10);
+  if (!pool) {
+    throw new Error(
+      `no pool with max:10 among ${JSON.stringify(options)} - lib/db changed shape`
+    );
+  }
+  return pool;
+}
+
+describe("app pool statement_timeout", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("bounds the main query pool at 30s by default", async () => {
+    process.env.APP_STATEMENT_TIMEOUT_MS = undefined;
+    delete process.env.APP_STATEMENT_TIMEOUT_MS;
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBe(30_000);
+  });
+
+  it("takes the override from APP_STATEMENT_TIMEOUT_MS", async () => {
+    process.env.APP_STATEMENT_TIMEOUT_MS = "45000";
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBe(45_000);
+  });
+
+  it.each(["", "not-a-number", "0", "-1"])(
+    "falls back to 30s when the override is %j",
+    async (value) => {
+      process.env.APP_STATEMENT_TIMEOUT_MS = value;
+
+      const pool = queryPool(await loadPoolOptions());
+
+      expect(pool.connection?.statement_timeout).toBe(30_000);
+    }
+  );
+
+  it("stays below the 120s RDS parameter-group backstop", async () => {
+    delete process.env.APP_STATEMENT_TIMEOUT_MS;
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBeLessThan(120_000);
+  });
+});


### PR DESCRIPTION
## What this changes

Two things, on the same seam.

1. The main `lib/db` pool now carries a per-statement `statement_timeout`,
   30000 ms by default, overridable with `APP_STATEMENT_TIMEOUT_MS`.
2. The `db-migration` initContainer opts out of it, by rewriting its own
   connection string with `statement_timeout=0&lock_timeout=60000`.

## Why

The main pool had no bound at all. On 2026-09-02 about 40 analytics queries each
ran for more than an hour on the 2-vCPU prod instance, pinned both vCPUs for 87
minutes, and starved the dispatchers that page off the same database.

30s is not a new number here. `keeperhub-executor/index.ts:113` and
`keeperhub-executor/workflow-runner.ts:102` already set exactly
`connection: { statement_timeout: 30_000 }` on their own pools, and the metrics
pool at `lib/db/index.ts` already sets 8000 the same way. This makes every
request-shaped pool carry the same bound.

## Two consumers of this pool that are not obvious

Worth stating, because they decide whether 30s is safe:

- **The CronJobs do not open their own connections.** All nine of them run
  `deploy/scripts/reaper.sh` or `digest-cron.sh`, which are signed `curl` calls
  into `http://keeperhub-common:3000/api/...`. So the reaper, the reconciler,
  the digest and the billing and security scans all run their SQL on this pool,
  inside a normal HTTP request.
- **The workflow runner reaches this pool transitively**, through
  `lib/workflow/executor/logging.ts` and friends, for step logging. Runner pods
  use it as well as their own 30s pool.

`statement_timeout` bounds one statement, not a request and not a job. The daily
digest takes 19 minutes at its worst, but that is wall-clock across a loop of
small per-org queries, so it is unaffected. The reaper's 480 s pre-query is
already gone: #2265 reached prod through #2286, and its statements are now
sub-3s.

## Why the migrator needs the opposite treatment

A migration file runs as one transaction and its DDL can wait far longer than
30s for a lock. `ALTER TABLE workflow_execution_logs ADD COLUMN` from
`drizzle/0117_keep_857_exec_log_network_gas.sql` has taken 546 s in prod, almost
all of it lock wait. 60 of 149 migrations contain `CREATE INDEX` and only 16
carry the `@requires-db-prep` directive, so a future migration that forgets it
would abort mid-deploy and roll its whole file back.

`lock_timeout=60000` replaces the cap that `statement_timeout=0` removes. Without
it, a migration waiting on a lock wedges every reader on the table behind a
pending `AccessExclusiveLock`, which is worse than a failed deploy. 60s outlasts
a normal app statement, which is now capped at 30s, and still gives up well
before an operator `psql` session does.

## Why the settings go on the URL as bare parameters

This one is easy to get subtly wrong, so it is verified rather than reasoned
about. Probed against Postgres 17 with both drivers the migrator actually uses
(`drizzle-kit migrate` and `world-postgres` take the `pg` branch because `pg`
8.20.0 is installed; the `tsx` seed and backfill use `postgres.js`):

| form | `pg` | `postgres.js` | overrides the pool option? |
| --- | --- | --- | --- |
| `?statement_timeout=0` | yes | yes | **yes** |
| `?options=-c%20statement_timeout%3D0` | yes | yes | **no** |
| `PGOPTIONS` | yes | no | n/a |

The `options=` form reaches the server but loses to the pool-level `connection`
option, so it would have left the 30s cap silently in place while the config
read as if the migrator had opted out. Only the bare form does both jobs.

`scripts/encode-pg-url.ts` preserves the appended parameters on both its fast
path and its manual-encoding path, checked with a password containing
`+ / = @ :`.

The initContainer also fails closed on an empty `DATABASE_URL` rather than
migrating against `getDatabaseUrl`'s localhost default.

## Companion change

The RDS parameter group gets a 120s backstop for everything that shares the
`keeperhub` role, including migrations and operator `psql` sessions:
techops-services/infrastructure#345. That PR also carries the runbook for
removing the hand-applied `ALTER ROLE` that currently shadows it.

## Behaviour change to expect

The analytics dashboard will return an error instead of hanging for the largest
organizations. That is the point of the change, and it is handled: every
analytics route already wraps its work in `try/catch` and returns `apiError`, so
a `57014` becomes a clean JSON 500, not an unhandled throw.

It will not page. `apiError` increments `keeperhub_api_errors_total`, and the P2
"API Errors Spike" alert is scoped to `org_slug=~"techops-services|ajna"`. On
live prod that metric has exactly one series over the last 7 days and it carries
no `org_slug` label, so the alert's query returns empty. (Worth a separate look
on its own merits.)

#2269 is still open and carries the step-log subquery fixes, so landing it
shortens the tail this change now truncates.

## Tests

`tests/unit/db-pool-statement-timeout.test.ts` loads the real `lib/db` past the
global mock in `tests/setup.ts` with `importActual`, mocks `postgres`, and
asserts the options the pool is **actually built with** - the default, the
override, four bad override values, and that it stays under the 120s backstop.
It fails 7/7 with the `lib/db/index.ts` change reverted and passes 7/7 with it.

The existing `tests/unit/workflow-runner.test.ts` block for the same setting
builds an object literal and asserts against itself, so it would not catch a
regression. This one does not follow that pattern.

## Local CI mirror

All green before pushing: `pnpm check`, `pnpm discover-plugins` + `pnpm
type-check`, `pnpm type-check:executor`, `pnpm check:api-docs` with no
`specs/api-coverage.json` drift, the three `Forbid ...` greps from the `lint`
job run verbatim from the workflow file, `next build` with the Dockerfile's
build-time env, and `pnpm test:unit __tests__ keeperhub-metrics-collector`
(599 files, 22072 tests).

Not run locally: `e2e-playwright-ephemeral`, and the ECR-cached image build,
which needs runner credentials. `migrate-check` does not apply, since its gate
is `^(drizzle/|lib/db/schema)` and this touches neither.
