### PR TITLE
fix: add AI Gateway runtime steps

### DIFF
--- a/plugins/ai-gateway/credentials.ts
+++ b/plugins/ai-gateway/credentials.ts
@@ -1,0 +1,3 @@
+export type AiGatewayCredentials = {
+  AI_GATEWAY_API_KEY?: string;
+};

--- a/plugins/ai-gateway/steps/ai-gateway-core.ts
+++ b/plugins/ai-gateway/steps/ai-gateway-core.ts
@@ -1,0 +1,98 @@
+import "server-only";
+
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { safeFetch } from "@/lib/safe-fetch";
+
+const AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1";
+
+export type AiGatewayFailure = {
+  success: false;
+  error: string;
+  errorClass: ExecutionErrorType;
+};
+
+type AiGatewaySuccess = {
+  success: true;
+  data: unknown;
+};
+
+export type AiGatewayRequestResult = AiGatewaySuccess | AiGatewayFailure;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function providerErrorMessage(data: unknown): string | undefined {
+  if (!isRecord(data)) {
+    return;
+  }
+
+  if (typeof data.message === "string" && data.message.trim()) {
+    return data.message;
+  }
+
+  if (typeof data.error === "string" && data.error.trim()) {
+    return data.error;
+  }
+
+  if (isRecord(data.error) && typeof data.error.message === "string") {
+    return data.error.message;
+  }
+}
+
+async function readResponseJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return;
+  }
+}
+
+export async function requestAiGateway(
+  path: "/chat/completions" | "/images/generations",
+  apiKey: string,
+  body: Record<string, unknown>
+): Promise<AiGatewayRequestResult> {
+  try {
+    const response = await safeFetch(`${AI_GATEWAY_BASE_URL}${path}`, {
+      plugin: "ai-gateway",
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await readResponseJson(response);
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error:
+          providerErrorMessage(data) ??
+          `AI Gateway request failed with HTTP ${response.status}.`,
+        errorClass:
+          response.status >= 500
+            ? ExecutionErrorType.EXTERNAL
+            : ExecutionErrorType.USER,
+      };
+    }
+
+    if (data === undefined) {
+      return {
+        success: false,
+        error: "AI Gateway returned a malformed JSON response.",
+        errorClass: ExecutionErrorType.EXTERNAL,
+      };
+    }
+
+    return { success: true, data };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      success: false,
+      error: `AI Gateway request failed: ${message}`,
+      errorClass: ExecutionErrorType.EXTERNAL,
+    };
+  }
+}

--- a/plugins/ai-gateway/steps/generate-image-core.ts
+++ b/plugins/ai-gateway/steps/generate-image-core.ts
@@ -1,0 +1,80 @@
+import "server-only";
+
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import type { AiGatewayCredentials } from "../credentials";
+import {
+  type AiGatewayFailure,
+  isRecord,
+  requestAiGateway,
+} from "./ai-gateway-core";
+
+const DEFAULT_IMAGE_MODEL = "google/imagen-4.0-generate-001";
+
+export type GenerateImageCoreInput = {
+  imageModel?: string;
+  imagePrompt?: string;
+};
+
+export type GenerateImageResult =
+  | { success: true; base64: string }
+  | AiGatewayFailure;
+
+function userFailure(error: string): AiGatewayFailure {
+  return { success: false, error, errorClass: ExecutionErrorType.USER };
+}
+
+function extractBase64(data: unknown): string | undefined {
+  if (!isRecord(data) || !Array.isArray(data.data)) {
+    return;
+  }
+  const firstImage = data.data[0];
+  if (!isRecord(firstImage) || typeof firstImage.b64_json !== "string") {
+    return;
+  }
+  const base64 = firstImage.b64_json.trim();
+  return base64 || undefined;
+}
+
+export async function generateImage(
+  input: GenerateImageCoreInput,
+  credentials: AiGatewayCredentials
+): Promise<GenerateImageResult> {
+  const apiKey = credentials.AI_GATEWAY_API_KEY;
+  if (!apiKey) {
+    return userFailure(
+      "AI_GATEWAY_API_KEY is not configured. Please add it in Project Integrations."
+    );
+  }
+
+  const prompt =
+    typeof input.imagePrompt === "string" ? input.imagePrompt.trim() : "";
+  if (!prompt) {
+    return userFailure("Prompt is required for image generation.");
+  }
+
+  const model = (input.imageModel ?? DEFAULT_IMAGE_MODEL).trim();
+  if (!model) {
+    return userFailure("Model is required for image generation.");
+  }
+
+  const response = await requestAiGateway("/images/generations", apiKey, {
+    model,
+    prompt,
+    size: "1024x1024",
+    response_format: "b64_json",
+  });
+  if (!response.success) {
+    return response;
+  }
+
+  const base64 = extractBase64(response.data);
+  if (!base64) {
+    return {
+      success: false,
+      error: "AI Gateway returned a malformed image-generation response.",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    };
+  }
+
+  return { success: true, base64 };
+}

--- a/plugins/ai-gateway/steps/generate-image.ts
+++ b/plugins/ai-gateway/steps/generate-image.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import type { AiGatewayCredentials } from "../credentials";
+import {
+  type GenerateImageCoreInput,
+  type GenerateImageResult,
+  generateImage,
+} from "./generate-image-core";
+
+export type {
+  GenerateImageCoreInput,
+  GenerateImageResult,
+} from "./generate-image-core";
+
+export type GenerateImageInput = StepInput &
+  GenerateImageCoreInput & {
+    integrationId?: string;
+  };
+
+async function stepHandler(
+  input: GenerateImageCoreInput,
+  credentials: AiGatewayCredentials
+): Promise<GenerateImageResult> {
+  return await generateImage(input, credentials);
+}
+
+export async function generateImageStep(
+  input: GenerateImageInput
+): Promise<GenerateImageResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
+    : {};
+
+  return runPluginStep(
+    { pluginName: "ai-gateway", actionName: "generate-image" },
+    input,
+    (stepInput) => stepHandler(stepInput, credentials)
+  );
+}
+generateImageStep.maxRetries = 0;
+
+export const _integrationType = "ai-gateway";

--- a/plugins/ai-gateway/steps/generate-text-core.ts
+++ b/plugins/ai-gateway/steps/generate-text-core.ts
@@ -1,0 +1,263 @@
+import "server-only";
+
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import type { AiGatewayCredentials } from "../credentials";
+import {
+  type AiGatewayFailure,
+  isRecord,
+  requestAiGateway,
+} from "./ai-gateway-core";
+
+const DEFAULT_TEXT_MODEL = "meta/llama-4-scout";
+const SCHEMA_FIELD_TYPES = new Set([
+  "string",
+  "number",
+  "boolean",
+  "array",
+  "object",
+]);
+const SCHEMA_ARRAY_ITEM_TYPES = new Set([
+  "string",
+  "number",
+  "boolean",
+  "object",
+]);
+
+export type SchemaField = {
+  name: string;
+  type: "string" | "number" | "boolean" | "array" | "object";
+  itemType?: "string" | "number" | "boolean" | "object";
+  fields?: SchemaField[];
+  description?: string;
+  required?: boolean;
+};
+
+export type GenerateTextCoreInput = {
+  aiModel?: string;
+  aiPrompt?: string;
+  aiFormat?: string;
+  aiSchema?: string | SchemaField[];
+};
+
+export type GenerateTextResult =
+  | { success: true; text: string }
+  | { success: true; object: Record<string, unknown> }
+  | AiGatewayFailure;
+
+type SchemaResult =
+  | { success: true; schema: Record<string, unknown> }
+  | AiGatewayFailure;
+
+function userFailure(error: string): AiGatewayFailure {
+  return { success: false, error, errorClass: ExecutionErrorType.USER };
+}
+
+function normaliseModel(model: string): string {
+  if (model.includes("/")) {
+    return model;
+  }
+  if (model.startsWith("claude-")) {
+    return `anthropic/${model}`;
+  }
+  return `openai/${model}`;
+}
+
+function parseSchemaFields(value: string | SchemaField[]): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return;
+  }
+}
+
+function schemaForFields(fields: unknown, location: string): SchemaResult {
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return userFailure(`${location} must contain at least one field.`);
+  }
+
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const candidate of fields) {
+    if (!isRecord(candidate)) {
+      return userFailure(`${location} contains an invalid field.`);
+    }
+
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    const type = typeof candidate.type === "string" ? candidate.type : "";
+    if (!name) {
+      return userFailure(`${location} contains a field without a name.`);
+    }
+    if (!SCHEMA_FIELD_TYPES.has(type)) {
+      return userFailure(`${location}.${name} has an unsupported type.`);
+    }
+    if (Object.hasOwn(properties, name)) {
+      return userFailure(`${location} contains duplicate field "${name}".`);
+    }
+
+    const property: Record<string, unknown> = { type };
+    if (
+      typeof candidate.description === "string" &&
+      candidate.description.trim()
+    ) {
+      property.description = candidate.description.trim();
+    }
+
+    if (type === "object") {
+      const nested = schemaForFields(candidate.fields, `${location}.${name}`);
+      if (!nested.success) {
+        return nested;
+      }
+      Object.assign(property, nested.schema);
+    } else if (type === "array") {
+      const itemType =
+        typeof candidate.itemType === "string" ? candidate.itemType : "";
+      if (!SCHEMA_ARRAY_ITEM_TYPES.has(itemType)) {
+        return userFailure(
+          `${location}.${name} must define a valid array item type.`
+        );
+      }
+      if (itemType === "object") {
+        const nested = schemaForFields(
+          candidate.fields,
+          `${location}.${name}[]`
+        );
+        if (!nested.success) {
+          return nested;
+        }
+        property.items = nested.schema;
+      } else {
+        property.items = { type: itemType };
+      }
+    }
+
+    properties[name] = property;
+    if (candidate.required === true) {
+      required.push(name);
+    }
+  }
+
+  const schema: Record<string, unknown> = {
+    type: "object",
+    properties,
+    additionalProperties: false,
+  };
+  if (required.length > 0) {
+    schema.required = required;
+  }
+  return { success: true, schema };
+}
+
+function extractText(data: unknown): string | undefined {
+  if (!isRecord(data) || !Array.isArray(data.choices)) {
+    return;
+  }
+  const firstChoice = data.choices[0];
+  if (!isRecord(firstChoice) || !isRecord(firstChoice.message)) {
+    return;
+  }
+  const content = firstChoice.message.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return;
+  }
+  const textParts: string[] = [];
+  for (const part of content) {
+    if (
+      isRecord(part) &&
+      part.type === "text" &&
+      typeof part.text === "string"
+    ) {
+      textParts.push(part.text);
+    }
+  }
+  return textParts.length > 0 ? textParts.join("") : undefined;
+}
+
+export async function generateText(
+  input: GenerateTextCoreInput,
+  credentials: AiGatewayCredentials
+): Promise<GenerateTextResult> {
+  const apiKey = credentials.AI_GATEWAY_API_KEY;
+  if (!apiKey) {
+    return userFailure(
+      "AI_GATEWAY_API_KEY is not configured. Please add it in Project Integrations."
+    );
+  }
+
+  const prompt =
+    typeof input.aiPrompt === "string" ? input.aiPrompt.trim() : "";
+  if (!prompt) {
+    return userFailure("Prompt is required for text generation.");
+  }
+
+  const model = (input.aiModel ?? DEFAULT_TEXT_MODEL).trim();
+  if (!model) {
+    return userFailure("Model is required for text generation.");
+  }
+
+  const format = input.aiFormat ?? "text";
+  if (format !== "text" && format !== "object") {
+    return userFailure('Output format must be either "text" or "object".');
+  }
+
+  const body: Record<string, unknown> = {
+    model: normaliseModel(model),
+    messages: [{ role: "user", content: prompt }],
+  };
+
+  if (format === "object") {
+    if (input.aiSchema === undefined || input.aiSchema === "") {
+      return userFailure("Schema is required for object output.");
+    }
+    const schema = schemaForFields(parseSchemaFields(input.aiSchema), "Schema");
+    if (!schema.success) {
+      return schema;
+    }
+    body.response_format = {
+      type: "json_schema",
+      json_schema: { name: "response", schema: schema.schema },
+    };
+  }
+
+  const response = await requestAiGateway("/chat/completions", apiKey, body);
+  if (!response.success) {
+    return response;
+  }
+
+  const text = extractText(response.data);
+  if (text === undefined) {
+    return {
+      success: false,
+      error: "AI Gateway returned a malformed text-generation response.",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    };
+  }
+
+  if (format === "object") {
+    try {
+      const object = JSON.parse(text) as unknown;
+      if (!isRecord(object)) {
+        return {
+          success: false,
+          error: "AI Gateway returned structured output that is not an object.",
+          errorClass: ExecutionErrorType.EXTERNAL,
+        };
+      }
+      return { success: true, object };
+    } catch {
+      return {
+        success: false,
+        error: "AI Gateway returned invalid JSON for structured output.",
+        errorClass: ExecutionErrorType.EXTERNAL,
+      };
+    }
+  }
+
+  return { success: true, text };
+}

--- a/plugins/ai-gateway/steps/generate-text.ts
+++ b/plugins/ai-gateway/steps/generate-text.ts
@@ -1,0 +1,52 @@
+import "server-only";
+
+import { fetchCredentials } from "@/lib/credential-fetcher";
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import type { AiGatewayCredentials } from "../credentials";
+import {
+  type GenerateTextCoreInput,
+  type GenerateTextResult,
+  generateText,
+} from "./generate-text-core";
+
+export type {
+  GenerateTextCoreInput,
+  GenerateTextResult,
+  SchemaField,
+} from "./generate-text-core";
+
+export type GenerateTextInput = StepInput &
+  GenerateTextCoreInput & {
+    integrationId?: string;
+  };
+
+async function stepHandler(
+  input: GenerateTextCoreInput,
+  credentials: AiGatewayCredentials
+): Promise<GenerateTextResult> {
+  return await generateText(input, credentials);
+}
+
+export async function generateTextStep(
+  input: GenerateTextInput
+): Promise<GenerateTextResult> {
+  "use step";
+
+  const credentials = input.integrationId
+    ? await fetchCredentials(input.integrationId, {
+        organizationId: input._context?.organizationId ?? null,
+      })
+    : {};
+
+  return runPluginStep(
+    { pluginName: "ai-gateway", actionName: "generate-text" },
+    input,
+    (stepInput) => stepHandler(stepInput, credentials)
+  );
+}
+generateTextStep.maxRetries = 0;
+
+export const _integrationType = "ai-gateway";

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -13,9 +13,10 @@
  * 1. Delete the plugin directory
  * 2. Run: pnpm discover-plugins (or it runs automatically on build)
  *
- * Discovered plugins: blockscout, code, discord, hyperliquid, math, protocol, robinhood, safe, sendgrid, slack, telegram, tempo, web3, webhook
+ * Discovered plugins: ai-gateway, blockscout, code, discord, hyperliquid, math, protocol, robinhood, safe, sendgrid, slack, telegram, tempo, web3, webhook
  */
 
+import "./ai-gateway";
 import "./blockscout";
 import "./code";
 import "./discord";

--- a/plugins/plugin-allowlist.json
+++ b/plugins/plugin-allowlist.json
@@ -2,6 +2,7 @@
   "$schema": "./plugin-allowlist.schema.json",
   "description": "Plugin allowlist - only plugins listed here will be enabled",
   "plugins": [
+    "ai-gateway",
     "blockscout",
     "code",
     "discord",

--- a/tests/unit/ai-gateway-registry.test.ts
+++ b/tests/unit/ai-gateway-registry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-fetch", () => ({
+  safeFetch: vi.fn(),
+}));
+
+import { getIntegration } from "@/plugins/registry";
+
+describe("AI Gateway registry discovery", () => {
+  const cases: Array<{
+    slug: string;
+    stepFunction: string;
+    load: () => Promise<Record<string, unknown>>;
+  }> = [
+    {
+      slug: "generate-text",
+      stepFunction: "generateTextStep",
+      load: () => import("@/plugins/ai-gateway/steps/generate-text"),
+    },
+    {
+      slug: "generate-image",
+      stepFunction: "generateImageStep",
+      load: () => import("@/plugins/ai-gateway/steps/generate-image"),
+    },
+  ];
+
+  it.each(cases)("discovers ai-gateway/$slug", async (testCase) => {
+    const plugin = getIntegration("ai-gateway");
+    const action = plugin?.actions.find(
+      (candidate) => candidate.slug === testCase.slug
+    );
+
+    expect(action).toMatchObject({
+      stepFunction: testCase.stepFunction,
+      stepImportPath: testCase.slug,
+    });
+    const stepModule = await testCase.load();
+    expect(stepModule[testCase.stepFunction]).toBeTypeOf("function");
+  });
+});

--- a/tests/unit/ai-gateway-steps.test.ts
+++ b/tests/unit/ai-gateway-steps.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+const { fetchCredentials } = vi.hoisted(() => ({
+  fetchCredentials: vi.fn(),
+}));
+vi.mock("@/lib/credential-fetcher", () => ({ fetchCredentials }));
+
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", () => ({ safeFetch }));
+
+import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
+import { generateImageStep } from "@/plugins/ai-gateway/steps/generate-image";
+import { generateTextStep } from "@/plugins/ai-gateway/steps/generate-text";
+
+function mockGatewayResponse(
+  body: unknown,
+  options?: { ok?: boolean; status?: number }
+): void {
+  safeFetch.mockResolvedValueOnce({
+    ok: options?.ok ?? true,
+    status: options?.status ?? 200,
+    json: vi.fn().mockResolvedValue(body),
+  });
+}
+
+function requestBody(callIndex = 0): Record<string, unknown> {
+  const options = safeFetch.mock.calls[callIndex]?.[1] as
+    | { body?: string }
+    | undefined;
+  return JSON.parse(options?.body ?? "{}") as Record<string, unknown>;
+}
+
+describe("AI Gateway generate text", () => {
+  beforeEach(() => {
+    fetchCredentials.mockReset();
+    safeFetch.mockReset();
+    fetchCredentials.mockResolvedValue({ AI_GATEWAY_API_KEY: "gateway-key" });
+  });
+
+  it("fetches BYOK credentials in the organization context and sends the Gateway request", async () => {
+    mockGatewayResponse({
+      choices: [{ message: { content: "Generated response" } }],
+    });
+
+    const result = await generateTextStep({
+      integrationId: "integration-1",
+      aiModel: "anthropic/claude-sonnet-4.5",
+      aiPrompt: "Write a summary",
+      aiFormat: "text",
+      _context: {
+        organizationId: "organization-1",
+        nodeId: "node-1",
+        nodeName: "Generate Text",
+        nodeType: "ai-gateway/generate-text",
+      },
+    });
+
+    expect(result).toEqual({ success: true, text: "Generated response" });
+    expect(fetchCredentials).toHaveBeenCalledWith("integration-1", {
+      organizationId: "organization-1",
+    });
+    expect(safeFetch).toHaveBeenCalledTimes(1);
+    expect(safeFetch).toHaveBeenCalledWith(
+      "https://ai-gateway.vercel.sh/v1/chat/completions",
+      expect.objectContaining({
+        plugin: "ai-gateway",
+        method: "POST",
+        headers: {
+          Authorization: "Bearer gateway-key",
+          "Content-Type": "application/json",
+        },
+      })
+    );
+    expect(requestBody()).toEqual({
+      model: "anthropic/claude-sonnet-4.5",
+      messages: [{ role: "user", content: "Write a summary" }],
+    });
+  });
+
+  it("requests and parses structured object output", async () => {
+    mockGatewayResponse({
+      choices: [{ message: { content: '{"title":"KeeperHub"}' } }],
+    });
+
+    const result = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Return a title",
+      aiFormat: "object",
+      aiSchema: JSON.stringify([
+        {
+          name: "title",
+          type: "string",
+          description: "The title",
+          required: true,
+        },
+      ]),
+    });
+
+    expect(result).toEqual({
+      success: true,
+      object: { title: "KeeperHub" },
+    });
+    expect(requestBody()).toEqual({
+      model: "meta/llama-4-scout",
+      messages: [{ role: "user", content: "Return a title" }],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          schema: {
+            type: "object",
+            properties: {
+              title: { type: "string", description: "The title" },
+            },
+            additionalProperties: false,
+            required: ["title"],
+          },
+        },
+      },
+    });
+  });
+
+  it("returns provider errors without throwing", async () => {
+    mockGatewayResponse(
+      { error: { message: "Model is unavailable" } },
+      { ok: false, status: 503 }
+    );
+
+    const result = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Hello",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Model is unavailable",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    });
+  });
+
+  it("returns a typed failure for a malformed success response", async () => {
+    mockGatewayResponse({ choices: [] });
+
+    const result = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Hello",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "AI Gateway returned a malformed text-generation response.",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    });
+  });
+
+  it("validates format and schema before egress", async () => {
+    const invalidFormat = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Hello",
+      aiFormat: "xml",
+    });
+    const missingSchema = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Hello",
+      aiFormat: "object",
+    });
+
+    expect(invalidFormat).toEqual({
+      success: false,
+      error: 'Output format must be either "text" or "object".',
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(missingSchema).toEqual({
+      success: false,
+      error: "Schema is required for object output.",
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("validates prompt and model before egress", async () => {
+    const missingPrompt = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: " ",
+    });
+    const missingModel = await generateTextStep({
+      integrationId: "integration-1",
+      aiPrompt: "Hello",
+      aiModel: "",
+    });
+
+    expect(missingPrompt).toEqual({
+      success: false,
+      error: "Prompt is required for text generation.",
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(missingModel).toEqual({
+      success: false,
+      error: "Model is required for text generation.",
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("AI Gateway generate image", () => {
+  beforeEach(() => {
+    fetchCredentials.mockReset();
+    safeFetch.mockReset();
+    fetchCredentials.mockResolvedValue({ AI_GATEWAY_API_KEY: "gateway-key" });
+  });
+
+  it("returns base64 and sends the intended image request shape", async () => {
+    mockGatewayResponse({ data: [{ b64_json: "aW1hZ2U=" }] });
+
+    const result = await generateImageStep({
+      integrationId: "integration-1",
+      imageModel: "google/imagen-4.0-fast-generate-001",
+      imagePrompt: "A mountain at sunset",
+    });
+
+    expect(result).toEqual({ success: true, base64: "aW1hZ2U=" });
+    expect(safeFetch).toHaveBeenCalledWith(
+      "https://ai-gateway.vercel.sh/v1/images/generations",
+      expect.objectContaining({ plugin: "ai-gateway", method: "POST" })
+    );
+    expect(requestBody()).toEqual({
+      model: "google/imagen-4.0-fast-generate-001",
+      prompt: "A mountain at sunset",
+      size: "1024x1024",
+      response_format: "b64_json",
+    });
+  });
+
+  it("returns a typed user failure for a provider rejection", async () => {
+    mockGatewayResponse(
+      { error: { message: "Unsupported image model" } },
+      { ok: false, status: 400 }
+    );
+
+    const result = await generateImageStep({
+      integrationId: "integration-1",
+      imagePrompt: "A mountain",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Unsupported image model",
+      errorClass: ExecutionErrorType.USER,
+    });
+  });
+
+  it("returns a typed failure for a malformed success response", async () => {
+    mockGatewayResponse({ data: [{ url: "https://example.com/image.png" }] });
+
+    const result = await generateImageStep({
+      integrationId: "integration-1",
+      imagePrompt: "A mountain",
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: "AI Gateway returned a malformed image-generation response.",
+      errorClass: ExecutionErrorType.EXTERNAL,
+    });
+  });
+
+  it("validates prompt and model before egress", async () => {
+    const missingPrompt = await generateImageStep({
+      integrationId: "integration-1",
+      imagePrompt: " ",
+    });
+    const missingModel = await generateImageStep({
+      integrationId: "integration-1",
+      imagePrompt: "A mountain",
+      imageModel: "",
+    });
+
+    expect(missingPrompt).toEqual({
+      success: false,
+      error: "Prompt is required for image generation.",
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(missingModel).toEqual({
+      success: false,
+      error: "Model is required for image generation.",
+      errorClass: ExecutionErrorType.USER,
+    });
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
﻿## Summary

Fixes #2316 by adding the missing runtime step implementations for the AI Gateway `generate-text` and `generate-image` actions.

- adds `generate-text` / `generate-image` step files and core logic
- uses `fetchCredentials` for the existing BYOK `apiKey` integration field
- routes outbound AI Gateway traffic through `safeFetch({ plugin: "ai-gateway" })`
- supports text and schema-backed object output
- returns base64 image output in the shape already declared by the plugin
- registers `ai-gateway` in the generated plugin index/allowlist
- adds focused mocked unit coverage without making external AI calls

## Validation

- `vitest run tests/unit/ai-gateway-steps.test.ts tests/unit/ai-gateway-registry.test.ts` — **12/12 PASS**
- `tsc --noEmit` — **PASS**
- `git diff --check` — **PASS**

`discover-plugins` on this Windows checkout reaches AI Gateway discovery successfully, then hits the repository's pre-existing Windows ESM absolute-path issue while importing `protocols/*.ts` (`ERR_UNSUPPORTED_ESM_URL_SCHEME`, drive-letter path). That failure is outside these AI Gateway files; the targeted registry tests prove both new runtime modules resolve and register correctly.

No API keys or paid external calls were used during validation.
