### PR TITLE
fix: #2328 discover-plugins fails on Windows — absolute path is not a valid ESM specifier

### DIFF
--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -29,6 +29,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import ts from "typescript";
 
 const PLUGINS_DIR = join(process.cwd(), "plugins");
@@ -118,7 +119,9 @@ async function loadProtocolDefinitions(): Promise<ProtocolEntry[]> {
 
   for (const filePath of filePaths) {
     try {
-      const mod = await import(filePath);
+      // Windows: a bare absolute path ("C:\...") is not a valid ESM
+      // specifier -- Node's loader rejects it with ERR_UNSUPPORTED_ESM_URL_SCHEME.
+      const mod = await import(pathToFileURL(filePath).href);
       const definition =
         mod.default as import("@/lib/protocol-registry").ProtocolDefinition;
 


### PR DESCRIPTION
## Problem

`pnpm discover-plugins` fails on Windows, and since it is the first step of both `dev` and `build`, nothing downstream runs.

```
Failed to import protocol from C:\work\keeperhub\protocols\aave-v3.ts
ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'
```

`scripts/discover-plugins.ts` passes an absolute filesystem path to `await import()`. On POSIX an absolute path happens to be a valid specifier; on Windows it is not — the ESM loader reads `C:` as a URL scheme and rejects it. This is why CI has never caught it: the pipeline runs on `ubuntu-latest`.

## Impact

The script generates four modules that the rest of the codebase imports:

```
lib/step-registry.ts
lib/credential-map.ts
lib/output-display-configs.ts
lib/workflow/codegen/registry.ts
```

When generation fails, those files are never written, and `pnpm type-check` reports 9 `TS2307 Cannot find module` errors. A Windows contributor sees a type-check failure and no obvious cause — the actual error scrolls past during a step that appears to succeed.

## Fix

One line, plus the import:

```diff
+ import { pathToFileURL } from "node:url";
- const mod = await import(filePath);
+ const mod = await import(pathToFileURL(filePath).href);
```

`pathToFileURL` is the documented way to turn a path into an ESM specifier and is a no-op in behaviour on POSIX, so this does not change anything for existing CI.

## Verification

Measured on Windows 11 / Node 24.18 / pnpm 10.34:

| | before | after |
|---|---|---|
| `pnpm discover-plugins` | exit 1, 14 import failures | exit 0, 0 failures |
| `pnpm type-check` | 9 errors | 0 errors, exit 0 |

I also grepped the repository for other dynamic imports with the same shape. Every other `await import()` takes either a string literal or a relative specifier (e.g. `STEP_REGISTRY` in `scripts/runtime/.../profile-step.ts` uses `../../plugins/...`), both of which are valid on all platforms. This occurrence is the only one.

## One note for maintainers

After generation, git reports three tracked files as modified — `lib/types/integration.ts`, `plugins/index.ts`, `protocols/index.ts` — but `git diff --numstat` is empty: the difference is line endings only. The generator writes CRLF and the repository has no `.gitattributes`. I deliberately excluded them from this commit so the PR stays one file, but a contributor with `core.autocrlf=true` will keep seeing them as dirty. Adding a `.gitattributes` would fix that; happy to do it here or leave it out of scope.