### PR TITLE
release: to prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@
 #   DATABASE_URL=postgresql://postgres:postgres@localhost:5433/keeperhub
 DATABASE_URL=
 
+# Per-statement cap on the main application connection pool, in milliseconds.
+# Leave empty to use the built-in 30000. It bounds one statement, not a request,
+# so a handler that issues many short queries is unaffected. Raise it only to
+# unblock a slow read path - a migration opts out through its own connection
+# string instead (KEEP-1305).
+APP_STATEMENT_TIMEOUT_MS=
+
 # better-auth signing key. Generate with: openssl rand -hex 32
 BETTER_AUTH_SECRET=
 

--- a/.github/workflows/pr-checks-events.yml
+++ b/.github/workflows/pr-checks-events.yml
@@ -55,9 +55,6 @@ jobs:
     # (anvil/redis/localstack stuck, or vitest deadlock) worth surfacing
     # as failure rather than burning the default 6h GHA budget.
     timeout-minutes: 15
-    # staging env carries LOCALSTACK_AUTH_TOKEN (the localstack image now
-    # requires it even for community SQS use). Mirrors e2e-tests-ephemeral.
-    environment: staging
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-events-deps
@@ -71,10 +68,9 @@ jobs:
         # Bring up only the services events tests need (anvil, localstack,
         # redis). --wait blocks until healthchecks pass. Excludes test-app /
         # test-dispatcher / test-executor — heavy main-app stack the events
-        # tests don't touch. LOCALSTACK_AUTH_TOKEN is required by the
-        # current localstack/localstack:latest image even for SQS-only use.
-        env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        # tests don't touch. No secrets: test-localstack is pinned to a
+        # LocalStack release that serves community SQS without a licence, so
+        # this job runs identically on a fork, where GitHub passes none.
         run: docker compose --profile test up -d --wait test-anvil test-localstack test-redis
       - name: Run integration tests
         working-directory: keeperhub-events

--- a/app/api/analytics/stream/route.ts
+++ b/app/api/analytics/stream/route.ts
@@ -5,7 +5,7 @@ import {
   getAnalyticsSummary,
 } from "@/lib/analytics/queries";
 import { createAnalyticsStreamStart } from "@/lib/analytics/stream-start";
-import { parseTimeRange } from "@/lib/analytics/time-range";
+import { getTimeRangeStart, parseTimeRange } from "@/lib/analytics/time-range";
 import { apiError } from "@/lib/api-error";
 import { requireOrganization } from "@/lib/middleware/require-org";
 
@@ -26,6 +26,11 @@ export const GET = requireOrganization(
       const customEnd = params.get("customEnd") ?? undefined;
       const projectId = params.get("projectId") ?? undefined;
 
+      // Resolved once, for the life of the stream. The checksum only has to
+      // detect change inside the window this stream is watching, and a fixed
+      // bound also stops the window sliding from registering as a change.
+      const rangeStart = getTimeRangeStart(range, customStart);
+
       const start = createAnalyticsStreamStart({
         signal: req.signal,
         organizationId,
@@ -34,7 +39,8 @@ export const GET = requireOrganization(
         customEnd,
         projectId,
         deps: {
-          getChecksum: getAnalyticsChecksum,
+          getChecksum: (orgId: string) =>
+            getAnalyticsChecksum(orgId, rangeStart),
           getSummary: getAnalyticsSummary,
         },
       });

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -25,6 +25,14 @@ app:
       type: parameterStore
       name: workflow-postgres-url
       parameter_name: /eks/techops-prod/keeperhub/db-url
+    # KEEP-1305: the request-path statement_timeout for the lib/db pool. The
+    # code defaults to the same 30000, so this entry exists to make the value
+    # visible in the deploy config and to let an operator raise it without a
+    # rebuild. The CronJobs run as HTTP calls into these pods, so it bounds
+    # their statements too. The RDS parameter group holds the 120s backstop.
+    APP_STATEMENT_TIMEOUT_MS:
+      type: kv
+      value: "30000"
     CHAIN_RPC_CONFIG:
       type: parameterStore
       name: chain-rpc-config
@@ -170,6 +178,33 @@ app:
         args:
           - |
             set -e
+            # KEEP-1305: this container opts out of the request-path
+            # statement_timeout. A migration file runs as one transaction and its
+            # DDL can wait far longer than 30s for a lock, so the 30s app-pool cap
+            # and the 120s RDS parameter-group cap would abort it mid-deploy.
+            # lock_timeout replaces the cap that statement_timeout=0 removes: a
+            # migration that cannot take its lock fails the deploy instead of
+            # wedging every reader on the table behind a pending
+            # AccessExclusiveLock. 60s outlasts a normal app statement (capped at
+            # 30s) and still gives up well before an operator psql session does.
+            #
+            # Both settings go on the URL as bare parameters. Verified 2026-09-03
+            # against Postgres 17 that this is the only form that both reaches the
+            # server through BOTH drivers - drizzle-kit and world-postgres use
+            # `pg`, the tsx seed and backfill use `postgres.js` - and overrides the
+            # pool-level connection option lib/db sets. The `options=-c ...` form
+            # loses to that pool option and silently leaves the 30s cap in place,
+            # and PGOPTIONS reaches `pg` only.
+            if [ -z "${DATABASE_URL:-}" ]; then
+              echo "[deploy] DATABASE_URL is empty, refusing to migrate" >&2
+              exit 1
+            fi
+            case "$DATABASE_URL" in
+              *\?*) MIGRATOR_URL="${DATABASE_URL}&statement_timeout=0&lock_timeout=60000" ;;
+              *)    MIGRATOR_URL="${DATABASE_URL}?statement_timeout=0&lock_timeout=60000" ;;
+            esac
+            export DATABASE_URL="$MIGRATOR_URL"
+            export WORKFLOW_POSTGRES_URL="$MIGRATOR_URL"
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
             # Called by path, not through the `bootstrap` bin: .npmrc public-hoists

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -25,6 +25,14 @@ app:
       type: parameterStore
       name: workflow-postgres-url
       parameter_name: /eks/techops-staging/keeperhub/db-url
+    # KEEP-1305: the request-path statement_timeout for the lib/db pool. The
+    # code defaults to the same 30000, so this entry exists to make the value
+    # visible in the deploy config and to let an operator raise it without a
+    # rebuild. The CronJobs run as HTTP calls into these pods, so it bounds
+    # their statements too. The RDS parameter group holds the 120s backstop.
+    APP_STATEMENT_TIMEOUT_MS:
+      type: kv
+      value: "30000"
     CHAIN_RPC_CONFIG:
       type: parameterStore
       name: chain-rpc-config
@@ -119,6 +127,33 @@ app:
         args:
           - |
             set -e
+            # KEEP-1305: this container opts out of the request-path
+            # statement_timeout. A migration file runs as one transaction and its
+            # DDL can wait far longer than 30s for a lock, so the 30s app-pool cap
+            # and the 120s RDS parameter-group cap would abort it mid-deploy.
+            # lock_timeout replaces the cap that statement_timeout=0 removes: a
+            # migration that cannot take its lock fails the deploy instead of
+            # wedging every reader on the table behind a pending
+            # AccessExclusiveLock. 60s outlasts a normal app statement (capped at
+            # 30s) and still gives up well before an operator psql session does.
+            #
+            # Both settings go on the URL as bare parameters. Verified 2026-09-03
+            # against Postgres 17 that this is the only form that both reaches the
+            # server through BOTH drivers - drizzle-kit and world-postgres use
+            # `pg`, the tsx seed and backfill use `postgres.js` - and overrides the
+            # pool-level connection option lib/db sets. The `options=-c ...` form
+            # loses to that pool option and silently leaves the 30s cap in place,
+            # and PGOPTIONS reaches `pg` only.
+            if [ -z "${DATABASE_URL:-}" ]; then
+              echo "[deploy] DATABASE_URL is empty, refusing to migrate" >&2
+              exit 1
+            fi
+            case "$DATABASE_URL" in
+              *\?*) MIGRATOR_URL="${DATABASE_URL}&statement_timeout=0&lock_timeout=60000" ;;
+              *)    MIGRATOR_URL="${DATABASE_URL}?statement_timeout=0&lock_timeout=60000" ;;
+            esac
+            export DATABASE_URL="$MIGRATOR_URL"
+            export WORKFLOW_POSTGRES_URL="$MIGRATOR_URL"
             echo "Setting up workflow postgres tables..."
             export WORKFLOW_POSTGRES_URL=$(tsx scripts/encode-pg-url.ts)
             # Called by path, not through the `bootstrap` bin: .npmrc public-hoists

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -718,18 +718,22 @@ services:
       - test
 
   test-localstack:
-    image: localstack/localstack:latest
+    # Pinned, and deliberately not `latest`. LocalStack's CalVer line (the
+    # 2026.* tags `latest` now points at) refuses to start without a valid
+    # LOCALSTACK_AUTH_TOKEN even for community SQS - it exits 55 on "License
+    # activation failed". That made this service unusable on pull requests
+    # from forks, which GitHub does not pass secrets to, so the events
+    # integration job could never pass for an outside contributor. 4.14.0 is
+    # the last release that serves SQS with no credentials at all. These
+    # tests only need community SQS, so the token is not passed here in any
+    # environment: fork runs, team branches and local dev all behave alike.
+    image: localstack/localstack:4.14.0
     container_name: keeperhub-test-localstack
     ports:
       - "4567:4566"
     environment:
       - SERVICES=sqs
       - DEBUG=0
-      # Recent localstack/localstack:latest builds require an auth token
-      # even for community-edition use; without it the container exits 55.
-      # CI passes the team token from GH secrets; local dev needs the var
-      # set in the host shell or .env to use the test profile.
-      - LOCALSTACK_AUTH_TOKEN=${LOCALSTACK_AUTH_TOKEN:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
       interval: 10s

--- a/drizzle/0150_keep_1333_summary_covering_index.sql
+++ b/drizzle/0150_keep_1333_summary_covering_index.sql
@@ -1,0 +1,53 @@
+-- @requires-db-prep
+-- KEEP-1333: covering index for the analytics summary aggregates.
+--
+-- /api/analytics/summary?range=30d returned 500 with "canceling statement due to
+-- statement timeout". On 2026-09-04 one organization's dashboard produced 246
+-- statement timeouts in 51 minutes and held the database on its provisioned read
+-- ceiling for the whole window.
+--
+-- The queries are getWorkflowCounts and getWorkflowGasTotal in
+-- lib/analytics/queries.ts, plus the same join in computeTimeSeries. They all share
+-- one predicate: workflow_id IN (the org's workflows) AND started_at within a
+-- window. computeAnalyticsSummary runs the first pair twice, once for the window
+-- and once for the previous period.
+--
+-- idx_workflow_executions_workflow_started (workflow_id, started_at DESC) from 0024
+-- already matches that predicate, but it carries no payload, so status, duration
+-- and gas_used_wei are read from the heap one row at a time. On the organization
+-- that triggered the incident a single 30-day aggregate was 173,893 heap blocks and
+-- 424,088 buffer touches. Four of those run concurrently per request. Warm they
+-- finish; cold they are 174k random reads and they do not.
+--
+-- Adding the payload makes the aggregates index-only. Measured with EXPLAIN on the
+-- same organization and window: total cost 437,397 with a bitmap heap scan, 26,216
+-- reading indexed columns only - and the planner stops degrading the workflows side
+-- to a parallel sequential scan. The table's visibility map is fully set, so the
+-- heap access really does drop to zero rather than moving to a recheck.
+--
+-- Key columns and their order mirror 0024's index exactly. This is therefore a
+-- strict superset: it serves everything that one serves, DESC included, so 0024's
+-- index becomes redundant and is dropped in a follow-up once this one is confirmed
+-- to have taken over.
+--
+-- NOT partial on deleted_at IS NULL. The summary aggregates carry no such
+-- predicate - only the runs and facets queries do - so a partial index would be
+-- unusable by exactly the queries this fixes. If the summary is ever made
+-- consistent with the runs table, this index has to be revisited or the heap
+-- fetches come straight back.
+--
+-- Cost: one more B-tree entry per insert and per non-HOT update on a hot table.
+-- HOT eligibility does not change. status and duration are already indexed by
+-- idx_workflow_executions_status, idx_workflow_executions_status_duration and
+-- idx_workflow_executions_stats_covering, so updates touching them were already
+-- non-HOT. gas_used_wei is newly indexed, but it is written by the same finalize
+-- UPDATE that sets status and duration, which was non-HOT for that reason already.
+--
+-- On large environments apply out-of-band as CREATE INDEX CONCURRENTLY IF NOT
+-- EXISTS (see the @requires-db-prep runbook). The build exceeds statement_timeout,
+-- so that session needs SET statement_timeout = 0. The transaction-safe form below
+-- then no-ops on deploy.
+
+CREATE INDEX IF NOT EXISTS "idx_workflow_executions_workflow_started_covering"
+  ON "workflow_executions" ("workflow_id", "started_at" DESC)
+  INCLUDE ("status", "duration", "gas_used_wei");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1051,6 +1051,13 @@
       "when": 1788348699824,
       "tag": "0149_keep_1308_exec_logs_execution_id_index",
       "breakpoints": true
+    },
+    {
+      "idx": 150,
+      "version": "7",
+      "when": 1788517619226,
+      "tag": "0150_keep_1333_summary_covering_index",
+      "breakpoints": true
     }
   ]
 }

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -19,6 +19,7 @@ import type {
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { formatError } from "./format-error";
+import type { TokenBucketPacer } from "./pacer";
 
 /**
  * EventListener encapsulates a single workflow's contract-event listener.
@@ -96,9 +97,22 @@ export interface EventListenerOptions {
   providerManager: ChainProviderManager;
 
   /**
+   * Optional per-chain pacer shared by every listener on the same chain.
+   * When set, `pacer.take()` is awaited before forwarding a matched event to
+   * SQS, replacing the fixed random jitter: a lone event forwards
+   * immediately (the bucket holds tokens), a large simultaneous batch is
+   * paced at the bucket's drain rate. When unset the legacy
+   * `jitterMs`/`DEFAULT_JITTER_MS` behaviour applies.
+   */
+  pacer?: TokenBucketPacer;
+
+  /**
    * Maximum jitter applied before forwarding a matched event to SQS.
    * Spreads downstream load when many events fire simultaneously. Tests
    * should pass 0 to keep runs deterministic.
+   *
+   * Ignored when `pacer` is set; kept for the legacy path and for tests of
+   * the jitter branch itself.
    */
   jitterMs?: number;
 }
@@ -197,9 +211,17 @@ export class EventListener {
         return;
       }
 
-      const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
-      if (maxJitter > 0) {
-        await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+      // Pace the dispatch. With a pacer (the production path, see registry)
+      // a lone event forwards immediately and a large batch drains at the
+      // per-chain rate. Without one, keep the legacy random jitter so the
+      // load-spreading property survives for direct/unit constructions.
+      if (this.opts.pacer) {
+        await this.opts.pacer.take();
+      } else {
+        const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
+        if (maxJitter > 0) {
+          await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+        }
       }
 
       // Dedup is best-effort. If the read throws we fall through and

--- a/keeperhub-events/event-tracker/src/listener/event-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/event-listener.ts
@@ -19,7 +19,9 @@ import type {
 import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { formatError } from "./format-error";
+import type { InFlightTracker } from "./in-flight";
 import type { TokenBucketPacer } from "./pacer";
+import { abortableSleep } from "./shutdown";
 
 /**
  * EventListener encapsulates a single workflow's contract-event listener.
@@ -107,6 +109,23 @@ export interface EventListenerOptions {
   pacer?: TokenBucketPacer;
 
   /**
+   * Optional registry-wide tracker for in-flight `onLog` promises. When set,
+   * every dispatch is registered with it so `ListenerRegistry.stopAll` can
+   * wait for handlers that are mid-flight at SIGTERM. Without it a parked or
+   * dispatching event dies with the process: it has no SQS message and no
+   * phantom row yet, and the provider manager keeps no cursor to replay it.
+   */
+  inFlight?: InFlightTracker;
+
+  /**
+   * Optional registry-wide shutdown signal. Once aborted the dispatch stops
+   * parking - both the pacer and the jitter below return immediately - so the
+   * drain that follows costs the dispatch rather than the remaining pace.
+   * Aborting does not cancel an event; it forwards it now.
+   */
+  shutdownSignal?: AbortSignal;
+
+  /**
    * Maximum jitter applied before forwarding a matched event to SQS.
    * Spreads downstream load when many events fire simultaneously. Tests
    * should pass 0 to keep runs deterministic.
@@ -155,7 +174,14 @@ export class EventListener {
       fallbackWssUrl: this.opts.fallbackWssUrl,
       address: this.opts.contractAddress,
       topic0: eventFragment.topicHash,
-      handler: (log) => this.onLog(log),
+      // Registered with the tracker so shutdown can wait for it. `onLog`
+      // swallows its own errors, so the tracked promise never rejects.
+      handler: (log) => {
+        const dispatch = this.onLog(log);
+        return this.opts.inFlight
+          ? this.opts.inFlight.track(dispatch)
+          : dispatch;
+      },
     });
     this.started = true;
     logger.log(
@@ -220,7 +246,10 @@ export class EventListener {
       } else {
         const maxJitter = this.opts.jitterMs ?? DEFAULT_JITTER_MS;
         if (maxJitter > 0) {
-          await new Promise((r) => setTimeout(r, Math.random() * maxJitter));
+          await abortableSleep(
+            Math.random() * maxJitter,
+            this.opts.shutdownSignal,
+          );
         }
       }
 

--- a/keeperhub-events/event-tracker/src/listener/in-flight.ts
+++ b/keeperhub-events/event-tracker/src/listener/in-flight.ts
@@ -1,0 +1,52 @@
+/**
+ * Tracks the tracker's in-flight `onLog` handlers so shutdown can wait for
+ * them. Without a drain, SIGTERM exits mid-dispatch: the matched event has
+ * not reached SQS and has no phantom row behind it, and nothing replays it.
+ * `lastProcessedBlock` lives on the in-memory `ChainEntry` and a fresh
+ * process resumes at `headBlock - 1`, so a killed handler is a trigger that
+ * never fires and never retries.
+ *
+ * This is a copy of `keeperhub-executor/lib/in-flight.ts`, kept in sync by
+ * hand. `@techops/events-tracker` is a standalone package (`rootDir: "."`,
+ * `include: ["src/**", "lib/**"]`) and cannot resolve modules from the root
+ * context, so the executor's class is not importable here.
+ */
+export class InFlightTracker {
+  private readonly pending = new Set<Promise<unknown>>();
+
+  get size(): number {
+    return this.pending.size;
+  }
+
+  /** Register a handler promise; it leaves the set once it settles either way. */
+  track<T>(promise: Promise<T>): Promise<T> {
+    this.pending.add(promise);
+    const remove = (): void => {
+      this.pending.delete(promise);
+    };
+    promise.then(remove, remove);
+    return promise;
+  }
+
+  /**
+   * Resolve true once every tracked promise has settled, including any tracked
+   * while waiting, or false when timeoutMs elapses first (work is still running
+   * and will be cut off by the exit that follows).
+   */
+  drain(timeoutMs: number): Promise<boolean> {
+    if (this.pending.size === 0) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      const settleAll = async (): Promise<void> => {
+        while (this.pending.size > 0) {
+          await Promise.allSettled([...this.pending]);
+        }
+        clearTimeout(timer);
+        resolve(true);
+      };
+      settleAll();
+    });
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/pacer.ts
+++ b/keeperhub-events/event-tracker/src/listener/pacer.ts
@@ -1,3 +1,5 @@
+import { abortableSleep } from "./shutdown";
+
 /**
  * Per-chain token bucket used to pace event dispatch to SQS.
  *
@@ -34,14 +36,22 @@ export class TokenBucketPacer {
   private readonly maxTokens: number;
   private readonly refillPerMs: number;
   private lastRefill: number;
+  private readonly signal?: AbortSignal;
 
   /**
    * @param drainRate - tokens (events) released per second when contended.
    * @param capacity - maximum burst the bucket holds. Defaults to the drain
    *   rate so a single event never waits (it takes one of the available
    *   tokens) while a burst is still smoothed to the configured rate.
+   * @param signal - shutdown signal. Once aborted the bucket stops pacing
+   *   and every `take()` returns immediately, parked callers included. See
+   *   `release` below.
    */
-  constructor(drainRate: number, capacity: number = drainRate) {
+  constructor(
+    drainRate: number,
+    capacity: number = drainRate,
+    signal?: AbortSignal,
+  ) {
     if (!Number.isFinite(drainRate) || drainRate <= 0) {
       throw new Error(
         `TokenBucketPacer: drainRate must be > 0, got ${drainRate}`,
@@ -56,6 +66,7 @@ export class TokenBucketPacer {
     this.maxTokens = capacity;
     this.refillPerMs = drainRate / 1000;
     this.lastRefill = Date.now();
+    this.signal = signal;
   }
 
   /**
@@ -69,6 +80,17 @@ export class TokenBucketPacer {
    * large batch, minus the unconditional mean.
    */
   async take(): Promise<void> {
+    // Release: once shutdown has begun the bucket stops pacing entirely.
+    // Waiting out the drain rate is not an option there - the drain that
+    // follows has a fixed budget (SHUTDOWN_DRAIN_TIMEOUT_MS) and covers only
+    // `budget * drainRate` events, so a burst larger than that would have its
+    // tail killed at exit with no row, no queue entry and no replay. Bursting
+    // the backlog into SQS instead makes the drain cost the dispatch, not the
+    // pacing, and SQS absorbs the burst.
+    if (this.signal?.aborted) {
+      return;
+    }
+
     // Refill from wall-clock so contention state survives between calls and
     // is shared correctly across listeners on the same chain.
     const now = Date.now();
@@ -90,7 +112,7 @@ export class TokenBucketPacer {
     // refills from the new wall-clock and consumes). Bounded by the drain
     // rate, never unbounded.
     const waitMs = Math.ceil((1 - this.tokens) / this.refillPerMs);
-    await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 1000)));
+    await abortableSleep(Math.min(waitMs, 1000), this.signal);
     await this.take();
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/pacer.ts
+++ b/keeperhub-events/event-tracker/src/listener/pacer.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-chain token bucket used to pace event dispatch to SQS.
+ *
+ * Replaces the fixed 0-10s random jitter (`DEFAULT_JITTER_MS`) that every
+ * event-triggered execution paid unconditionally (issue #2290). The jitter
+ * spread downstream load when a block matched many subscriptions, but it cost
+ * a mean 5s on every event, including a single match on an otherwise idle
+ * chain.
+ *
+ * A token bucket keeps the load-spreading property while making the delay
+ * scale with actual contention:
+ * - a single match takes a token that is already available and forwards
+ *   immediately (no fixed mean delay);
+ * - a large simultaneous batch drains at the configured rate, so downstream
+ *   sees the same smoothed arrival the jitter produced, without the arbitrary
+ *   reordering (a bucket preserves arrival order; per-event random sleeps do
+ *   not).
+ *
+ * Backpressure: `take()` never queues. When the bucket is empty the caller
+ * waits (a bounded sleep) and retries, so a burst larger than the drain rate
+ * is paced rather than dropped or buffered without bound. The wait loop is
+ * deliberately a sleep-poll rather than a condition queue: dispatch is
+ * fire-and-forget per log and the bucket is contended by at most the number of
+ * matched logs in one drain pass, so a wait queue would add machinery without
+ * changing the outcome.
+ *
+ * The bucket is created once per chain and shared by every listener on that
+ * chain, which is what makes the pacing global per chain rather than
+ * per-workflow (a single workflow spiking would otherwise pace only itself and
+ * the downstream spike would remain).
+ */
+export class TokenBucketPacer {
+  private tokens: number;
+  private readonly maxTokens: number;
+  private readonly refillPerMs: number;
+  private lastRefill: number;
+
+  /**
+   * @param drainRate - tokens (events) released per second when contended.
+   * @param capacity - maximum burst the bucket holds. Defaults to the drain
+   *   rate so a single event never waits (it takes one of the available
+   *   tokens) while a burst is still smoothed to the configured rate.
+   */
+  constructor(drainRate: number, capacity: number = drainRate) {
+    if (!Number.isFinite(drainRate) || drainRate <= 0) {
+      throw new Error(
+        `TokenBucketPacer: drainRate must be > 0, got ${drainRate}`,
+      );
+    }
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error(
+        `TokenBucketPacer: capacity must be > 0, got ${capacity}`,
+      );
+    }
+    this.tokens = capacity;
+    this.maxTokens = capacity;
+    this.refillPerMs = drainRate / 1000;
+    this.lastRefill = Date.now();
+  }
+
+  /**
+   * Refills the bucket from elapsed time, then waits (if necessary) until a
+   * token is available and consumes it.
+   *
+   * A single event when the bucket is full returns without waiting. Under a
+   * burst the wait is bounded by how long the drain rate needs to release the
+   * next token, so total latency for the tail of a large batch is
+   * `batchSize / drainRate` — the same smoothed arrival the old jitter gave a
+   * large batch, minus the unconditional mean.
+   */
+  async take(): Promise<void> {
+    // Refill from wall-clock so contention state survives between calls and
+    // is shared correctly across listeners on the same chain.
+    const now = Date.now();
+    const elapsed = now - this.lastRefill;
+    if (elapsed > 0) {
+      this.tokens = Math.min(
+        this.maxTokens,
+        this.tokens + elapsed * this.refillPerMs,
+      );
+      this.lastRefill = now;
+    }
+
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return;
+    }
+
+    // Bucket empty: wait for the next token, then recurse (the recursive call
+    // refills from the new wall-clock and consumes). Bounded by the drain
+    // rate, never unbounded.
+    const waitMs = Math.ceil((1 - this.tokens) / this.refillPerMs);
+    await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 1000)));
+    await this.take();
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -5,7 +5,9 @@ import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
 import { formatError } from "./format-error";
+import { InFlightTracker } from "./in-flight";
 import { TokenBucketPacer } from "./pacer";
+import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "./shutdown";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -73,6 +75,13 @@ export class ListenerRegistry {
   private readonly deps: RegistryDeps;
   /** One pacer per chain, shared by every listener on that chain. */
   private readonly pacers = new Map<number, TokenBucketPacer>();
+  /** In-flight `onLog` dispatches across every listener, drained by stopAll. */
+  private readonly inFlight = new InFlightTracker();
+  /**
+   * Aborted by `stopAll` to stop every parked dispatch. Terminal: a registry
+   * that has been stopped is not restarted, the process exits behind it.
+   */
+  private readonly shutdown = new AbortController();
 
   /** Events released per second per chain when a batch contends the bucket. */
   private static readonly DRAIN_RATE_PER_SEC = 50;
@@ -85,7 +94,11 @@ export class ListenerRegistry {
   private pacerFor(chainId: number): TokenBucketPacer {
     let pacer = this.pacers.get(chainId);
     if (!pacer) {
-      pacer = new TokenBucketPacer(ListenerRegistry.DRAIN_RATE_PER_SEC);
+      pacer = new TokenBucketPacer(
+        ListenerRegistry.DRAIN_RATE_PER_SEC,
+        undefined,
+        this.shutdown.signal,
+      );
       this.pacers.set(chainId, pacer);
     }
     return pacer;
@@ -116,6 +129,8 @@ export class ListenerRegistry {
       sqs: this.deps.sqs,
       sqsQueueUrl: this.deps.sqsQueueUrl,
       pacer: this.pacerFor(reg.chainId),
+      inFlight: this.inFlight,
+      shutdownSignal: this.shutdown.signal,
     });
     try {
       await listener.start();
@@ -162,10 +177,42 @@ export class ListenerRegistry {
     return this.entries.size;
   }
 
+  /**
+   * Terminal teardown, called from the SIGTERM path.
+   *
+   * Order is load-bearing. Unsubscribing first removes each listener from the
+   * provider manager's subscriber set, so no further log can start a handler
+   * while an already-dispatched one keeps its captured reference. Aborting
+   * next releases every parked dispatch, which is what keeps the drain inside
+   * its budget: waiting out the pace instead would cover only
+   * `SHUTDOWN_DRAIN_TIMEOUT_MS * drainRate` events and kill the rest. The
+   * drain then waits for the sends themselves.
+   *
+   * Bounded rather than unbounded on purpose: a drain that outlives the K8s
+   * grace period is SIGKILLed with nothing logged. On timeout the remaining
+   * handlers are lost exactly as they are without a drain, but the count is
+   * on the record.
+   */
   async stopAll(): Promise<void> {
     for (const entry of this.entries.values()) {
       entry.listener.stop();
     }
+    this.shutdown.abort();
+
+    const outstanding = this.inFlight.size;
+    if (outstanding > 0) {
+      logger.log(
+        `[ListenerRegistry] draining ${outstanding} in-flight dispatch(es) (up to ${SHUTDOWN_DRAIN_TIMEOUT_MS}ms)`,
+      );
+    }
+    const drained = await this.inFlight.drain(SHUTDOWN_DRAIN_TIMEOUT_MS);
+    if (!drained) {
+      logger.error(
+        `[ListenerRegistry] drain timed out with ${this.inFlight.size} dispatch(es) unfinished; those events are lost`,
+      );
+    }
+
     this.entries.clear();
+    this.pacers.clear();
   }
 }

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -5,6 +5,7 @@ import type { AbiEvent } from "../chains/validation";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
 import { formatError } from "./format-error";
+import { TokenBucketPacer } from "./pacer";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -70,9 +71,24 @@ interface RegistryEntry {
 export class ListenerRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
   private readonly deps: RegistryDeps;
+  /** One pacer per chain, shared by every listener on that chain. */
+  private readonly pacers = new Map<number, TokenBucketPacer>();
+
+  /** Events released per second per chain when a batch contends the bucket. */
+  private static readonly DRAIN_RATE_PER_SEC = 50;
 
   constructor(deps: RegistryDeps) {
     this.deps = deps;
+  }
+
+  /** Returns the shared pacer for a chain, creating it on first use. */
+  private pacerFor(chainId: number): TokenBucketPacer {
+    let pacer = this.pacers.get(chainId);
+    if (!pacer) {
+      pacer = new TokenBucketPacer(ListenerRegistry.DRAIN_RATE_PER_SEC);
+      this.pacers.set(chainId, pacer);
+    }
+    return pacer;
   }
 
   /**
@@ -99,6 +115,7 @@ export class ListenerRegistry {
       dedup: this.deps.dedup,
       sqs: this.deps.sqs,
       sqsQueueUrl: this.deps.sqsQueueUrl,
+      pacer: this.pacerFor(reg.chainId),
     });
     try {
       await listener.start();

--- a/keeperhub-events/event-tracker/src/listener/shutdown.ts
+++ b/keeperhub-events/event-tracker/src/listener/shutdown.ts
@@ -12,13 +12,21 @@
  * How long `stopAll` waits for in-flight handlers before giving up and
  * letting the process exit.
  *
- * Mirrors `SHUTDOWN_TIMEOUT_MS` in `lib/workflow/executor/runner-constants.ts`
- * (25s inside the K8s 30s default grace period), duplicated because this
- * package cannot import from the root context. The buffer matters: a drain
- * that outlives the grace period is SIGKILLed with nothing logged, which is
- * the failure this drain exists to remove.
+ * Sized against the 30s K8s default grace period, not copied from the
+ * executor's 25s: this process still has to tear down the provider manager
+ * (a WSS close per chain) and the health server after the drain returns, and
+ * a drain that outlives the grace period is SIGKILLed with nothing logged -
+ * the exact failure this drain exists to remove.
+ *
+ * 20s is chosen to cover one dispatch stuck on the internal API. A
+ * `createPhantomExecution` that gets no answer spends 3 attempts at
+ * `REQUEST_TIMEOUT_MS = 5_000` plus `RETRY_DELAYS_MS = [500, 1_000]` before
+ * giving up - 16.5s (`lib/phantom.ts`). Nothing under the grace period can
+ * also cover the send-failure path, where `failPhantomExecution` runs the
+ * same ladder again; that case times out and is logged, which is the
+ * designed outcome rather than a gap.
  */
-export const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+export const SHUTDOWN_DRAIN_TIMEOUT_MS = 20_000;
 
 /**
  * Sleeps for `ms`, or returns early when `signal` aborts.

--- a/keeperhub-events/event-tracker/src/listener/shutdown.ts
+++ b/keeperhub-events/event-tracker/src/listener/shutdown.ts
@@ -1,0 +1,58 @@
+/**
+ * Shutdown-time primitives shared by the dispatch path.
+ *
+ * A matched event parks before it is forwarded to SQS - on the pacer under
+ * contention, on the legacy jitter otherwise. That park is the window in
+ * which SIGTERM loses the event outright, so shutdown does two things to it:
+ * it stops the park (this module's signal) and then waits for the handlers
+ * to finish dispatching (`InFlightTracker`).
+ */
+
+/**
+ * How long `stopAll` waits for in-flight handlers before giving up and
+ * letting the process exit.
+ *
+ * Mirrors `SHUTDOWN_TIMEOUT_MS` in `lib/workflow/executor/runner-constants.ts`
+ * (25s inside the K8s 30s default grace period), duplicated because this
+ * package cannot import from the root context. The buffer matters: a drain
+ * that outlives the grace period is SIGKILLed with nothing logged, which is
+ * the failure this drain exists to remove.
+ */
+export const SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;
+
+/**
+ * Sleeps for `ms`, or returns early when `signal` aborts.
+ *
+ * Resolves in both cases - it never rejects. An abort here means "stop
+ * waiting and dispatch now", not "cancel this event". That is the right
+ * trade at shutdown: pacing exists to keep a spike off SQS and the phantom
+ * execution API, and a burst into SQS is recoverable where a dropped trigger
+ * is not. Because it resolves rather than throws, callers need no
+ * abort-specific branch and a parked event follows its normal path straight
+ * through to the send.
+ */
+export function abortableSleep(
+  ms: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    // `onAbort` closes over `timer` before it is declared. Safe: the listener
+    // is registered after the timer is assigned, so the handle always exists
+    // by the time abort can fire.
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -518,6 +518,39 @@ describe("EventListener", () => {
       expect(sqs.send.mock.calls.length).toBe(11);
     });
 
+    it("releases a jittered dispatch immediately when shutdown aborts", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      const controller = new AbortController();
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          // No pacer: this is the legacy jitter branch, which is what the
+          // deployed tracker runs until this PR's pacer reaches it.
+          jitterMs: 10_000,
+          shutdownSignal: controller.signal,
+        }),
+      );
+      await listener.start();
+
+      const started = Date.now();
+      const dispatch = providerMock.capturedHandler!(
+        makeLog({
+          txHash: `0x${"c".repeat(64)}`,
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      controller.abort();
+      await dispatch;
+
+      // Abort forwards the event now rather than cancelling it: the send
+      // still happens, it just does not wait out the remaining jitter.
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+      expect(Date.now() - started).toBeLessThan(500);
+    });
+
     it("applies jitter up to the configured cap before forwarding", async () => {
       const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
       vi.useFakeTimers();

--- a/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/event-listener.test.ts
@@ -16,6 +16,7 @@ import {
   EventListener,
   type EventListenerOptions,
 } from "../../src/listener/event-listener";
+import { TokenBucketPacer } from "../../src/listener/pacer";
 
 // KEEP-693: stub the phantom helpers so the listener does not call the internal
 // API. Default (no id) keeps existing SQS-path tests on the id-less path.
@@ -436,11 +437,88 @@ describe("EventListener", () => {
       expect(sqs.send).toHaveBeenCalledTimes(1);
     });
 
+    it("uses the shared pacer (lone event forwards immediately) instead of jitter", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      // A fresh bucket is full, so the first take() does not wait: a lone
+      // matched event on an idle chain must not pay the old fixed delay.
+      const pacer = new TokenBucketPacer(1000);
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          pacer,
+        }),
+      );
+      await listener.start();
+
+      const started = Date.now();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash:
+            "0x9999000000000000000000000000000000000000000000000000000000000000",
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      expect(sqs.send).toHaveBeenCalledTimes(1);
+      // A full token bucket returns immediately (well under the old 0-10s
+      // jitter cap).
+      expect(Date.now() - started).toBeLessThan(200);
+    });
+
+    it("paces a burst through the shared pacer rather than a per-event sleep", async () => {
+      const providerMock = makeProviderManagerMock();
+      const sqs = makeSqsMock();
+      // Slow drain rate so the pacing effect is measurable with real timers.
+      const pacer = new TokenBucketPacer(10); // 1 token per 100ms
+      const listener = new EventListener(
+        buildOptions({
+          providerManager: providerMock.manager,
+          sqs,
+          pacer,
+        }),
+      );
+      await listener.start();
+
+      // Drain the initial burst (capacity == drain rate == 10).
+      const drain = async () => {
+        for (let i = 0; i < 10; i++) {
+          await providerMock.capturedHandler!(
+            makeLog({
+              txHash: `0x${"a".repeat(60)}${i.toString(16).padStart(4, "0")}`,
+              sender: SENDER,
+              value: 1n,
+            }),
+          );
+        }
+      };
+      const started = Date.now();
+      await drain();
+      const burstElapsed = Date.now() - started;
+      // First 10 = bucket capacity, no waiting expected.
+      expect(burstElapsed).toBeLessThan(500);
+
+      // Next event must wait for the drain rate (100ms per token).
+      const pacedStart = Date.now();
+      await providerMock.capturedHandler!(
+        makeLog({
+          txHash: `0x${"b".repeat(64)}`,
+          sender: SENDER,
+          value: 1n,
+        }),
+      );
+      const pacedElapsed = Date.now() - pacedStart;
+      // The bucket is empty after the 10-token burst, so the 11th event must
+      // wait ~1 drain interval (100ms at 10/s). Allow generous slack for timer
+      // granularity — the point is it waited (vs the burst's ~0ms), not the
+      // exact millisecond.
+      expect(pacedElapsed).toBeGreaterThanOrEqual(50);
+      expect(pacedElapsed).toBeLessThan(500);
+      expect(sqs.send.mock.calls.length).toBe(11);
+    });
+
     it("applies jitter up to the configured cap before forwarding", async () => {
-      // Pin Math.random() to 1 so the jitter is exactly the cap, and use
-      // fake timers so the test does not actually wait. The goal is to
-      // verify the jitter branch executes and respects the cap; precise
-      // timing is out of scope.
       const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
       vi.useFakeTimers();
       try {

--- a/keeperhub-events/event-tracker/tests/unit/in-flight.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/in-flight.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { InFlightTracker } from "../../src/listener/in-flight";
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve: () => void = () => undefined;
+  let reject: (reason: unknown) => void = () => undefined;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("InFlightTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drains immediately when nothing is in flight", async () => {
+    await expect(new InFlightTracker().drain(25_000)).resolves.toBe(true);
+  });
+
+  it("returns the tracked promise unchanged and forgets it once it settles", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+
+    const tracked = tracker.track(work.promise);
+
+    expect(tracked).toBe(work.promise);
+    expect(tracker.size).toBe(1);
+    work.resolve();
+    await tracked;
+    expect(tracker.size).toBe(0);
+  });
+
+  it("forgets a rejected promise too, without adding a rejection of its own", async () => {
+    const tracker = new InFlightTracker();
+    const work = deferred();
+    const tracked = tracker.track(work.promise);
+
+    work.reject(new Error("boom"));
+
+    await expect(tracked).rejects.toThrow("boom");
+    expect(tracker.size).toBe(0);
+  });
+
+  it("waits for every in-flight handler and reports a clean drain", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const second = deferred();
+    tracker.track(first.promise);
+    tracker.track(second.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+    expect(tracker.size).toBe(1);
+
+    second.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+
+  it("gives up once the bound elapses while work is still running", async () => {
+    const tracker = new InFlightTracker();
+    const stuck = deferred();
+    tracker.track(stuck.promise);
+
+    const drained = tracker.drain(25_000);
+    await vi.advanceTimersByTimeAsync(24_999);
+    expect(tracker.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(drained).resolves.toBe(false);
+    // The handler is still running; the caller exits knowing it was cut off.
+    expect(tracker.size).toBe(1);
+    stuck.resolve();
+  });
+
+  it("also waits for a handler tracked after the drain began", async () => {
+    const tracker = new InFlightTracker();
+    const first = deferred();
+    const late = deferred();
+    tracker.track(first.promise);
+
+    const drained = tracker.drain(25_000);
+    let outcome: boolean | undefined;
+    drained.then((value) => {
+      outcome = value;
+    });
+    tracker.track(late.promise);
+
+    first.resolve();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(outcome).toBeUndefined();
+
+    late.resolve();
+    await expect(drained).resolves.toBe(true);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -75,4 +75,37 @@ describe("TokenBucketPacer", () => {
     expect(() => new TokenBucketPacer(0)).toThrow(/drainRate/);
     expect(() => new TokenBucketPacer(-5)).toThrow(/drainRate/);
   });
+
+  it("stops pacing once the shutdown signal aborts, releasing a parked take", async () => {
+    const controller = new AbortController();
+    const drainRate = 10; // 1 token per 100ms
+    const pacer = new TokenBucketPacer(drainRate, undefined, controller.signal);
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // Bucket empty: this take would otherwise wait ~100ms for the next token.
+    const started = Date.now();
+    const parked = pacer.take();
+    controller.abort();
+    await parked;
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it("keeps letting takes through after abort, so a whole backlog bursts", async () => {
+    const controller = new AbortController();
+    const pacer = new TokenBucketPacer(10, undefined, controller.signal);
+    for (let i = 0; i < 10; i++) {
+      await pacer.take();
+    }
+    controller.abort();
+
+    // 100 events at 10/s would be 10s of pacing. After abort they cost nothing:
+    // the drain that follows pays for the sends, not for the remaining pace.
+    const started = Date.now();
+    for (let i = 0; i < 100; i++) {
+      await pacer.take();
+    }
+    expect(Date.now() - started).toBeLessThan(100);
+  });
 });

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TokenBucketPacer } from "../../src/listener/pacer";
+
+describe("TokenBucketPacer", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lets a lone event through immediately when the bucket is full", async () => {
+    const pacer = new TokenBucketPacer(50);
+    const started = Date.now();
+    await pacer.take();
+    // A full bucket holds `capacity` (= drain rate) tokens, so the first take
+    // consumes one without waiting.
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  it("paces a large burst at the drain rate", async () => {
+    const drainRate = 100; // tokens/sec -> 10ms per token
+    const pacer = new TokenBucketPacer(drainRate);
+
+    // Drain the initial burst (capacity == drainRate) instantly.
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // After the burst, each further take must wait ~1/rate.
+    const started = Date.now();
+    for (let i = 0; i < 5; i++) {
+      await pacer.take();
+    }
+    const elapsed = Date.now() - started;
+    // 5 tokens at 100/s = ~50ms, allow generous timer slack both ways.
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("refills over wall-clock time (idle bucket recovers)", async () => {
+    const pacer = new TokenBucketPacer(100); // 1 token per 10ms
+    for (let i = 0; i < 100; i++) {
+      await pacer.take();
+    }
+
+    // Bucket is now empty. Wait ~50ms -> ~5 tokens refilled.
+    await new Promise((r) => setTimeout(r, 60));
+    const started = Date.now();
+    // 5 tokens should be available without waiting.
+    for (let i = 0; i < 5; i++) {
+      await pacer.take();
+    }
+    expect(Date.now() - started).toBeLessThan(100);
+  });
+
+  it("shares one bucket across consumers on the same chain (contention is global)", async () => {
+    const drainRate = 100;
+    const pacer = new TokenBucketPacer(drainRate);
+    for (let i = 0; i < drainRate; i++) {
+      await pacer.take();
+    }
+
+    // Two consumers taking concurrently still drain at the shared rate.
+    const started = Date.now();
+    await Promise.all([
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+      pacer.take(),
+    ]);
+    const elapsed = Date.now() - started;
+    expect(elapsed).toBeGreaterThanOrEqual(40); // ~5 tokens / 100 per sec
+  });
+
+  it("rejects a non-positive drain rate", () => {
+    expect(() => new TokenBucketPacer(0)).toThrow(/drainRate/);
+    expect(() => new TokenBucketPacer(-5)).toThrow(/drainRate/);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/pacer.test.ts
@@ -78,34 +78,47 @@ describe("TokenBucketPacer", () => {
 
   it("stops pacing once the shutdown signal aborts, releasing a parked take", async () => {
     const controller = new AbortController();
-    const drainRate = 10; // 1 token per 100ms
-    const pacer = new TokenBucketPacer(drainRate, undefined, controller.signal);
-    for (let i = 0; i < drainRate; i++) {
-      await pacer.take();
-    }
+    // 1 token/sec, capacity 1. A slow rate keeps the assertions honest: the
+    // single warm-up take cannot refill a meaningful fraction of a token, so
+    // the bucket is genuinely empty below and the test cannot pass by
+    // accident on a loaded runner.
+    const pacer = new TokenBucketPacer(1, 1, controller.signal);
+    await pacer.take();
 
-    // Bucket empty: this take would otherwise wait ~100ms for the next token.
-    const started = Date.now();
     const parked = pacer.take();
+    let settled = false;
+    parked.then(() => {
+      settled = true;
+    });
+
+    // Prove it is actually parked before aborting; otherwise this test would
+    // pass whether or not abort does anything.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(settled).toBe(false);
+
+    const started = Date.now();
     controller.abort();
     await parked;
-    expect(Date.now() - started).toBeLessThan(50);
+    expect(settled).toBe(true);
+    // Would have been ~1s of remaining pace.
+    expect(Date.now() - started).toBeLessThan(200);
   });
 
   it("keeps letting takes through after abort, so a whole backlog bursts", async () => {
     const controller = new AbortController();
-    const pacer = new TokenBucketPacer(10, undefined, controller.signal);
-    for (let i = 0; i < 10; i++) {
-      await pacer.take();
-    }
+    const pacer = new TokenBucketPacer(1, 1, controller.signal);
+    await pacer.take();
     controller.abort();
 
-    // 100 events at 10/s would be 10s of pacing. After abort they cost nothing:
-    // the drain that follows pays for the sends, not for the remaining pace.
+    // At 1 token/sec these 100 takes would be ~100s of pacing. After abort
+    // they cost nothing: the drain that follows pays for the sends, not for
+    // the remaining pace. The bound is deliberately loose - two orders of
+    // magnitude below the paced cost is proof enough, and a tight floor
+    // would only buy flakes on a loaded runner.
     const started = Date.now();
     for (let i = 0; i < 100; i++) {
       await pacer.take();
     }
-    expect(Date.now() - started).toBeLessThan(100);
+    expect(Date.now() - started).toBeLessThan(2_000);
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/registry.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/registry.test.ts
@@ -1,5 +1,8 @@
 import type { SQSClient } from "@aws-sdk/client-sqs";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ethers } from "ethers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../lib/utils/logger";
+import { getInterface } from "../../src/chains/interface-cache";
 import type {
   ChainProviderManager,
   SubscribeOptions,
@@ -11,6 +14,7 @@ import {
   ListenerRegistry,
   type WorkflowRegistration,
 } from "../../src/listener/registry";
+import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "../../src/listener/shutdown";
 
 const RAW_EVENTS_ABI: AbiEvent[] = [
   {
@@ -77,6 +81,33 @@ function makeDeps(): {
     sqs: sqs as unknown as SQSClient,
     sqsQueueUrl: "https://sqs.test/queue",
   };
+}
+
+function makeLog(txHash: string): ethers.Log {
+  const iface = getInterface(EVENTS_ABI_STRINGS);
+  const { topics, data } = iface.encodeEventLog("Emitted", [
+    "0x2222222222222222222222222222222222222222",
+    1n,
+  ]);
+  return {
+    topics,
+    data,
+    address: "0x1111111111111111111111111111111111111111",
+    blockNumber: 100,
+    blockHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    transactionHash: txHash,
+    transactionIndex: 0,
+    index: 0,
+  } as unknown as ethers.Log;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe("ListenerRegistry", () => {
@@ -175,6 +206,80 @@ describe("ListenerRegistry", () => {
       registry.remove("wf-1");
       await registry.add(makeWorkflow("wf-1", { configHash: "second" }));
       expect(registry.getConfigHash("wf-1")).toBe("second");
+    });
+  });
+
+  describe("shutdown drain", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    /**
+     * Parks the handler inside the dedup read, which sits after the pace and
+     * before any SQS or phantom call. That is the same in-flight state a
+     * SIGTERM would catch, without the test needing the internal API.
+     */
+    async function dispatchAndPark(): Promise<{
+      release: (alreadyProcessed: boolean) => void;
+    }> {
+      const gate = deferred<boolean>();
+      (deps.dedup.isProcessed as ReturnType<typeof vi.fn>).mockReturnValue(
+        gate.promise,
+      );
+      await registry.add(makeWorkflow("wf-1"));
+      const { handler } = deps.subscribeToLogs.mock
+        .calls[0][0] as SubscribeOptions;
+      void handler(makeLog(`0x${"a".repeat(64)}`));
+      // Let the handler run up to the dedup await.
+      await Promise.resolve();
+      await Promise.resolve();
+      return { release: gate.resolve };
+    }
+
+    it("waits for an in-flight dispatch before returning", async () => {
+      const { release } = await dispatchAndPark();
+
+      let stopped = false;
+      const stopping = registry.stopAll().then(() => {
+        stopped = true;
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      // The listener is already unsubscribed, but the handler that was
+      // mid-flight when the signal arrived has not finished.
+      expect(deps.unsubscribe).toHaveBeenCalledTimes(1);
+      expect(stopped).toBe(false);
+
+      release(true);
+      await stopping;
+      expect(stopped).toBe(true);
+    });
+
+    it("gives up at the drain bound and records what it could not finish", async () => {
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      // Parked and never released: the handler outlives the budget.
+      await dispatchAndPark();
+      vi.useFakeTimers();
+
+      const stopping = registry.stopAll();
+      await vi.advanceTimersByTimeAsync(SHUTDOWN_DRAIN_TIMEOUT_MS);
+      await stopping;
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("drain timed out"),
+      );
+      expect(registry.size()).toBe(0);
+    });
+
+    it("clears the registry once drained", async () => {
+      const { release } = await dispatchAndPark();
+      const stopping = registry.stopAll();
+      release(true);
+      await stopping;
+      expect(registry.size()).toBe(0);
+      expect(registry.ids()).toEqual([]);
     });
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/shutdown.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/shutdown.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { abortableSleep } from "../../src/listener/shutdown";
+
+describe("abortableSleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sleeps the full interval when nothing aborts", async () => {
+    let settled = false;
+    const sleep = abortableSleep(5_000).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await sleep;
+    expect(settled).toBe(true);
+  });
+
+  it("returns immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await abortableSleep(10_000, controller.signal);
+    // Nothing was scheduled, so the sleep cannot be holding a timer open.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns early when the signal aborts mid-sleep, and clears its timer", async () => {
+    const controller = new AbortController();
+    let settled = false;
+    const sleep = abortableSleep(10_000, controller.signal).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(settled).toBe(false);
+
+    controller.abort();
+    await sleep;
+    expect(settled).toBe(true);
+    // The pending timer is cleared rather than left to fire into a resolved
+    // promise and hold the event loop open past the drain.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resolves rather than rejecting on abort, so callers need no abort branch", async () => {
+    const controller = new AbortController();
+    const sleep = abortableSleep(10_000, controller.signal);
+    controller.abort();
+    await expect(sleep).resolves.toBeUndefined();
+  });
+});

--- a/keeperhub-events/package.json
+++ b/keeperhub-events/package.json
@@ -16,6 +16,7 @@
   },
   "pnpm": {
     "overrides": {
+      "toml": "^4.2.0",
       "fast-xml-parser": "^5.7.0",
       "fast-xml-builder": "~1.1.7",
       "ws": ">=8.21.0",

--- a/keeperhub-events/pnpm-lock.yaml
+++ b/keeperhub-events/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  toml: ^4.2.0
   fast-xml-parser: ^5.7.0
   fast-xml-builder: ~1.1.7
   ws: '>=8.21.0'
@@ -213,28 +214,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -496,42 +493,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.6':
     resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
     resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.6':
     resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.6':
     resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.6':
     resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
@@ -588,79 +579,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1050,28 +1028,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -1278,8 +1252,9 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
+    engines: {node: '>=20'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -1664,7 +1639,7 @@ snapshots:
       eventemitter3: 4.0.7
       pako: 2.2.0
       superstruct: 0.15.5
-      toml: 3.0.0
+      toml: 4.3.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2528,7 +2503,7 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
-  toml@3.0.0: {}
+  toml@4.3.0: {}
 
   tr46@0.0.3: {}
 

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -2133,25 +2133,57 @@ export async function getSpendCapData(organizationId: string): Promise<{
 /**
  * Get a lightweight checksum for SSE change detection.
  * Returns max timestamps + active count so we know when to push updates.
+ *
+ * `rangeStart` is the lower bound of the window the stream is watching. A run
+ * that started before the window cannot change what that window summarises, so
+ * bounding by it is exact rather than an approximation.
+ *
+ * The run-side MAX is a lateral per workflow, not a plain aggregate over the
+ * join, because the two plan nothing alike. An aggregate over the join has to
+ * read every row it might be the maximum of; the lateral lets the planner turn
+ * each workflow into an index-only scan with LIMIT 1. Measured on the busiest
+ * organization over 30 days: 424 ms and 152,914 buffers unbounded, 120 ms and
+ * 78,496 bounded, 2 ms and 1,189 as the lateral. This runs every poll interval
+ * for every connected viewer, only to answer "has anything changed", so the
+ * difference is what it costs to have the dashboard open.
+ *
+ * The active-run count is deliberately left unbounded: the summary's activeRuns
+ * is unbounded too, and the two have to agree.
  */
 export async function getAnalyticsChecksum(
-  organizationId: string
+  organizationId: string,
+  rangeStart: Date
 ): Promise<string> {
+  // Bound as ISO text for the same reason the step-log scan is: a raw template
+  // has no column to map a Date through, the way the comparison helpers do.
+  const from = rangeStart.toISOString();
+
   const [wfMax, deMax, activeCount] = await Promise.all([
     db
-      .select({
-        maxStarted: sql<string>`COALESCE(MAX(${workflowExecutions.startedAt}), '1970-01-01')::text`,
-      })
-      .from(workflowExecutions)
-      .innerJoin(workflows, eq(workflowExecutions.workflowId, workflows.id))
-      .where(eq(workflows.organizationId, organizationId))
-      .then((r) => r[0]?.maxStarted ?? ""),
+      .execute<{ max_started: string }>(
+        sql`
+    SELECT COALESCE(MAX(latest.started_at), '1970-01-01')::text AS max_started
+      FROM ${workflows} AS scoped_wf
+      CROSS JOIN LATERAL (
+        SELECT MAX(${workflowExecutions.startedAt}) AS started_at
+          FROM ${workflowExecutions}
+         WHERE ${workflowExecutions.workflowId} = scoped_wf.id
+           AND ${workflowExecutions.startedAt} >= ${from}
+      ) AS latest
+     WHERE scoped_wf.organization_id = ${organizationId}`
+      )
+      .then((r) => r[0]?.max_started ?? ""),
     db
       .select({
         maxCreated: sql<string>`COALESCE(MAX(${directExecutions.createdAt}), '1970-01-01')::text`,
       })
       .from(directExecutions)
-      .where(eq(directExecutions.organizationId, organizationId))
+      .where(
+        and(
+          eq(directExecutions.organizationId, organizationId),
+          gte(directExecutions.createdAt, rangeStart)
+        )
+      )
       .then((r) => r[0]?.maxCreated ?? ""),
     db
       .select({ count: count() })

--- a/lib/analytics/queries.ts
+++ b/lib/analytics/queries.ts
@@ -228,10 +228,18 @@ function directSearchCondition(term: string): SQL {
 // asking for "runs over 30s" means.
 const directDurationMs = sql`(EXTRACT(EPOCH FROM (${directExecutions.completedAt} - ${directExecutions.createdAt})) * 1000)`;
 
-// Per-step gas and the sponsorship marker, each read as COALESCE(denormalised
-// column, JSONB extract) so rows written before migration 0117 - and rows the
-// backfill has not reached - still classify correctly.
-const filterStepGasWei = sql`COALESCE(${workflowExecutionLogs.gasUsedWei}, CAST(NULLIF(${logOutputField("gasUsed")}, '') AS NUMERIC))`;
+// Per-step gas, read straight off the denormalised column that migration 0117
+// added. This was COALESCE(column, JSONB extract) while the backfill still had
+// rows to reach; the backfill has since run - gas_used_wei is populated back to
+// 2026-02-24, and eight sample slices spanning the last 31 days found no row
+// whose JSONB carried gas the column did not.
+//
+// The JSONB arm was the entire cost of a gas filter. Reading `output` per row
+// de-TOASTs and re-parses it, which no index can avoid, so filtering by gas
+// walked every step the organization ran in the window: cost 925,055 for the
+// largest organization over 30 days. Off the column it is 4,382 (see
+// scopedGasLogs), because the scan can be driven by a partial index instead.
+const filterStepGasWei = sql`${workflowExecutionLogs.gasUsedWei}`;
 const filterStepSponsored = sql`${workflowExecutionLogs.outputRaw}->>'sponsored' = 'true'`;
 
 /**
@@ -284,6 +292,23 @@ function scopedLogs(scope: LogScope): SQL {
 }
 
 /**
+ * `scopedLogs` narrowed to the steps that actually recorded gas.
+ *
+ * Every reader of the gas dimension only asks about gas-bearing steps, and they
+ * are a rounding error on this table: 21,481 of the step-log rows in the 30 days
+ * to 2026-09-04 carried gas, against the millions a bare window scan reads. The
+ * predicate matches `idx_exec_logs_gas_started_at` (btree(started_at) WHERE
+ * gas_used_wei IS NOT NULL), so the planner drives the scan off that index and
+ * never touches a step that could not have contributed.
+ *
+ * `> 0` rather than `IS NOT NULL` because a recorded zero contributes nothing to
+ * any of the three categories, and the index still serves it as a filter.
+ */
+function scopedGasLogs(scope: LogScope): SQL {
+  return sql`${scopedLogs(scope)} AND ${filterStepGasWei} > 0`;
+}
+
+/**
  * Gas facts per execution, aggregated once over the window.
  *
  * These were correlated subqueries on workflow_executions.id, so the planner
@@ -297,17 +322,26 @@ function scopedLogs(scope: LogScope): SQL {
  * cannot start before the run that owns it, so every log of an execution
  * inside the window has started_at >= the window start; and a step may finish
  * after the window closes, so there is no upper bound to apply.
+ *
+ * Restricted to gas-bearing steps, which leaves both surviving columns
+ * value-identical: SUM ignores the NULL a gas-free step contributes, and
+ * `unsponsored_gas_step` already required gas above zero, so the rows dropped
+ * could only ever have added false to its BOOL_OR.
+ *
+ * The old `sponsored_step` column is gone. Every group here now has gas above
+ * zero, so `step_gas_wei > 0 OR sponsored_step` reduced to its first arm and the
+ * second could not change an answer. What it used to add - a sponsored marker on
+ * a step that recorded no gas - is a sponsored transfer that errored before
+ * broadcast, which spends nothing and now reads as free. See workflowGasCondition.
  */
 function workflowGasTotals(scope: LogScope): SQL {
   return sql`(
     SELECT ${workflowExecutionLogs.executionId} AS execution_id,
            COALESCE(SUM(${filterStepGasWei}), 0) AS step_gas_wei,
-           COALESCE(BOOL_OR(${filterStepSponsored}), false) AS sponsored_step,
            COALESCE(BOOL_OR(
-             ${filterStepGasWei} > 0
-             AND ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
+             ${workflowExecutionLogs.outputRaw}->>'sponsored' IS DISTINCT FROM 'true'
            ), false) AS unsponsored_gas_step
-    ${scopedLogs(scope)}
+    ${scopedGasLogs(scope)}
      GROUP BY ${workflowExecutionLogs.executionId}
   )`;
 }
@@ -343,12 +377,14 @@ function workflowLedgerTotals(scope: LogScope): SQL {
 function workflowGasCondition(value: GasSpend, scope: LogScope): SQL {
   if (value === "sponsored") {
     // Only the marker decides this one, so it reads output_raw directly rather
-    // than paying for the gas rollup - and its JSONB decode - that the other
-    // two branches genuinely need.
+    // than building the gas rollup the other two branches need. Scoped to
+    // gas-bearing steps for the same reason free is: a sponsored step that
+    // recorded no gas never reached the chain, and letting it answer here while
+    // free also claims it would put one run in two mutually exclusive buckets.
     return sql`(
       ${workflowExecutions.id} IN (
         SELECT ${workflowExecutionLogs.executionId}
-        ${scopedLogs(scope)}
+        ${scopedGasLogs(scope)}
            AND ${filterStepSponsored}
       )
       OR ${workflowExecutions.id} IN (
@@ -371,10 +407,14 @@ function workflowGasCondition(value: GasSpend, scope: LogScope): SQL {
          AND g.step_gas_wei > COALESCE(s.sponsored_gas_wei, 0)
     )`;
   }
+  // `step_gas_wei > 0` is already true of every group the rollup returns, so it
+  // reads as intent rather than as a filter: free is "no step of this run put
+  // gas on a chain", and the ledger arm below covers a run whose sponsorship was
+  // only ever recorded as a credit charge.
   return sql`(
     ${workflowExecutions.id} NOT IN (
       SELECT g.execution_id FROM ${totals} AS g
-       WHERE g.step_gas_wei > 0 OR g.sponsored_step
+       WHERE g.step_gas_wei > 0
     )
     AND ${workflowExecutions.id} NOT IN (
       SELECT s.execution_id FROM ${workflowLedgerTotals(scope)} AS s

--- a/lib/analytics/stream-start.ts
+++ b/lib/analytics/stream-start.ts
@@ -8,6 +8,7 @@ export const POLL_INTERVAL_MS = 5000;
 export const HEARTBEAT_INTERVAL_MS = 30_000;
 export const MAX_LIFETIME_MS = 5 * 60 * 1000;
 export const MIN_EVENT_INTERVAL_MS = 1000;
+export const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 function formatSSE(event: AnalyticsStreamEvent): string {
   return `data: ${JSON.stringify(event)}\n\n`;
@@ -29,6 +30,7 @@ export type AnalyticsStreamConfig = {
   heartbeatIntervalMs?: number;
   maxLifetimeMs?: number;
   minEventIntervalMs?: number;
+  maxConsecutiveFailures?: number;
 };
 
 export type AnalyticsStreamOpts = {
@@ -61,6 +63,8 @@ export function createAnalyticsStreamStart(
   const maxLifetimeMs = config?.maxLifetimeMs ?? MAX_LIFETIME_MS;
   const minEventIntervalMs =
     config?.minEventIntervalMs ?? MIN_EVENT_INTERVAL_MS;
+  const maxConsecutiveFailures =
+    config?.maxConsecutiveFailures ?? MAX_CONSECUTIVE_POLL_FAILURES;
 
   return (controller): void => {
     const encoder = new TextEncoder();
@@ -69,6 +73,8 @@ export function createAnalyticsStreamStart(
     let lastChecksum = "";
     let lastEventTime = 0;
     let closed = false;
+    let primed = false;
+    let consecutiveFailures = 0;
 
     const safeClose = (): void => {
       if (closed) {
@@ -132,6 +138,22 @@ export function createAnalyticsStreamStart(
           return;
         }
 
+        // The poll itself worked, so the stream is healthy. Only the checksum
+        // read counts towards giving up; a failing summary deliberately keeps
+        // the stream open (see the catch).
+        consecutiveFailures = 0;
+
+        // The first checksum only records where this stream started. The client
+        // already fetched the summary over HTTP when it mounted, so pushing one
+        // here buys it nothing - and because maxLifetimeMs closes every stream
+        // after a few minutes, doing so made every viewer force a full summary
+        // recompute on every reconnect, whether or not anything had changed.
+        if (!primed) {
+          primed = true;
+          lastChecksum = checksum;
+          return;
+        }
+
         if (checksum === lastChecksum) {
           return;
         }
@@ -152,7 +174,15 @@ export function createAnalyticsStreamStart(
 
         safeEnqueue(chunk);
       } catch {
-        safeClose();
+        // One failed poll is not fatal. Closing here sent the browser straight
+        // into a reconnect, and the reconnect re-ran the work that had just
+        // failed, which is how a single slow query turned into a sustained
+        // burst on 2026-09-04. Skip the tick instead, and give up only once the
+        // checksum read itself has failed repeatedly.
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= maxConsecutiveFailures) {
+          safeClose();
+        }
       }
     }, pollIntervalMs);
 

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -90,9 +90,47 @@ const globalForDb = globalThis as unknown as {
   metricsDb: PostgresJsDatabase<typeof schema> | undefined;
 };
 
+// statement_timeout is set once on every app-pool connection (not per query).
+// It bounds a single statement, not a request and not a job, so a handler that
+// issues many short queries is unaffected. Before KEEP-1305 this pool had no
+// bound at all: on 2026-09-02 about 40 analytics queries each ran for more than
+// an hour on the 2-vCPU prod instance and starved the dispatchers, which page
+// off the same database.
+//
+// 30s matches what keeperhub-executor/index.ts and
+// keeperhub-executor/workflow-runner.ts already set on their own pools, so
+// every request-shaped pool now carries the same bound.
+//
+// Two things this value reaches that are not obvious. The CronJobs (reaper,
+// reconciler, digest, the billing and security scans) do not open their own
+// connections - they are signed HTTP calls into these same pods, so their SQL
+// runs on this pool. And the workflow runner imports lib/db transitively for
+// step logging, so runner pods use this pool too, not only their own.
+//
+// The RDS parameter group holds a 120s backstop for everything that shares the
+// keeperhub role, including migrations and operator psql sessions. This value
+// is the tighter request-path bound and must stay below it. The migrator opts
+// out through statement_timeout on its DSN, so raising this number is never the
+// way to make a migration pass.
+//
+// Override with APP_STATEMENT_TIMEOUT_MS. A cancelled statement surfaces as
+// Postgres 57014.
+const parsedAppTimeoutMs = Number.parseInt(
+  process.env.APP_STATEMENT_TIMEOUT_MS ?? "",
+  10
+);
+const APP_STATEMENT_TIMEOUT_MS =
+  Number.isFinite(parsedAppTimeoutMs) && parsedAppTimeoutMs > 0
+    ? parsedAppTimeoutMs
+    : 30_000;
+
 // For queries - reuse connection in development
 const queryClient =
-  globalForDb.queryClient ?? postgres(connectionString, { max: 10 });
+  globalForDb.queryClient ??
+  postgres(connectionString, {
+    max: 10,
+    connection: { statement_timeout: APP_STATEMENT_TIMEOUT_MS },
+  });
 export const db = globalForDb.db ?? drizzle(queryClient, { schema });
 
 // Dedicated pool for the /api/metrics/db scrape aggregations. The collector

--- a/package.json
+++ b/package.json
@@ -198,6 +198,8 @@
       "prisma"
     ],
     "overrides": {
+      "toml": "^4.2.0",
+      "fflate": "^0.7.5",
       "rollup": "^4.59.0",
       "minimatch": "^10.2.3",
       "devalue": "^5.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  toml: ^4.2.0
+  fflate: ^0.7.5
   rollup: ^4.59.0
   minimatch: ^10.2.3
   devalue: ^5.8.1
@@ -168,7 +170,7 @@ importers:
         version: 0.11.1(@types/node@24.12.2)
       '@workflow/world-postgres':
         specifier: 4.3.5
-        version: 4.3.5(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
+        version: 4.3.5(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
       '@x402/core':
         specifier: ^2.24.0
         version: 2.24.0
@@ -186,7 +188,7 @@ importers:
         version: 5.0.250(zod@4.5.4)
       better-auth:
         specifier: ^1.7.2
-        version: 1.7.2(7ntpfzidggtluxxvikqv3cutvi)
+        version: 1.7.2(3flr2omfiri4ji4kwqmy57cppa)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -216,7 +218,7 @@ importers:
         version: 1.8.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
       ethers:
         specifier: ^6.17.0
         version: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -5777,8 +5779,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  fflate@0.7.5:
+    resolution: {integrity: sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g==}
 
   file-type@22.0.1:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
@@ -8018,8 +8020,9 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
-  toml@3.0.0:
-    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+  toml@4.3.0:
+    resolution: {integrity: sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==}
+    engines: {node: '>=20'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -9012,12 +9015,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)))':
+  '@better-auth/drizzle-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)))':
     dependencies:
       '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
 
   '@better-auth/kysely-adapter@1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
@@ -9201,7 +9204,7 @@ snapshots:
       eventemitter3: 4.0.7
       pako: 2.2.0
       superstruct: 0.15.5
-      toml: 3.0.0
+      toml: 4.3.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -11275,7 +11278,7 @@ snapshots:
 
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
-      fflate: 0.7.4
+      fflate: 0.7.5
       string.prototype.codepointat: 0.2.1
 
   '@signinwithethereum/siwe-parser@4.2.0':
@@ -13183,7 +13186,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@workflow/world-postgres@4.3.5(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)':
+  '@workflow/world-postgres@4.3.5(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@vercel/queue': 0.3.1
       '@workflow/errors': 4.2.1
@@ -13192,7 +13195,7 @@ snapshots:
       '@workflow/world-local': 4.4.0(@opentelemetry/api@1.9.1)
       cbor-x: 1.6.0
       dotenv: 17.3.1
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
       graphile-worker: 0.16.6(typescript@5.9.3)
       pg: 8.20.0
       ulid: 3.0.2
@@ -13670,10 +13673,10 @@ snapshots:
 
   baseline-browser-mapping@2.11.13: {}
 
-  better-auth@1.7.2(7ntpfzidggtluxxvikqv3cutvi):
+  better-auth@1.7.2(3flr2omfiri4ji4kwqmy57cppa):
     dependencies:
       '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)))
+      '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)))
       '@better-auth/kysely-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
       '@better-auth/memory-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0(socks@2.8.7))
@@ -13692,8 +13695,9 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))
       mongodb: 7.1.0(socks@2.8.7)
+      mysql2: 3.24.3(@types/node@24.12.2)
       next: 16.3.3(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.12.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       pg: 8.20.0
       prisma: 7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
@@ -14348,13 +14352,14 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.13
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(kysely@0.28.17)(mysql2@3.24.3(@types/node@24.12.2))(pg@8.20.0)(postgres@3.4.9)(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@opentelemetry/api': 1.9.1
       '@prisma/client': 7.4.2(prisma@7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3))(typescript@5.9.3)
       '@types/pg': 8.20.0
       kysely: 0.28.17
+      mysql2: 3.24.3(@types/node@24.12.2)
       pg: 8.20.0
       postgres: 3.4.9
       prisma: 7.4.2(@types/node@24.12.2)(@types/react@19.2.14)(magicast@0.5.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
@@ -14689,7 +14694,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fflate@0.7.4: {}
+  fflate@0.7.5: {}
 
   file-type@22.0.1:
     dependencies:
@@ -16932,7 +16937,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  toml@3.0.0: {}
+  toml@4.3.0: {}
 
   tough-cookie@6.0.1:
     dependencies:

--- a/tests/e2e/vitest/analytics-checksum.db.test.ts
+++ b/tests/e2e/vitest/analytics-checksum.db.test.ts
@@ -1,0 +1,196 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  organization,
+  users,
+  workflowExecutions,
+  workflows,
+} from "../../../lib/db/schema";
+
+// vitest runs in Node, not an SSR context.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally stubs @/lib/db; this suite needs the checksum to hit
+// Postgres. The run-side MAX is a hand-written lateral rather than a builder
+// query, so nothing else in the suite would catch a malformed statement, a
+// wrong window bound, or a lateral that only sees one workflow.
+vi.unmock("@/lib/db");
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+const PREFIX = "test_checksum_";
+const ORG_ID = `${PREFIX}org`;
+const EMPTY_ORG_ID = `${PREFIX}org_empty`;
+const USER_ID = `${PREFIX}user`;
+// Two workflows, because a lateral evaluates per workflow and a rewrite that
+// stopped aggregating across them would still look right with only one.
+const WORKFLOW_A = `${PREFIX}wf_a`;
+const WORKFLOW_B = `${PREFIX}wf_b`;
+
+const SENTINEL = "1970-01-01 00:00:00";
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+// Truncated to the second: started_at is `timestamp without time zone` and the
+// checksum renders it as text, so comparing against a millisecond-bearing Date
+// would compare two different string shapes.
+function atSecond(date: Date): Date {
+  const copy = new Date(date);
+  copy.setMilliseconds(0);
+  return copy;
+}
+
+const OLDEST = atSecond(daysAgo(40));
+const NEWEST_IN_WINDOW = atSecond(daysAgo(2));
+const MIDDLE = atSecond(daysAgo(20));
+
+function pgText(date: Date): string {
+  return date
+    .toISOString()
+    .replace("T", " ")
+    .replace(/\.\d+Z$/, "");
+}
+
+describe.skipIf(SKIP)("getAnalyticsChecksum", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+  let getAnalyticsChecksum: (
+    organizationId: string,
+    rangeStart: Date
+  ) => Promise<string>;
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM workflow_executions WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM workflows WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    db = drizzle(queryClient);
+    await cleanup();
+
+    const now = new Date();
+
+    await db.insert(organization).values([
+      { id: ORG_ID, name: "checksum org", slug: ORG_ID, createdAt: now },
+      {
+        id: EMPTY_ORG_ID,
+        name: "checksum empty org",
+        slug: EMPTY_ORG_ID,
+        createdAt: now,
+      },
+    ]);
+    await db.insert(users).values({
+      id: USER_ID,
+      email: `${USER_ID}@keeperhub.test`,
+      emailVerified: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(workflows).values([
+      {
+        id: WORKFLOW_A,
+        name: "checksum workflow a",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+      {
+        id: WORKFLOW_B,
+        name: "checksum workflow b",
+        userId: USER_ID,
+        organizationId: ORG_ID,
+        enabled: true,
+        nodes: [],
+        edges: [],
+      },
+    ]);
+
+    await db.insert(workflowExecutions).values([
+      // Outside a 30-day window. The newest run the org has overall, if the
+      // bound were dropped this would be the answer for every case below.
+      {
+        id: `${PREFIX}exec_old`,
+        workflowId: WORKFLOW_A,
+        userId: USER_ID,
+        status: "success",
+        startedAt: OLDEST,
+        completedAt: OLDEST,
+        totalSteps: "1",
+        completedSteps: "1",
+      },
+      // Inside the window, on workflow A.
+      {
+        id: `${PREFIX}exec_mid`,
+        workflowId: WORKFLOW_A,
+        userId: USER_ID,
+        status: "success",
+        startedAt: MIDDLE,
+        completedAt: MIDDLE,
+        totalSteps: "1",
+        completedSteps: "1",
+      },
+      // Inside the window and the newest of all, on the OTHER workflow, so the
+      // answer can only be right if the lateral aggregates across workflows.
+      {
+        id: `${PREFIX}exec_new`,
+        workflowId: WORKFLOW_B,
+        userId: USER_ID,
+        status: "running",
+        startedAt: NEWEST_IN_WINDOW,
+        completedAt: null,
+        totalSteps: "1",
+        completedSteps: "0",
+      },
+    ]);
+
+    ({ getAnalyticsChecksum } = await import("@/lib/analytics/queries"));
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  it("returns the newest run in the window, across every workflow in the org", async () => {
+    const checksum = await getAnalyticsChecksum(ORG_ID, daysAgo(30));
+
+    // max started_at | max direct created_at | active runs
+    expect(checksum).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+  });
+
+  it("ignores runs that started before the window", async () => {
+    // A 25-day window still contains MIDDLE; a 10-day one does not, and the
+    // 40-day-old run must not resurface in either.
+    const wide = await getAnalyticsChecksum(ORG_ID, daysAgo(25));
+    const narrow = await getAnalyticsChecksum(ORG_ID, daysAgo(10));
+
+    expect(wide).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+    expect(narrow).toBe(`${pgText(NEWEST_IN_WINDOW)}|${SENTINEL}|1`);
+  });
+
+  it("falls back to the window start excluding everything", async () => {
+    const checksum = await getAnalyticsChecksum(ORG_ID, daysAgo(1));
+
+    // Nothing started in the last day, so both timestamps collapse to the
+    // sentinel. The active count is deliberately unwindowed and still counts.
+    expect(checksum).toBe(`${SENTINEL}|${SENTINEL}|1`);
+  });
+
+  it("returns the sentinel for an organization with no runs", async () => {
+    const checksum = await getAnalyticsChecksum(EMPTY_ORG_ID, daysAgo(30));
+
+    expect(checksum).toBe(`${SENTINEL}|${SENTINEL}|0`);
+  });
+});

--- a/tests/e2e/vitest/analytics-run-filters.db.test.ts
+++ b/tests/e2e/vitest/analytics-run-filters.db.test.ts
@@ -549,4 +549,89 @@ describe.skipIf(SKIP)("analytics run filters", () => {
     expect(facets.success).toBe(1);
     expect(facets.error).toBeUndefined();
   });
+
+  // KEEP-1334. Both of these pin behaviour the gas rollup did NOT have before
+  // it moved onto the denormalised column, so both fail against the previous
+  // implementation. They are seeded per-test rather than added to SEEDS because
+  // the count assertions above pin the fixture exactly.
+  async function withGasRow(
+    id: string,
+    row: { gasUsedWei?: string | null; output?: unknown; outputRaw?: unknown },
+    assertions: () => Promise<void>
+  ): Promise<void> {
+    const now = new Date();
+    await db.insert(workflowExecutions).values({
+      id,
+      workflowId: NIGHTLY_ID,
+      userId: USER_ID,
+      status: "success",
+      duration: "1000",
+      startedAt: now,
+      completedAt: now,
+    });
+    await db.insert(workflowExecutionLogs).values({
+      id: `${id}_log`,
+      executionId: id,
+      nodeId: "n1",
+      nodeName: "Send",
+      nodeType: "web3/transfer-funds",
+      status: "success",
+      network: BASE,
+      gasUsedWei: row.gasUsedWei ?? null,
+      output: row.output ?? null,
+      outputRaw: row.outputRaw ?? null,
+      startedAt: now,
+    });
+    try {
+      await assertions();
+    } finally {
+      await queryClient`DELETE FROM workflow_execution_logs WHERE id = ${`${id}_log`}`;
+      await queryClient`DELETE FROM workflow_executions WHERE id = ${id}`;
+    }
+  }
+
+  // A sponsored transfer that errored before broadcast carries the gas-station
+  // marker and no gas, and has no ledger row because nothing was ever charged.
+  // On prod on 2026-09-04 nineteen such steps existed in two days. They used to
+  // answer to "sponsored" purely on the marker, which put a run that spent
+  // nothing in the same bucket as one KeeperHub actually paid for. Now the
+  // marker only speaks for a step that reached the chain, so the run reads as
+  // free - and free and sponsored stay mutually exclusive.
+  it("reads a sponsored step that never spent as free, not as sponsored", async () => {
+    const id = `${PREFIX}sponsored_no_gas`;
+    await withGasRow(
+      id,
+      { gasUsedWei: null, outputRaw: { sponsored: true } },
+      async () => {
+        expect(await idsFor({ gas: ["sponsored"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["wallet"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["free"] })).toContain(id);
+      }
+    );
+  });
+
+  // The filter reads gas_used_wei and nothing else, so a row the KEEP-857
+  // backfill never reached classifies as free however much gas its JSONB names.
+  // That is what lets the scan run off idx_exec_logs_gas_started_at instead of
+  // de-TOASTing `output` for every step in the window. It is safe because the
+  // backfill has run: gas_used_wei is populated back to 2026-02-24 and no row
+  // in the last 31 days has gas the column is missing.
+  //
+  // The runs listing still renders such a row's gas, because that read is
+  // already bounded to one page and can afford the JSONB. The asymmetry is the
+  // point of this test - it is deliberate, and it is what the backfill closes.
+  it("classifies gas from the denormalised column, not from the JSONB", async () => {
+    const id = `${PREFIX}jsonb_only_gas`;
+    await withGasRow(
+      id,
+      { gasUsedWei: null, output: { gasUsed: "21000" } },
+      async () => {
+        expect(await idsFor({ gas: ["wallet"] })).not.toContain(id);
+        expect(await idsFor({ gas: ["free"] })).toContain(id);
+
+        const { runs } = await getUnifiedRuns(ORG_ID, "7d", { limit: 50 });
+        expect(runs.find((run) => run.id === id)?.gasUsedWei).toBe("21000");
+      }
+    );
+  });
 });

--- a/tests/unit/analytics-stream-start.test.ts
+++ b/tests/unit/analytics-stream-start.test.ts
@@ -121,4 +121,120 @@ describe("createAnalyticsStreamStart", () => {
 
     expect(controller.close).toHaveBeenCalledTimes(1);
   });
+
+  // The client already has the summary from its own HTTP fetch on mount, and
+  // maxLifetimeMs forces a reconnect every few minutes. Pushing on the first
+  // checksum therefore made every viewer recompute the summary on a fixed
+  // interval regardless of activity.
+  it("primes on the first poll without computing a summary", async () => {
+    const { opts } = makeOpts();
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(opts.deps.getChecksum).toHaveBeenCalledTimes(1);
+    expect(opts.deps.getSummary).not.toHaveBeenCalled();
+    expect(controller.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("pushes a summary once the checksum moves off the primed value", async () => {
+    const checksums = ["first", "second"];
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(async () => checksums.shift() ?? "second"),
+        getSummary: vi.fn(async () => EMPTY_SUMMARY),
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(opts.deps.getSummary).toHaveBeenCalledTimes(1);
+    expect(controller.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the stream open when a single poll fails", async () => {
+    const getChecksum = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("statement timeout"))
+      .mockResolvedValue("recovered");
+    const { opts } = makeOpts({
+      deps: { getChecksum, getSummary: vi.fn(async () => EMPTY_SUMMARY) },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(getChecksum).toHaveBeenCalledTimes(2);
+    expect(controller.close).not.toHaveBeenCalled();
+  });
+
+  it("closes once the checksum has failed maxConsecutiveFailures times", async () => {
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(() =>
+          Promise.reject(new Error("statement timeout"))
+        ),
+        getSummary: vi.fn(async () => EMPTY_SUMMARY),
+      },
+      config: {
+        pollIntervalMs: 100,
+        heartbeatIntervalMs: 10_000,
+        maxLifetimeMs: 5000,
+        minEventIntervalMs: 50,
+        maxConsecutiveFailures: 3,
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(controller.close).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  // A failing summary is the case that caused the outage. Closing on it sent the
+  // browser into a reconnect that recomputes the very query that just failed, so
+  // only the checksum read counts towards giving up.
+  it("does not close when the summary keeps failing but the checksum works", async () => {
+    let n = 0;
+    const { opts } = makeOpts({
+      deps: {
+        getChecksum: vi.fn(async () => {
+          n += 1;
+          return `checksum-${n}`;
+        }),
+        getSummary: vi.fn(() => Promise.reject(new Error("statement timeout"))),
+      },
+      config: {
+        pollIntervalMs: 100,
+        heartbeatIntervalMs: 10_000,
+        maxLifetimeMs: 5000,
+        minEventIntervalMs: 50,
+        maxConsecutiveFailures: 3,
+      },
+    });
+    const controller = makeController();
+
+    const start = createAnalyticsStreamStart(opts);
+    start(controller);
+
+    await vi.advanceTimersByTimeAsync(650);
+
+    expect(opts.deps.getSummary).toHaveBeenCalled();
+    expect(controller.close).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/db-pool-statement-timeout.test.ts
+++ b/tests/unit/db-pool-statement-timeout.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The app pool carries a per-statement timeout (KEEP-1305).
+ *
+ * Before this, lib/db's main pool had no bound at all, and on 2026-09-02 about
+ * 40 analytics queries each ran for more than an hour on prod. The CronJobs are
+ * signed HTTP calls into the same pods, so they share this pool, and the
+ * workflow runner reaches it transitively for step logging. That makes the
+ * option below the single request-path bound for almost every query the
+ * platform issues, which is worth asserting against the real module rather
+ * than against a hand-written copy of the config.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type PoolOptions = {
+  max?: number;
+  connection?: { statement_timeout?: number };
+};
+
+const postgresMock = vi.fn<
+  (url: string, options?: PoolOptions) => { end: () => void }
+>(() => ({
+  end: vi.fn(),
+}));
+
+vi.mock("postgres", () => ({ default: postgresMock }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: vi.fn(() => ({})) }));
+
+/**
+ * Re-import lib/db under the current env and return the pool option objects.
+ *
+ * tests/setup.ts mocks "@/lib/db" for every suite, so this has to reach past
+ * that mock with importActual to get the real module. The "postgres" mock above
+ * still applies, so no connection is opened.
+ */
+async function loadPoolOptions(): Promise<PoolOptions[]> {
+  postgresMock.mockClear();
+  // lib/db parks its clients on globalThis outside production so HMR does not
+  // exhaust connections. vi.resetModules() clears the module registry but not
+  // globalThis, so without this the second load reuses the first pool and never
+  // calls postgres() again.
+  for (const key of ["queryClient", "db", "metricsClient", "metricsDb"]) {
+    delete (globalThis as unknown as Record<string, unknown>)[key];
+  }
+  await vi.importActual("@/lib/db");
+  return postgresMock.mock.calls.map((call) => call[1] ?? {});
+}
+
+/** The main query pool is the only one built with max: 10. */
+function queryPool(options: PoolOptions[]): PoolOptions {
+  const pool = options.find((o) => o.max === 10);
+  if (!pool) {
+    throw new Error(
+      `no pool with max:10 among ${JSON.stringify(options)} - lib/db changed shape`
+    );
+  }
+  return pool;
+}
+
+describe("app pool statement_timeout", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("bounds the main query pool at 30s by default", async () => {
+    process.env.APP_STATEMENT_TIMEOUT_MS = undefined;
+    delete process.env.APP_STATEMENT_TIMEOUT_MS;
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBe(30_000);
+  });
+
+  it("takes the override from APP_STATEMENT_TIMEOUT_MS", async () => {
+    process.env.APP_STATEMENT_TIMEOUT_MS = "45000";
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBe(45_000);
+  });
+
+  it.each(["", "not-a-number", "0", "-1"])(
+    "falls back to 30s when the override is %j",
+    async (value) => {
+      process.env.APP_STATEMENT_TIMEOUT_MS = value;
+
+      const pool = queryPool(await loadPoolOptions());
+
+      expect(pool.connection?.statement_timeout).toBe(30_000);
+    }
+  );
+
+  it("stays below the 120s RDS parameter-group backstop", async () => {
+    delete process.env.APP_STATEMENT_TIMEOUT_MS;
+
+    const pool = queryPool(await loadPoolOptions());
+
+    expect(pool.connection?.statement_timeout).toBeLessThan(120_000);
+  });
+});


### PR DESCRIPTION
11 commits, 24 files, since #2306 (prod head `ea4fff2`, 2026-09-03 21:55Z).

## What ships

**Analytics load, both halves of today's incident**

- #2312 (KEEP-1333) — the summary aggregates become index-only, the SSE checksum is bounded to the window and rewritten as a lateral, and a single failed poll no longer closes the stream into a reconnect that re-runs the query that just failed.
- #2313 (KEEP-1334) — the gas filter on `/api/analytics/runs` and `/api/analytics/facets` reads `gas_used_wei` off the denormalised column instead of de-TOASTing `output` on every step-log row in the window. Statement cost for a 30-day window on the largest org drops 4,809,647 -> 2,265,934, and three sequential scans of `workflows` disappear.

Both reduce database read load, which is what saturated prod storage between 12:43Z and 14:11Z today and dropped 618 workflow executions across 25 organizations.

**Event tracker**

- #2300 / #2290 — per-chain token bucket replaces the fixed 0-10s dispatch jitter, and in-flight event dispatches drain on shutdown with the budget sized to the grace period.

**Dependencies**

- #2311 (KEEP-1322) — `toml` and `fflate` overrides to clear Dependabot alerts.

## Migration

One: `0150_keep_1333_summary_covering_index`, carrying `@requires-db-prep`. Its single statement is `CREATE INDEX IF NOT EXISTS idx_workflow_executions_workflow_started_covering`.

I verified against the production database directly rather than trusting the source PR: the index already exists, `indisvalid` and `indisready` both true, 385 MB, and there are no invalid indexes anywhere. The db-prep was applied out of band, so the statement in the migration no-ops and takes no ACCESS EXCLUSIVE lock. Prod's newest applied migration is `0149`, applied 2026-09-02 11:31:39Z, so `0150` is the only one this deploy runs.

## Watch after deploy

- Event-tracker chains. This release changes the shutdown drain path, and there is a known failure mode where a WSS reconnect leaves `draining` set forever: the chain goes silent while the pod and `/healthz` still look healthy. Confirm chains are still producing after the rollout rather than reading pod status alone.
- The analytics gas filter now classifies a sponsored transfer that errored before broadcast as `free` rather than `sponsored`. That is deliberate and documented in #2313; it is user-visible in the runs filter.
