### PR TITLE
perf: make the analytics summary index-only and stop the SSE retry loop

### DIFF
--- a/app/api/analytics/stream/route.ts
+++ b/app/api/analytics/stream/route.ts
@@ -5,7 +5,7 @@ import {
   getAnalyticsSummary,
 } from "@/lib/analytics/queries";
 import { createAnalyticsStreamStart } from "@/lib/analytics/stream-start";
-import { parseTimeRange } from "@/lib/analytics/time-range";
+import { getTimeRangeStart, parseTimeRange } from "@/lib/analytics/time-range";
 import { apiError } from "@/lib/api-error";
 import { requireOrganization } from "@/lib/middleware/require-org";
 
@@ -26,6 +26,11 @@ export const GET = requireOrganization(
       const customEnd = params.get("customEnd") ?? undefined;
       const projectId = params.get("projectId") ?? undefined;
 
+      // Resolved once, for the life of the stream. The checksum only has to
+      // detect change inside the window this stream is watching, and a fixed
+      // bound also stops the window sliding from registering as a change.
+      const rangeStart = getTimeRangeStart(range, customStart);
+
       const start = createAnalyticsStreamStart({
         signal: req.signal,
         organizationId,
@@ -34,7 +39,8 @@ export const GET = requireOrganization(
         customEnd,
         projectId,
         deps: {
-          getChecksum: getAnalyticsChecksum,
+          getChecksum: (orgId: string) =>
+            getAnalyticsChecksum(orgId, rangeStart),
           getSummary: getAnalyticsSummary,
         },
       });

--- a/drizzle/0150_keep_1333_summary_covering_index.sql
+++ b/drizzle/0150_keep_1333_summary_covering_index.sql
@@ -1,0 +1,53 @@
+-- @requires-db-prep
+-- KEEP-1333: covering index for the analytics summary aggregates.
+--
+-- /api/analytics/summary?range=30d returned 500 with "canceling statement due to
+-- statement timeout". On 2026-09-04 one organization's dashboard produced 246
+-- statement timeouts in 51 minutes and held the database on its provisioned read
+-- ceiling for the whole window.
+--
+-- The queries are getWorkflowCounts and getWorkflowGasTotal in
+-- lib/analytics/queries.ts, plus the same join in computeTimeSeries. They all share
+-- one predicate: workflow_id IN (the org's workflows) AND started_at within a
+-- window. computeAnalyticsSummary runs the first pair twice, once for the window
+-- and once for the previous period.
+--
+-- idx_workflow_executions_workflow_started (workflow_id, started_at DESC) from 0024
+-- already matches that predicate, but it carries no payload, so status, duration
+-- and gas_used_wei are read from the heap one row at a time. On the organization
+-- that triggered the incident a single 30-day aggregate was 173,893 heap blocks and
+-- 424,088 buffer touches. Four of those run concurrently per request. Warm they
+-- finish; cold they are 174k random reads and they do not.
+--
+-- Adding the payload makes the aggregates index-only. Measured with EXPLAIN on the
+-- same organization and window: total cost 437,397 with a bitmap heap scan, 26,216
+-- reading indexed columns only - and the planner stops degrading the workflows side
+-- to a parallel sequential scan. The table's visibility map is fully set, so the
+-- heap access really does drop to zero rather than moving to a recheck.
+--
+-- Key columns and their order mirror 0024's index exactly. This is therefore a
+-- strict superset: it serves everything that one serves, DESC included, so 0024's
+-- index becomes redundant and is dropped in a follow-up once this one is confirmed
+-- to have taken over.
+--
+-- NOT partial on deleted_at IS NULL. The summary aggregates carry no such
+-- predicate - only the runs and facets queries do - so a partial index would be
+-- unusable by exactly the queries this fixes. If the summary is ever made
+-- consistent with the runs table, this index has to be revisited or the heap
+-- fetches come straight back.
+--
+-- Cost: one more B-tree entry per insert and per non-HOT update on a hot table.
+-- HOT eligibility does not change. status and duration are already indexed by
+-- idx_workflow_executions_status, idx_workflow_executions_status_duration and
+-- idx_workflow_executions_stats_covering, so updates touching them were already
+-- non-HOT. gas_used_wei is newly indexed, but it is written by the same finalize
+-- UPDATE that sets status and duration, which was non-HOT for that reason already.
+--
+-- On large environments apply out-of-band as CREATE INDEX CONCURRENTLY IF NOT
+-- EXISTS (see the @requires-db-prep runbook). The build exceeds statement_timeout,
+-- so that session needs SET statement_timeout = 0. The transaction-safe form below
+-- then no-ops on deploy.
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_workflow_started_covering"
+  ON "workflow_executions" ("workflow_id", "started_at" DESC)
+  INCLUDE ("status", "duration", "gas_used_wei");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1051,6 +1051,13 @@
       "when": 1788348699824,
       "tag": "0149_keep_1308_exec_logs_execution_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 150,
+      "version": "7",
+      "when": 1788517619226,
+      "tag": "0150_keep_1333_summary_covering_index",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -2133,25 +2133,57 @@ export async function getSpendCapData(organizationId: string): Promise<{
 /**
  * Get a lightweight checksum for SSE change detection.
  * Returns max timestamps + active count so we know when to push updates.
+ *
+ * `rangeStart` is the lower bound of the window the stream is watching. A run
+ * that started before the window cannot change what that window summarises, so
+ * bounding by it is exact rather than an approximation.
+ *
+ * The run-side MAX is a lateral per workflow, not a plain aggregate over the
+ * join, because the two plan nothing alike. An aggregate over the join has to
+ * read every row it might be the maximum of; the lateral lets the planner turn
+ * each workflow into an index-only scan with LIMIT 1. Measured on the busiest
+ * organization over 30 days: 424 ms and 152,914 buffers unbounded, 120 ms and
+ * 78,496 bounded, 2 ms and 1,189 as the lateral. This runs every poll interval
+ * for every connected viewer, only to answer "has anything changed", so the
+ * difference is what it costs to have the dashboard open.
+ *
+ * The active-run count is deliberately left unbounded: the summary's activeRuns
+ * is unbounded too, and the two have to agree.
  */
 export async function getAnalyticsChecksum(
-  organizationId: string
+  organizationId: string,
+  rangeStart: Date
 ): Promise<string> {
+  // Bound as ISO text for the same reason the step-log scan is: a raw template
+  // has no column to map a Date through, the way the comparison helpers do.
+  const from = rangeStart.toISOString();
+
   const [wfMax, deMax, activeCount] = await Promise.all([
     db
-      .select({
-        maxStarted: sql<string>`COALESCE(MAX(${workflowExecutions.startedAt}), '1970-01-01')::text`,
-      })
-      .from(workflowExecutions)
-      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-      .where(eq(workflows.organizationId, organizationId))
-      .then((r) => r[0]?.maxStarted ?? ""),
+      .execute<{ max_started: string }>(
+        sql`
+    SELECT COALESCE(MAX(latest.started_at), '1970-01-01')::text AS max_started
+      FROM ${workflows} AS scoped_wf
+      CROSS JOIN LATERAL (
+        SELECT MAX(${workflowExecutions.startedAt}) AS started_at
+          FROM ${workflowExecutions}
+         WHERE ${workflowExecutions.workflowId} = scoped_wf.id
+           AND ${workflowExecutions.startedAt} >= ${from}
+      ) AS latest
+     WHERE scoped_wf.organization_id = ${organizationId}`
+      )
+      .then((r) => r[0]?.max_started ?? ""),
     db
       .select({
         maxCreated: sql<string>`COALESCE(MAX(${directExecutions.createdAt}), '1970-01-01')::text`,
       })
       .from(directExecutions)
-      .where(eq(directExecutions.organizationId, organizationId))
+      .where(
+        and(
+          eq(directExecutions.organizationId, organizationId),
+          gte(directExecutions.createdAt, rangeStart)
+        )
+      )
       .then((r) => r[0]?.maxCreated ?? ""),
     db
       .select({ count: count() })

--- a/lib/analytics/stream-start.ts
+++ b/lib/analytics/stream-start.ts
@@ -8,6 +8,7 @@ export const POLL_INTERVAL_MS = 5000;
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_LIFETIME_MS = 5 * 60 * 1000;
 export const MIN_EVENT_INTERVAL_MS = 1000;
+export const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 function formatSSE(event: AnalyticsStreamEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
@@ -29,6 +30,7 @@ export type AnalyticsStreamConfig = {
   heartbeatIntervalMs?: number;
   maxLifetimeMs?: number;
   minEventIntervalMs?: number;
+  maxConsecutiveFailures?: number;
 };
 
 export type AnalyticsStreamOpts = {
@@ -61,6 +63,8 @@ export function createAnalyticsStreamStart(
   const maxLifetimeMs = config?.maxLifetimeMs ?? MAX_LIFETIME_MS;
   const minEventIntervalMs =
     config?.minEventIntervalMs ?? MIN_EVENT_INTERVAL_MS;
+  const maxConsecutiveFailures =
+    config?.maxConsecutiveFailures ?? MAX_CONSECUTIVE_POLL_FAILURES;
 
   return (controller): void => {
     const encoder = new TextEncoder();
@@ -69,6 +73,8 @@ export function createAnalyticsStreamStart(
     let lastChecksum = "";
     let lastEventTime = 0;
     let closed = false;
+    let primed = false;
+    let consecutiveFailures = 0;
 
     const safeClose = (): void => {
       if (closed) {
@@ -132,6 +138,22 @@ export function createAnalyticsStreamStart(
           return;
         }
 
+        // The poll itself worked, so the stream is healthy. Only the checksum
+        // read counts towards giving up; a failing summary deliberately keeps
+        // the stream open (see the catch).
+        consecutiveFailures = 0;
+
+        // The first checksum only records where this stream started. The client
+        // already fetched the summary over HTTP when it mounted, so pushing one
+        // here buys it nothing - and because maxLifetimeMs closes every stream
+        // after a few minutes, doing so made every viewer force a full summary
+        // recompute on every reconnect, whether or not anything had changed.
+        if (!primed) {
+          primed = true;
+          lastChecksum = checksum;
+          return;
+        }
+
         if (checksum === lastChecksum) {
           return;
         }
@@ -152,7 +174,15 @@ export function createAnalyticsStreamStart(
 
         safeEnqueue(chunk);
       } catch {
-        safeClose();
+        // One failed poll is not fatal. Closing here sent the browser straight
+        // into a reconnect, and the reconnect re-ran the work that had just
+        // failed, which is how a single slow query turned into a sustained
+        // burst on 2026-09-04. Skip the tick instead, and give up only once the
+        // checksum read itself has failed repeatedly.
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= maxConsecutiveFailures) {
+          safeClose();
+        }
       }
     }, pollIntervalMs);
 

--- a/tests/e2e/vitest/analytics-checksum.db.test.ts
+++ b/tests/e2e/vitest/analytics-checksum.db.test.ts
@@ -1,0 +1,196 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  organization,
+  users,
+  workflowExecutions,
+  workflows,
+} from "../../../lib/db/schema";
+
+// vitest runs in Node, not an SSR context.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally stubs @/lib/db; this suite needs the checksum to hit
+// Postgres. The run-side MAX is a hand-written lateral rather than a builder
+// query, so nothing else in the suite would catch a malformed statement, a
+// wrong window bound, or a lateral that only sees one workflow.
+vi.unmock("@/lib/db");
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+const PREFIX = "test_checksum_";
+const ORG_ID = `${PREFIX}org`;
+const EMPTY_ORG_ID = `${PREFIX}org_empty`;
+const USER_ID = `${PREFIX}user`;
+// Two workflows, because a lateral evaluates per workflow and a rewrite that
+// stopped aggregating across them would still look right with only one.
+const WORKFLOW_A = `${PREFIX}wf_a`;
+const WORKFLOW_B = `${PREFIX}wf_b`;
+
+const SENTINEL = "1970-01-01 00:00:00";
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+// Truncated to the second: started_at is `timestamp without time zone` and the
+// checksum renders it as text, so comparing against a millisecond-bearing Date
+// would compare two different string shapes.
+function atSecond(date: Date): Date {
+  const copy = new Date(date);
+  copy.setMilliseconds(0);
+  return copy;
+}
+
+const OLDEST = atSecond(daysAgo(40));
+const NEWEST_IN_WINDOW = atSecond(daysAgo(2));
+const MIDDLE = atSecond(daysAgo(20));
+
+function pgText(date: Date): string {
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d+Z$/, "");
+}
+
+describe.skipIf(SKIP)("getAnalyticsChecksum", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let getAnalyticsChecksum: (
+    organizationId: string,
+    rangeStart: Date
+  ) => Promise<string>;
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    db = drizzle(queryClient);
+    await cleanup();
+
+    const now = new Date();
+
+    await db.insert(organization).values([
+      { id: ORG_ID, name: "checksum org", slug: ORG_ID, createdAt: now },
+      {
+        id: EMPTY_ORG_ID,
+        name: "checksum empty org",
+        slug: EMPTY_ORG_ID,
+        createdAt: now,
+      },
+    ]);
+    await db.insert(users).values({
+      id: USER_ID,
+      email: `${USER_ID}@keeperhub.test`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(workflows).values([
+      {
+        id: WORKFLOW_A,
+        name: "checksum workflow a",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+      {
+        id: WORKFLOW_B,
+        name: "checksum workflow b",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+    ]);
+
+    await db.insert(workflowExecutions).values([
+      // Outside a 30-day window. The newest run the org has overall, if the
+      // bound were dropped this would be the answer for every case below.
+      {
+        id: `${PREFIX}exec_old`,
+        workflowId: WORKFLOW_A,
+        userId: USER_ID,
+        status: "success",
+        startedAt: OLDEST,
+        completedAt: OLDEST,
+        totalSteps: "1",
+        completedSteps: "1",
+      },
+      // Inside the window, on workflow A.
+      {
+        id: `${PREFIX}exec_mid`,
+        workflowId: WORKFLOW_A,
+        userId: USER_ID,
+        status: "success",
+        startedAt: MIDDLE,
+        completedAt: MIDDLE,
+        totalSteps: "1",
+        completedSteps: "1",
+      },
+      // Inside the window and the newest of all, on the OTHER workflow, so the
+      // answer can only be right if the lateral aggregates across workflows.
+      {
+        id: `${PREFIX}exec_new`,
+        workflowId: WORKFLOW_B,
+        userId: USER_ID,
+        status: "running",
+        startedAt: NEWEST_IN_WINDOW,
+        completedAt: null,
+        totalSteps: "1",
+        completedSteps: "0",
+      },
+    ]);
+
+    ({ getAnalyticsChecksum } = await import("@/lib/analytics/queries"));
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  it("returns the newest run in the window, across every workflow in the org", async () => {
+    const checksum = await getAnalyticsChecksum(ORG_ID, daysAgo(30));
+
+    // max started_at | max direct created_at | active runs
+    expect(checksum).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+  });
+
+  it("ignores runs that started before the window", async () => {
+    // A 25-day window still contains MIDDLE; a 10-day one does not, and the
+    // 40-day-old run must not resurface in either.
+    const wide = await getAnalyticsChecksum(ORG_ID, daysAgo(25));
+    const narrow = await getAnalyticsChecksum(ORG_ID, daysAgo(10));
+
+    expect(wide).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+    expect(narrow).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+  });
+
+  it("falls back to the window start excluding everything", async () => {
+    const checksum = await getAnalyticsChecksum(ORG_ID, daysAgo(1));
+
+    // Nothing started in the last day, so both timestamps collapse to the
+    // sentinel. The active count is deliberately unwindowed and still counts.
+    expect(checksum).toBe(`${SENTINEL}|${SENTINEL}|1`);
+  });
+
+  it("returns the sentinel for an organization with no runs", async () => {
+    const checksum = await getAnalyticsChecksum(EMPTY_ORG_ID, daysAgo(30));
+
+    expect(checksum).toBe(`${SENTINEL}|${SENTINEL}|0`);
+  });
+});

--- a/tests/unit/analytics-stream-start.test.ts
+++ b/tests/unit/analytics-stream-start.test.ts
@@ -121,4 +121,120 @@ describe("createAnalyticsStreamStart", () => {
 
     expect(controller.close).toHaveBeenCalledTimes(1);
   });
+
+  // The client already has the summary from its own HTTP fetch on mount, and
+  // maxLifetimeMs forces a reconnect every few minutes. Pushing on the first
+  // checksum therefore made every viewer recompute the summary on a fixed
+  // interval regardless of activity.
+  it("primes on the first poll without computing a summary", async () => {
+    const { opts } = makeOpts();
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(opts.deps.getChecksum).toHaveBeenCalledTimes(1);
+    expect(opts.deps.getSummary).not.toHaveBeenCalled();
+    expect(controller.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("pushes a summary once the checksum moves off the primed value", async () => {
+    const checksums = ["first", "second"];
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(async () => checksums.shift() ?? "second"),
+        getSummary: vi.fn(async () => EMPTY_SUMMARY),
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(opts.deps.getSummary).toHaveBeenCalledTimes(1);
+    expect(controller.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the stream open when a single poll fails", async () => {
+    const getChecksum = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("statement timeout"))
+      .mockResolvedValue("recovered");
+    const { opts } = makeOpts({
+      deps: { getChecksum, getSummary: vi.fn(async () => EMPTY_SUMMARY) },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(getChecksum).toHaveBeenCalledTimes(2);
+    expect(controller.close).not.toHaveBeenCalled();
+  });
+
+  it("closes once the checksum has failed maxConsecutiveFailures times", async () => {
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(() =>
+          Promise.reject(new Error("statement timeout"))
+        ),
+        getSummary: vi.fn(async () => EMPTY_SUMMARY),
+      },
+      config: {
+        pollIntervalMs: 100,
+        heartbeatIntervalMs: 10_000,
+        maxLifetimeMs: 5000,
+        minEventIntervalMs: 50,
+        maxConsecutiveFailures: 3,
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(controller.close).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  // A failing summary is the case that caused the outage. Closing on it sent the
+  // browser into a reconnect that recomputes the very query that just failed, so
+  // only the checksum read counts towards giving up.
+  it("does not close when the summary keeps failing but the checksum works", async () => {
+    let n = 0;
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(async () => {
+          n += 1;
+          return `checksum-${n}`;
+        }),
+        getSummary: vi.fn(() => Promise.reject(new Error("statement timeout"))),
+      },
+      config: {
+        pollIntervalMs: 100,
+        heartbeatIntervalMs: 10_000,
+        maxLifetimeMs: 5000,
+        minEventIntervalMs: 50,
+        maxConsecutiveFailures: 3,
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(650);
+
+    expect(opts.deps.getSummary).toHaveBeenCalled();
+    expect(controller.close).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What was wrong

`GET /api/analytics/summary?range=30d` returned 500 with `canceling statement due to statement timeout`. On 2026-09-04 one organization's dashboard produced **246 statement timeouts between 07:13Z and 08:04Z** across four `keeperhub-common` pods. Every log line I could parse carried the same organization and the same 30-day window.

It was an IO problem, not CPU. Over that window the database sat flat on its provisioned read ceiling for 55 minutes, read latency went from 0.6 ms to 3.5 ms, and CPU only reached 85%. Two things combined to put it there.

### 1. The summary aggregates read the heap for every row

`getWorkflowCounts` and `getWorkflowGasTotal` filter `workflow_id` within an organization plus a `started_at` window. `idx_workflow_executions_workflow_started` already matches that predicate, but it carries no payload, so `status`, `duration` and `gas_used_wei` each cost a heap fetch. `computeAnalyticsSummary` runs the pair twice, once for the window and once for the previous period, so one request paid it four times.

### 2. The SSE stream turned one slow query into a burst

`getAnalyticsChecksum` ran an unbounded `MAX(started_at)` per organization - every execution ever recorded - once per poll interval per viewer, uncached. The stream also seeded `lastChecksum` empty, so the first poll after every connect recomputed the summary, and `MAX_LIFETIME_MS` forces a reconnect every few minutes; every viewer paid a full recompute on a timer regardless of activity. And any single failed poll closed the stream, which sent the browser into a reconnect that re-ran the query that had just failed.

## What changed

**Migration 0150** adds the same key as the existing index with `status`, `duration` and `gas_used_wei` as `INCLUDE`, making the aggregates index-only. `INCLUDE` cannot be expressed in drizzle-orm 0.45.2, so it is SQL-only with no `schema.ts` change and no snapshot, matching `0095` and `0135`. It carries `@requires-db-prep`.

It is deliberately **not** partial on `deleted_at IS NULL`: the summary aggregates have no such predicate, only the runs and facets queries do, so a partial index would be unusable by exactly the queries being fixed. The migration header says so, because adding that filter later would bring the heap fetches straight back.

HOT eligibility does not change. `status` and `duration` are already indexed by three existing indexes, so updates touching them were already non-HOT; `gas_used_wei` is newly indexed but is written by the same finalize UPDATE that sets the other two.

**The checksum** is now bounded to the window the stream watches - a run that started before the window cannot change what that window summarises - and rewritten as a lateral per workflow so the planner can use an index-only scan with `LIMIT 1` instead of reading every row it might be the maximum of.

**The stream** now primes on the first checksum without pushing a summary, since the client already fetched one over HTTP when it mounted. A single failed poll no longer closes it; only repeated checksum failures do.

## Measured

Same organization, same 30-day window, read off production.

| | before | after |
| --- | --- | --- |
| plan | Bitmap Heap Scan | Index Only Scan |
| heap blocks | 173,893 | 0 |
| buffer touches | 424,088 | 88,195 |
| planner cost | 443,807 | 63,359 |
| warm time | 360 ms | 200 ms |

The largest organization, which previously parallel-sequential-scanned the whole table, now also gets a Parallel Index Only Scan.

Checksum, same organization over 30 days: **424 ms / 152,914 buffers** unbounded, 120 ms / 78,496 bounded, **2 ms / 1,189** as the lateral. This runs every poll interval for every connected viewer, only to answer "has anything changed".

I also fired the summary's full six-statement fan-out concurrently against production for the organization that produced the timeouts. It finished in 2.46 s wall clock, including roughly 1 s of exec overhead per call, against a 120 s timeout.

## Database prep

Applied out-of-band as `CREATE INDEX CONCURRENTLY IF NOT EXISTS` with `SET statement_timeout = 0`, so the transaction-safe form in the migration no-ops on deploy.

- **staging**: applied, build took 1.9 s, index VALID at 55 MB
- **production**: applied 2026-09-04 12:12:45Z, build took 14.9 s, index VALID at 382 MB

`SELECT ... WHERE NOT ix.indisvalid` returns zero rows on both. Read IOPS never moved during either build.

## Testing

- Five new cases in `tests/unit/analytics-stream-start.test.ts` covering priming, pushing once the checksum moves, surviving a single failed poll, closing after repeated failures, and staying open while the summary keeps failing. All five fail against the previous implementation.
- New `tests/e2e/vitest/analytics-checksum.db.test.ts` runs the hand-written lateral against a real Postgres. Nothing else in the suite would catch a malformed statement, a wrong window bound, or a lateral that only sees one workflow. I mutation-checked it: dropping the bound and breaking the correlation are both caught.
- I verified the lateral returns identical values to the aggregate across four organizations and four window sizes, including the empty-organization and no-rows-in-window cases.
- Full local pipeline green: `pnpm check`, `check:api-docs`, `type-check`, `type-check:executor`, `discover-plugins`, 22,113 unit tests, 1,030 integration tests, `pnpm build`, and the migration gate on a fresh database (`drizzle-kit generate` prints "nothing to migrate").

## Note for whoever merges

Two other open PRs also add a migration numbered `0150`. The journal test requires file number, `idx` and array position to agree, so whoever merges second has to renumber. Worth a re-check immediately before merge.

## Follow-ups, not here

- Drop `idx_workflow_executions_workflow_started` once the covering superset is confirmed to have taken over.
- The previous period is still recomputed on every request. Caching it needs the sliding window quantized, which changes the KPI delta numbers, so it is a product call.
- The network breakdown still reads the step-log table unbounded over the window.
- The summary counts soft-deleted runs while the runs table below it does not.
