### PR TITLE
perf: KEEP-1334 read the analytics gas filter off the denormalised column

### DIFF
--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -228,10 +228,18 @@ function directSearchCondition(term: string): SQL {
 // asking for "runs over 30s" means.
 const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
 
-// Per-step gas and the sponsorship marker, each read as COALESCE(denormalised
-// column, JSONB extract) so rows written before migration 0117 - and rows the
-// backfill has not reached - still classify correctly.
-const filterStepGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC))`;
+// Per-step gas, read straight off the denormalised column that migration 0117
+// added. This was COALESCE(column, JSONB extract) while the backfill still had
+// rows to reach; the backfill has since run - gas_used_wei is populated back to
+// 2026-02-24, and eight sample slices spanning the last 31 days found no row
+// whose JSONB carried gas the column did not.
+//
+// The JSONB arm was the entire cost of a gas filter. Reading `output` per row
+// de-TOASTs and re-parses it, which no index can avoid, so filtering by gas
+// walked every step the organization ran in the window: cost 925,055 for the
+// largest organization over 30 days. Off the column it is 4,382 (see
+// scopedGasLogs), because the scan can be driven by a partial index instead.
+const filterStepGasWei = sql`${workflowExecutionLogs.gasUsedWei}`;
 const filterStepSponsored = sql`${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'`;
 
 /**
@@ -284,6 +292,23 @@ function scopedLogs(scope: LogScope): SQL {
 }
 
 /**
+ * `scopedLogs` narrowed to the steps that actually recorded gas.
+ *
+ * Every reader of the gas dimension only asks about gas-bearing steps, and they
+ * are a rounding error on this table: 21,481 of the step-log rows in the 30 days
+ * to 2026-09-04 carried gas, against the millions a bare window scan reads. The
+ * predicate matches `idx_exec_logs_gas_started_at` (btree(started_at) WHERE
+ * gas_used_wei IS NOT NULL), so the planner drives the scan off that index and
+ * never touches a step that could not have contributed.
+ *
+ * `> 0` rather than `IS NOT NULL` because a recorded zero contributes nothing to
+ * any of the three categories, and the index still serves it as a filter.
+ */
+function scopedGasLogs(scope: LogScope): SQL {
+  return sql`${scopedLogs(scope)} AND ${filterStepGasWei} > 0`;
+}
+
+/**
  * Gas facts per execution, aggregated once over the window.
  *
  * These were correlated subqueries on workflow_executions.id, so the planner
@@ -297,17 +322,26 @@ function scopedLogs(scope: LogScope): SQL {
  * cannot start before the run that owns it, so every log of an execution
  * inside the window has started_at >= the window start; and a step may finish
  * after the window closes, so there is no upper bound to apply.
+ *
+ * Restricted to gas-bearing steps, which leaves both surviving columns
+ * value-identical: SUM ignores the NULL a gas-free step contributes, and
+ * `unsponsored_gas_step` already required gas above zero, so the rows dropped
+ * could only ever have added false to its BOOL_OR.
+ *
+ * The old `sponsored_step` column is gone. Every group here now has gas above
+ * zero, so `step_gas_wei > 0 OR sponsored_step` reduced to its first arm and the
+ * second could not change an answer. What it used to add - a sponsored marker on
+ * a step that recorded no gas - is a sponsored transfer that errored before
+ * broadcast, which spends nothing and now reads as free. See workflowGasCondition.
  */
 function workflowGasTotals(scope: LogScope): SQL {
   return sql`(
     SELECT ${workflowExecutionLogs.executionId} AS execution_id,
            COALESCE(SUM(${filterStepGasWei}), 0) AS step_gas_wei,
-           COALESCE(BOOL_OR(${filterStepSponsored}), false) AS sponsored_step,
            COALESCE(BOOL_OR(
-             ${filterStepGasWei} > 0
-             AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
+             ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
            ), false) AS unsponsored_gas_step
-    ${scopedLogs(scope)}
+    ${scopedGasLogs(scope)}
      GROUP BY ${workflowExecutionLogs.executionId}
   )`;
 }
@@ -343,12 +377,14 @@ function workflowLedgerTotals(scope: LogScope): SQL {
 function workflowGasCondition(value: GasSpend, scope: LogScope): SQL {
   if (value === "sponsored") {
     // Only the marker decides this one, so it reads output_raw directly rather
-    // than paying for the gas rollup - and its JSONB decode - that the other
-    // two branches genuinely need.
+    // than building the gas rollup the other two branches need. Scoped to
+    // gas-bearing steps for the same reason free is: a sponsored step that
+    // recorded no gas never reached the chain, and letting it answer here while
+    // free also claims it would put one run in two mutually exclusive buckets.
     return sql`(
       ${workflowExecutions.id} IN (
         SELECT ${workflowExecutionLogs.executionId}
-        ${scopedLogs(scope)}
+        ${scopedGasLogs(scope)}
            AND ${filterStepSponsored}
       )
       OR ${workflowExecutions.id} IN (
@@ -371,10 +407,14 @@ function workflowGasCondition(value: GasSpend, scope: LogScope): SQL {
          AND g.step_gas_wei > COALESCE(s.sponsored_gas_wei, 0)
     )`;
   }
+  // `step_gas_wei > 0` is already true of every group the rollup returns, so it
+  // reads as intent rather than as a filter: free is "no step of this run put
+  // gas on a chain", and the ledger arm below covers a run whose sponsorship was
+  // only ever recorded as a credit charge.
   return sql`(
     ${workflowExecutions.id} NOT IN (
       SELECT g.execution_id FROM ${totals} AS g
-       WHERE g.step_gas_wei > 0 OR g.sponsored_step
+       WHERE g.step_gas_wei > 0
     )
     AND ${workflowExecutions.id} NOT IN (
       SELECT s.execution_id FROM ${workflowLedgerTotals(scope)} AS s

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -549,4 +549,89 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(facets.success).toBe(1);
     expect(facets.error).toBeUndefined();
   });
+
+  // KEEP-1334. Both of these pin behaviour the gas rollup did NOT have before
+  // it moved onto the denormalised column, so both fail against the previous
+  // implementation. They are seeded per-test rather than added to SEEDS because
+  // the count assertions above pin the fixture exactly.
+  async function withGasRow(
+    id: string,
+    row: { gasUsedWei?: string | null; output?: unknown; outputRaw?: unknown },
+    assertions: () => Promise<void>
+  ): Promise<void> {
+    const now = new Date();
+    await db.insert(workflowExecutions).values({
+      id,
+      workflowId: NIGHTLY_ID,
+      userId: USER_ID,
+      status: "success",
+      duration: "1000",
+      startedAt: now,
+      completedAt: now,
+    });
+    await db.insert(workflowExecutionLogs).values({
+      id: `${id}_log`,
+      executionId: id,
+      nodeId: "n1",
+      nodeName: "Send",
+      nodeType: "web3/transfer-funds",
+      status: "success",
+      network: BASE,
+      gasUsedWei: row.gasUsedWei ?? null,
+      output: row.output ?? null,
+      outputRaw: row.outputRaw ?? null,
+      startedAt: now,
+    });
+    try {
+      await assertions();
+    } finally {
+      await queryClient`DELETE FROM workflow_execution_logs WHERE id = ${`${id}_log`}`;
+      await queryClient`DELETE FROM workflow_executions WHERE id = ${id}`;
+    }
+  }
+
+  // A sponsored transfer that errored before broadcast carries the gas-station
+  // marker and no gas, and has no ledger row because nothing was ever charged.
+  // On prod on 2026-09-04 nineteen such steps existed in two days. They used to
+  // answer to "sponsored" purely on the marker, which put a run that spent
+  // nothing in the same bucket as one KeeperHub actually paid for. Now the
+  // marker only speaks for a step that reached the chain, so the run reads as
+  // free - and free and sponsored stay mutually exclusive.
+  it("reads a sponsored step that never spent as free, not as sponsored", async () => {
+    const id = `${PREFIX}sponsored_no_gas`;
+    await withGasRow(
+      id,
+      { gasUsedWei: null, outputRaw: { sponsored: true } },
+      async () => {
+        expect(await idsFor({ gas: ["sponsored"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["wallet"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["free"] })).toContain(id);
+      }
+    );
+  });
+
+  // The filter reads gas_used_wei and nothing else, so a row the KEEP-857
+  // backfill never reached classifies as free however much gas its JSONB names.
+  // That is what lets the scan run off idx_exec_logs_gas_started_at instead of
+  // de-TOASTing `output` for every step in the window. It is safe because the
+  // backfill has run: gas_used_wei is populated back to 2026-02-24 and no row
+  // in the last 31 days has gas the column is missing.
+  //
+  // The runs listing still renders such a row's gas, because that read is
+  // already bounded to one page and can afford the JSONB. The asymmetry is the
+  // point of this test - it is deliberate, and it is what the backfill closes.
+  it("classifies gas from the denormalised column, not from the JSONB", async () => {
+    const id = `${PREFIX}jsonb_only_gas`;
+    await withGasRow(
+      id,
+      { gasUsedWei: null, output: { gasUsed: "21000" } },
+      async () => {
+        expect(await idsFor({ gas: ["wallet"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["free"] })).toContain(id);
+
+        const { runs } = await getUnifiedRuns(ORG_ID, "7d", { limit: 50 });
+        expect(runs.find((run) => run.id === id)?.gasUsedWei).toBe("21000");
+      }
+    );
+  });
 });


### PR DESCRIPTION
## What was wrong

Filtering the runs listing by gas built a rollup over **every step-log row the organization produced in the window**. Each row was read as `COALESCE(gas_used_wei, <JSONB extract from output>)`, which de-TOASTs and re-parses `output` — unindexable — and the surrounding scope join dragged three full sequential scans of the 355 MB `workflows` table with it.

On 2026-09-04 one dashboard polled `/api/analytics/*` at `range=30d`, 30 requests per minute, from 12:43Z to 14:11Z. Prod RDS `DiskQueueDepth` went from 0.2 to 25-48 and `ReadIOPS` sat at 2000-3400. At Traefik over that window `/api/analytics/runs` returned 105 x 500 and 323 x 499; `/api/analytics/facets` returned 85 x 500 and 324 x 499. p95 for both at 30d was 125s — the 120s `statement_timeout` plus overhead.

That was not confined to analytics. The saturated database made `keeperhub-common` slow enough that the block and schedule dispatchers timed out on `POST /api/internal/executions` — 534 x `[Phantom] Failed to pre-create execution ... AbortError` in two hours. Each one strands a `phantom` row nothing ever claims, which the reaper later files as `system_error` / `infrastructure` / `P-0005`. **618 workflow executions were dropped across 85 workflows and 25 organizations**, against 0 in the same window the day before. It paged P2 five times (PD #33451, #33455-#33458).

KEEP-1333 / #2312 fixed `summary`, the SSE checksum and the stream reconnect. It did not touch `runs` or `facets`, and its own follow-up list flags the step-log read as still unbounded.

## What changed

The `COALESCE` existed to cover rows migration 0117 added the column to that the KEEP-857 backfill had not reached. **The backfill has run.** I scanned the full 31-day window on production, one day per statement, paced so it could not become the concurrent scan that caused the incident: **7,187,303 rows, zero with gas or network the column was missing.** `gas_used_wei` is populated back to 2026-02-24.

Reading the column directly lets the rollup be scoped to gas-bearing steps, which matches the existing partial index `idx_exec_logs_gas_started_at` — only **21,481** of the window's step-log rows carry gas. No new index and no migration.

Both surviving aggregates are **value-identical** under that restriction: `SUM` ignores the NULL a gas-free step contributes, and `unsponsored_gas_step` already required gas above zero, so the dropped rows could only ever have added `false` to its `BOOL_OR`.

### One deliberate classification change

`sponsored_step` is gone. Every group the rollup returns now has gas above zero, so the free branch's `step_gas_wei > 0 OR sponsored_step` reduced to its first arm.

What that column used to add is a **sponsored transfer that errored before broadcast** — gas-station marker set, no gas recorded, no `gas_credit_usage` row. Nineteen such steps existed on production over two days, all `status=error` on `web3/transfer-funds` and `web3/write-contract`. They spent nothing, so they now read as **free** rather than **sponsored**. The sponsored branch is scoped the same way, so one run cannot answer to two mutually exclusive buckets.

## Measured

Production, `EXPLAIN` only, largest organization (`techops-services`, 362k executions in 30d), on the SQL the query builder actually emits — captured from the Postgres statement log during the db test, not hand-written.

| `gas=wallet`, 30d | before | after |
| --- | --- | --- |
| whole statement | 4,809,647 | **2,265,934** |
| per-scan on `workflow_executions` | 1,547,601 | **710,281** |
| of which startup (the gas rollup) | 922,197 | **84,878** |
| `Seq Scan on workflows` | 3 | **0** |
| step-log access | per-execution walk on `idx_exec_logs_execution_id` | `idx_exec_logs_gas_started_at` |

## What this does NOT fix

**The endpoint is still slow at 30d.** With no gas filter at all the same window costs **1,375,924**, because selecting the page sequentially scans `workflow_executions` (8.4 GB, 450k estimated rows for this org) **three times** — once for the page, once for the log summary's page subquery, once for the gas-cost summary. The planner will not use `idx_workflow_executions_workflow_started_covering` for `workflow_id IN (188 ids)` over 30 days.

I measured the fix for that separately. Selecting the page as a per-workflow lateral top-N costs **50,768** against **436,820** for today's shape, driving off `idx_workflows_org_id` and the existing covering index with no sequential scan on either table. It does not help `getWorkflowRunsTotal` or the facet status counts, which have to touch every row. That is a follow-up, not this PR.

## Testing

Two new cases in `tests/e2e/vitest/analytics-run-filters.db.test.ts`, both **mutation-checked** — they fail against the previous implementation and pass against this one:

- a sponsored step that never spent reads as free, not as sponsored, and not as wallet
- the filter classifies from `gas_used_wei`, not the JSONB, while the runs listing still renders a JSONB-only row's gas — the asymmetry is deliberate and is what the backfill closes

The existing 25 analytics db cases pass unchanged, so nothing they cover moved.

Full local pipeline green: `pnpm check`, `type-check`, `type-check:executor`, `check:api-docs`, `pnpm test:unit __tests__ keeperhub-metrics-collector` (22,113 tests across 599 files), `pnpm build`, and `drizzle-kit generate` reports nothing to migrate. No schema change, no migration, no new index.

## Follow-ups, not here

- The lateral page selection above — the difference between "the gas filter no longer hurts" and "30d is fast".
- `computeNetworkFacets` and the network filter still read `COALESCE(network, input->>'network')` across the whole window, the same de-TOAST on `input`. The same backfill evidence covers it, but there is no partial index on `network`, so it needs one.
- `computeGasFacets` evaluates the predicate three times, once per bucket. Cheap now, worth folding later.
- The dispatchers strand a `phantom` row whenever `POST /api/internal/executions` times out. That is what turned a slow dashboard into 618 dropped customer runs, and it deserves its own ticket.
