### PR TITLE
feat(event-tracker): eth_call threshold-trigger core evaluation logic (#2240)

### DIFF
--- a/keeperhub-events/event-tracker/lib/types.ts
+++ b/keeperhub-events/event-tracker/lib/types.ts
@@ -35,6 +35,26 @@ export interface RawWorkflowNodeConfig {
   // memo filter, applied as post-decode predicates in the listener.
   recipientAddress?: string;
   memo?: string;
+  // State-threshold trigger (issue #2240). Present only when
+  // `triggerType === "stateThreshold"`; the field names mirror the existing
+  // `web3/read-contract` node config so the builder does not have to invent a
+  // second vocabulary for naming a view call.
+  /** View function to call, by name, resolved against `contractABI`. */
+  abiFunction?: string;
+  /** Arguments for that function, in declaration order. */
+  functionArgs?: unknown[];
+  /** Which output to compare: an index into the outputs, or an output name. */
+  outputPath?: string | number;
+  /** "lt" | "lte" | "gt" | "gte". Validated in the mapper. */
+  comparator?: string;
+  /** Decimal string, scaled by `decimals` into the comparable integer. */
+  threshold?: string | number;
+  /** Fixed-point scale of the read value. Defaults to 0 (raw integer). */
+  decimals?: number;
+  /** Re-arm band width, same units as `threshold`. Defaults to 2% of it. */
+  hysteresis?: string | number;
+  /** Optional floor on blocks between two dispatches. */
+  minBlocksBetweenFires?: number;
 }
 
 export interface RawWorkflowNode {

--- a/keeperhub-events/event-tracker/src/chains/multicall3.ts
+++ b/keeperhub-events/event-tracker/src/chains/multicall3.ts
@@ -1,0 +1,95 @@
+import { ethers } from "ethers";
+
+/**
+ * Multicall3 batching for state reads (issue #2240).
+ *
+ * `provider-manager.ts` already documents why log delivery uses a block
+ * subscription plus batched `eth_getLogs` rather than one subscription per
+ * listener: it decouples RPC-side cost from workflow count. A state trigger
+ * that issued its own `eth_call` per subscription would give that property
+ * back. Batching every state subscription on a chain into one `aggregate3`
+ * restores it - one additional call per chain per drain, whatever the
+ * subscription count.
+ *
+ * `aggregate3` rather than `aggregate` because it takes `allowFailure` per
+ * call: one reverting view function then fails in its own slot instead of
+ * reverting the batch and costing every other subscription on the chain its
+ * sample.
+ */
+
+/**
+ * Canonical Multicall3 deployment address, identical across the chains that
+ * have it. Presence is probed per chain rather than assumed - see
+ * `ChainProviderManager.probeMulticall3`. A contributor's `eth_getCode` sweep
+ * on issue #2240 found it on all 11 configured mainnets, which is a statement
+ * about the chain table as it stood on one day, and the table grows.
+ */
+export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+
+/**
+ * Local ABI slice rather than an import from the monorepo root's
+ * `lib/contracts`. `@techops/events-tracker` is a standalone package
+ * (`rootDir: "."`, `include: ["src/**", "lib/**"]` scoped to its own `lib/`)
+ * and cannot resolve modules above itself, the same constraint `in-flight.ts`
+ * documents for its copy of the executor's tracker.
+ */
+const AGGREGATE3_ABI = [
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[] returnData)",
+];
+
+const aggregate3Interface = new ethers.Interface(AGGREGATE3_ABI);
+
+/**
+ * Calls per `aggregate3`. Every call in a batch shares one `eth_call`, so the
+ * batch is bounded by the node's `eth_call` gas cap rather than by response
+ * size: above it the whole batch fails, taking every subscription on the chain
+ * with it. Caps are commonly 10-50M and a view like Aave's
+ * `getUserAccountData` costs a few hundred thousand, so 50 keeps a batch
+ * inside the tightest of those with room to spare. Chunking also bounds the
+ * blast radius of a batch that fails for any other reason: it costs its own
+ * chunk a sample, not the chain. Analogous in role to
+ * `GETLOGS_MAX_BLOCK_SPAN`.
+ */
+export const STATE_CALL_MAX_BATCH = 50;
+
+export interface Aggregate3Call {
+  target: string;
+  callData: string;
+}
+
+export interface Aggregate3Result {
+  success: boolean;
+  returnData: string;
+}
+
+/** Encode one `aggregate3` batch to calldata ready for `eth_call`. */
+export function encodeAggregate3(calls: Aggregate3Call[]): string {
+  return aggregate3Interface.encodeFunctionData("aggregate3", [
+    calls.map((call) => ({
+      target: call.target,
+      allowFailure: true,
+      callData: call.callData,
+    })),
+  ]);
+}
+
+/** Decode an `aggregate3` return into one slot per call, in call order. */
+export function decodeAggregate3(returnData: string): Aggregate3Result[] {
+  const [results] = aggregate3Interface.decodeFunctionResult(
+    "aggregate3",
+    returnData,
+  );
+  return (results as Array<{ success: boolean; returnData: string }>).map(
+    (slot) => ({ success: slot.success, returnData: slot.returnData }),
+  );
+}
+
+/** Split a list into `STATE_CALL_MAX_BATCH`-sized chunks. */
+export function chunkCalls<T>(items: T[], size = STATE_CALL_MAX_BATCH): T[][] {
+  const bounded = size > 0 ? size : STATE_CALL_MAX_BATCH;
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += bounded) {
+    chunks.push(items.slice(i, i + bounded));
+  }
+  return chunks;
+}

--- a/keeperhub-events/event-tracker/src/chains/provider-manager.ts
+++ b/keeperhub-events/event-tracker/src/chains/provider-manager.ts
@@ -1,6 +1,13 @@
 import { ethers } from "ethers";
 import { WebSocket } from "ws";
 import { logger } from "../../lib/utils/logger";
+import {
+  type Aggregate3Result,
+  MULTICALL3_ADDRESS,
+  chunkCalls,
+  decodeAggregate3,
+  encodeAggregate3,
+} from "./multicall3";
 
 /**
  * ChainProviderManager centralises WebSocket provider ownership and
@@ -235,7 +242,34 @@ export const GETLOGS_TIMEOUT_RECONNECT_THRESHOLD = 3;
 /** Marks the timeout branch of the `eth_getLogs` race, for escalation. */
 class GetLogsTimeoutError extends Error {}
 
+/**
+ * Cap on a state read's round-trip, for the same reason `GETLOGS_TIMEOUT_MS`
+ * exists: state sampling runs inside the drain and the drain owns `draining`
+ * for its whole duration, so an `eth_call` ethers never settles would hold the
+ * chain's log delivery shut behind it.
+ */
+export const STATE_CALL_TIMEOUT_MS = 30_000;
+
 export type LogHandler = (log: ethers.Log) => void | Promise<void>;
+
+/**
+ * Delivery of one state subscription's sample. `result` carries the raw call
+ * outcome; decoding it needs the subscription's ABI output types, which the
+ * manager deliberately does not know. `undefined` is not delivered - a
+ * subscription whose chunk failed simply has no sample this drain.
+ */
+export type StateCallHandler = (
+  result: Aggregate3Result,
+  blockNumber: number,
+) => void | Promise<void>;
+
+/**
+ * Whether Multicall3 is deployed on a chain. `unknown` until probed, and back
+ * to `unknown` if the probe itself failed rather than answered - a transient
+ * RPC error must not pin a chain to the per-subscription fallback for the
+ * lifetime of the process.
+ */
+type Multicall3Status = "unknown" | "present" | "absent";
 export type Unsubscribe = () => void;
 
 export type ProviderFactory = (wssUrl: string) => ethers.WebSocketProvider;
@@ -355,6 +389,17 @@ export interface SubscribeOptions {
   handler: LogHandler;
 }
 
+export interface SubscribeStateOptions {
+  chainId: number;
+  wssUrl: string;
+  fallbackWssUrl?: string;
+  /** Contract the view function is called on. */
+  contractAddress: string;
+  /** ABI-encoded calldata for the view function. */
+  callData: string;
+  handler: StateCallHandler;
+}
+
 export interface ChainProviderManagerOptions {
   factory?: ProviderFactory;
   onPermanentFailure?: (chainId: number) => void;
@@ -370,6 +415,12 @@ interface Subscriber {
   address: string; // normalized to lowercase
   topic0: string; // 0x-prefixed, lowercase
   handler: LogHandler;
+}
+
+interface StateSubscriber {
+  contractAddress: string;
+  callData: string;
+  handler: StateCallHandler;
 }
 
 interface ChainEntry {
@@ -403,6 +454,15 @@ interface ChainEntry {
    */
   reconnectPromise: Promise<void> | null;
   subscribers: Set<Subscriber>;
+  /**
+   * State-threshold subscriptions on this chain (issue #2240). Batched into
+   * one `aggregate3` per drain, so their cost is one call per chain per drain
+   * rather than one per subscription - the same decoupling of RPC cost from
+   * workflow count the log path gets from ranged `eth_getLogs`.
+   */
+  stateSubscribers: Set<StateSubscriber>;
+  /** Cached Multicall3 deployment status for this chain. */
+  multicall3: Multicall3Status;
   blockListener: ((blockNumber: number) => Promise<void>) | null;
   errorListener: ((err: Error) => void) | null;
   heartbeatTimer: ReturnType<typeof setInterval> | null;
@@ -521,6 +581,10 @@ interface ChainStats {
   /** Times a re-announced height was too deep to rewind to, so was dropped. */
   reorgRewindsRefused: number;
   getLogsCallsTotal: number;
+  /** `eth_call`s issued for state sampling: one per aggregate3 chunk, or one
+   * per subscription on a chain with no Multicall3. */
+  stateCalls: number;
+  stateCallErrors: number;
 }
 
 function newChainStats(): ChainStats {
@@ -534,6 +598,8 @@ function newChainStats(): ChainStats {
     reorgRewinds: 0,
     reorgRewindsRefused: 0,
     getLogsCallsTotal: 0,
+    stateCalls: 0,
+    stateCallErrors: 0,
   };
 }
 
@@ -713,11 +779,63 @@ export class ChainProviderManager {
 
     return () => {
       entry.subscribers.delete(subscriber);
-      if (entry.subscribers.size === 0) {
-        this.detachBlockListener(entry);
-        this.stopHeartbeat(entry);
-      }
+      this.detachIfIdle(entry);
     };
+  }
+
+  /**
+   * Register a state-threshold subscription (issue #2240). Shares the chain's
+   * provider, block subscription, drain loop, rate limit and heartbeat with
+   * the log path - there is no second connection, no second cadence and no
+   * new process.
+   *
+   * Sampling happens once per drain at the head block, not once per block:
+   * a chain accumulating against the high-water mark serves state at the
+   * drain's cadence, so intermediate blocks are not observed. See the header
+   * of `state-threshold.ts` for what that costs.
+   */
+  async subscribeToState(opts: SubscribeStateOptions): Promise<Unsubscribe> {
+    const entry = this.ensureEntry(
+      opts.chainId,
+      opts.wssUrl,
+      opts.fallbackWssUrl,
+    );
+    await this.getOrCreateProvider(
+      opts.chainId,
+      opts.wssUrl,
+      opts.fallbackWssUrl,
+    );
+
+    const subscriber: StateSubscriber = {
+      contractAddress: opts.contractAddress,
+      callData: opts.callData,
+      handler: opts.handler,
+    };
+    entry.stateSubscribers.add(subscriber);
+
+    // Same lifecycle rule as subscribeToLogs: attach on the first subscriber
+    // of either kind, detach on the last.
+    if (!entry.blockListener) {
+      this.attachBlockListener(entry);
+      this.startHeartbeat(entry);
+    }
+
+    return () => {
+      entry.stateSubscribers.delete(subscriber);
+      this.detachIfIdle(entry);
+    };
+  }
+
+  /**
+   * Tear down the block listener and heartbeat once a chain has no subscriber
+   * of either kind left. Both subscriber sets are checked because either one
+   * alone is reason enough to keep the block subscription alive.
+   */
+  private detachIfIdle(entry: ChainEntry): void {
+    if (entry.subscribers.size === 0 && entry.stateSubscribers.size === 0) {
+      this.detachBlockListener(entry);
+      this.stopHeartbeat(entry);
+    }
   }
 
   /**
@@ -755,6 +873,15 @@ export class ChainProviderManager {
    */
   subscriberCount(chainId: number): number {
     return this.chains.get(chainId)?.subscribers.size ?? 0;
+  }
+
+  /**
+   * Number of active state-threshold subscribers for `chainId`. Returns 0 for
+   * an unknown chain. Used by tests to assert that state subscriptions
+   * multiplex through the same ChainEntry as log ones.
+   */
+  stateSubscriberCount(chainId: number): number {
+    return this.chains.get(chainId)?.stateSubscribers.size ?? 0;
   }
 
   /**
@@ -884,6 +1011,8 @@ export class ChainProviderManager {
       readyPromise: null,
       reconnectPromise: null,
       subscribers: new Set(),
+      stateSubscribers: new Set(),
+      multicall3: "unknown",
       blockListener: null,
       errorListener: null,
       heartbeatTimer: null,
@@ -1217,7 +1346,7 @@ export class ChainProviderManager {
       entry.isReconnecting ||
       this.isDestroyed ||
       !entry.provider ||
-      entry.subscribers.size === 0 ||
+      (entry.subscribers.size === 0 && entry.stateSubscribers.size === 0) ||
       entry.headBlock === null
     ) {
       return;
@@ -1286,8 +1415,25 @@ export class ChainProviderManager {
       entry.lastRequestAt = Date.now();
       // The mark advances only on success. A failed range stays owed, so the
       // next drain re-queries it instead of losing every event in it.
-      if (await this.processBlockRange(entry, from, to)) {
+      //
+      // A chain carrying only state subscriptions has no range to serve, and
+      // must still advance the mark: leaving it behind would arm the catch-up
+      // timer on a gap nothing will ever close and spin the drain at the rate
+      // limit forever.
+      const served =
+        entry.subscribers.size === 0
+          ? true
+          : await this.processBlockRange(entry, from, to);
+      if (served) {
         entry.lastProcessedBlock = to;
+      }
+      // Sampled at the head rather than at `to`: `to` can trail the head on a
+      // chain that is catching up, and a state trigger wants the current
+      // value, not the one at the oldest block still owed. Read inside the
+      // drain so it shares the rate limit, and after the logs so a slow state
+      // read cannot delay them.
+      if (entry.stateSubscribers.size > 0 && entry.headBlock !== null) {
+        await this.sampleState(entry, entry.headBlock);
       }
     } finally {
       entry.draining = false;
@@ -1725,6 +1871,215 @@ export class ChainProviderManager {
    * makes the next drain re-query it. Dispatching the chunks that did return
    * would deliver a partial view of the range and then never fetch the rest.
    */
+  /**
+   * One state sample for a chain: read every state subscription's view
+   * function at `blockNumber` and hand each its own result.
+   *
+   * Batched through Multicall3 where it is deployed, so the marginal cost is
+   * one `eth_call` per chunk per drain rather than one per subscription. On a
+   * chain without it the fallback is one call per subscription, logged once so
+   * the degradation is known rather than silent - a batching design that
+   * quietly becomes an N-call design is worse than one that says it has.
+   *
+   * A failed chunk costs its own subscriptions this sample and nothing else.
+   * There is no retry and no owed-range equivalent: a state read is a sample
+   * of the present, so re-reading a block that has since been superseded
+   * would report a value that is no longer true.
+   */
+  private async sampleState(
+    entry: ChainEntry,
+    blockNumber: number,
+  ): Promise<void> {
+    const subscribers = [...entry.stateSubscribers];
+    // Captured once, for the same reason `processBlockRange` captures it: a
+    // reconnect between chunks would otherwise bill the remaining calls
+    // against a connection this sample does not belong to.
+    const provider = entry.provider;
+    if (subscribers.length === 0 || !provider) {
+      return;
+    }
+
+    const blockTag = `0x${blockNumber.toString(16)}`;
+    const status = await this.probeMulticall3(entry, provider);
+    if (entry.provider !== provider) {
+      return;
+    }
+
+    const results =
+      status === "present"
+        ? await this.sampleViaMulticall3(entry, provider, subscribers, blockTag)
+        : await this.sampleOneByOne(entry, provider, subscribers, blockTag);
+
+    // Concurrently and error-isolated, matching `dispatchLog`: a handler that
+    // parks (the listener's SQS round-trip) must not stall every other
+    // subscription sharing the sample.
+    await Promise.all(
+      subscribers.map(async (sub, index) => {
+        const result = results[index];
+        if (result === undefined) {
+          return;
+        }
+        try {
+          await sub.handler(result, blockNumber);
+        } catch (err) {
+          logger.warn(
+            `[ChainProviderManager] chain=${entry.chainId} state subscriber handler threw: ${String(err)}`,
+          );
+        }
+      }),
+    );
+  }
+
+  /**
+   * Whether Multicall3 is deployed on this chain, probed once and cached.
+   *
+   * A probe that throws leaves the status `unknown` rather than `absent`: an
+   * RPC hiccup must not pin the chain to the per-subscription fallback for
+   * the life of the process. The sample it was probing for still goes out,
+   * one call per subscription, and the next drain probes again.
+   */
+  private async probeMulticall3(
+    entry: ChainEntry,
+    provider: ethers.WebSocketProvider,
+  ): Promise<Multicall3Status> {
+    if (entry.multicall3 !== "unknown") {
+      return entry.multicall3;
+    }
+    try {
+      const code = await this.sendWithTimeout(
+        provider,
+        "eth_getCode",
+        [MULTICALL3_ADDRESS, "latest"],
+        STATE_CALL_TIMEOUT_MS,
+      );
+      const deployed = typeof code === "string" && code.length > 2;
+      entry.multicall3 = deployed ? "present" : "absent";
+      if (!deployed) {
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} no Multicall3 at ${MULTICALL3_ADDRESS}; state reads on this chain cost one eth_call per subscription`,
+        );
+      }
+      return entry.multicall3;
+    } catch (err) {
+      logger.warn(
+        `[ChainProviderManager] chain=${entry.chainId} Multicall3 probe failed, sampling one call per subscription this drain: ${String(err)}`,
+      );
+      return "unknown";
+    }
+  }
+
+  /** Batched path: one `eth_call` per chunk, `allowFailure` per call. */
+  private async sampleViaMulticall3(
+    entry: ChainEntry,
+    provider: ethers.WebSocketProvider,
+    subscribers: StateSubscriber[],
+    blockTag: string,
+  ): Promise<Array<Aggregate3Result | undefined>> {
+    const results = new Array<Aggregate3Result | undefined>(subscribers.length);
+    let offset = 0;
+    for (const chunk of chunkCalls(subscribers)) {
+      const base = offset;
+      offset += chunk.length;
+      if (entry.provider !== provider) {
+        break;
+      }
+      entry.stats.stateCalls += 1;
+      try {
+        const data = encodeAggregate3(
+          chunk.map((sub) => ({
+            target: sub.contractAddress,
+            callData: sub.callData,
+          })),
+        );
+        const raw = await this.sendWithTimeout(
+          provider,
+          "eth_call",
+          [{ to: MULTICALL3_ADDRESS, data }, blockTag],
+          STATE_CALL_TIMEOUT_MS,
+        );
+        const decoded = decodeAggregate3(raw as string);
+        for (let i = 0; i < chunk.length; i += 1) {
+          results[base + i] = decoded[i];
+        }
+      } catch (err) {
+        entry.stats.stateCallErrors += 1;
+        logger.warn(
+          `[ChainProviderManager] chain=${entry.chainId} block=${blockTag} aggregate3 of ${chunk.length} call(s) failed, no sample this drain: ${String(err)}`,
+        );
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Unbatched fallback for a chain with no Multicall3, and for the drain on
+   * which the probe itself failed.
+   *
+   * A revert and a transport failure are indistinguishable here - both arrive
+   * as a rejected `eth_call` - so both are reported as an unsuccessful slot,
+   * which is what `allowFailure` would have produced for the revert anyway.
+   * Either way the subscription has no observation and is skipped.
+   */
+  private async sampleOneByOne(
+    entry: ChainEntry,
+    provider: ethers.WebSocketProvider,
+    subscribers: StateSubscriber[],
+    blockTag: string,
+  ): Promise<Array<Aggregate3Result | undefined>> {
+    const results = new Array<Aggregate3Result | undefined>(subscribers.length);
+    for (let i = 0; i < subscribers.length; i += 1) {
+      if (entry.provider !== provider) {
+        break;
+      }
+      const sub = subscribers[i];
+      entry.stats.stateCalls += 1;
+      try {
+        const raw = await this.sendWithTimeout(
+          provider,
+          "eth_call",
+          [{ to: sub.contractAddress, data: sub.callData }, blockTag],
+          STATE_CALL_TIMEOUT_MS,
+        );
+        results[i] = { success: true, returnData: raw as string };
+      } catch {
+        entry.stats.stateCallErrors += 1;
+        results[i] = { success: false, returnData: "0x" };
+      }
+    }
+    return results;
+  }
+
+  /**
+   * `provider.send` raced against an explicit timeout, for the reason
+   * `processBlockRange` documents at length: ethers exposes no externally
+   * controllable timeout, and a request written to a socket that is then
+   * destroyed is never settled at all.
+   */
+  private async sendWithTimeout(
+    provider: ethers.WebSocketProvider,
+    method: string,
+    params: unknown[],
+    timeoutMs: number,
+  ): Promise<unknown> {
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(
+        () => reject(new Error(`${method} timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+    });
+    try {
+      return await Promise.race([
+        provider.send(method, params),
+        timeoutPromise,
+      ]);
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    }
+  }
+
   private async processBlockRange(
     entry: ChainEntry,
     fromBlock: number,
@@ -1880,7 +2235,9 @@ export class ChainProviderManager {
         stats.getLogsCalls === 0 &&
         stats.getLogsErrors === 0 &&
         stats.blocksSkipped === 0 &&
-        stats.reorgRewindsRefused === 0
+        stats.reorgRewindsRefused === 0 &&
+        stats.stateCalls === 0 &&
+        stats.stateCallErrors === 0
       ) {
         continue;
       }
@@ -1893,7 +2250,7 @@ export class ChainProviderManager {
           ? Math.max(0, entry.headBlock - entry.lastProcessedBlock)
           : 0;
       logger.log(
-        `[ChainProviderManager] getlogs-stats chain=${entry.chainId} blockIntervalMs=${interval} minRequestIntervalMs=${GETLOGS_MIN_INTERVAL_MS} statsIntervalMs=${STATS_LOG_INTERVAL_MS} getLogsCalls=${stats.getLogsCalls} getLogsErrors=${stats.getLogsErrors} blocksCovered=${stats.blocksCovered} ranges=${stats.ranges} blocksSkipped=${stats.blocksSkipped} reorgRewinds=${stats.reorgRewinds} reorgRewindsRefused=${stats.reorgRewindsRefused} blocksBehindHead=${behind} logsDispatched=${stats.logsDispatched} getLogsCallsTotal=${stats.getLogsCallsTotal}`,
+        `[ChainProviderManager] getlogs-stats chain=${entry.chainId} blockIntervalMs=${interval} minRequestIntervalMs=${GETLOGS_MIN_INTERVAL_MS} statsIntervalMs=${STATS_LOG_INTERVAL_MS} getLogsCalls=${stats.getLogsCalls} getLogsErrors=${stats.getLogsErrors} blocksCovered=${stats.blocksCovered} ranges=${stats.ranges} blocksSkipped=${stats.blocksSkipped} reorgRewinds=${stats.reorgRewinds} reorgRewindsRefused=${stats.reorgRewindsRefused} blocksBehindHead=${behind} logsDispatched=${stats.logsDispatched} getLogsCallsTotal=${stats.getLogsCallsTotal} stateCalls=${stats.stateCalls} stateCallErrors=${stats.stateCallErrors}`,
       );
       stats.getLogsCalls = 0;
       stats.getLogsErrors = 0;
@@ -1903,6 +2260,8 @@ export class ChainProviderManager {
       stats.blocksSkipped = 0;
       stats.reorgRewinds = 0;
       stats.reorgRewindsRefused = 0;
+      stats.stateCalls = 0;
+      stats.stateCallErrors = 0;
     }
   }
 

--- a/keeperhub-events/event-tracker/src/listener/arm-state-redis.ts
+++ b/keeperhub-events/event-tracker/src/listener/arm-state-redis.ts
@@ -1,0 +1,90 @@
+import { Redis } from "ioredis";
+import {
+  NODE_ENV,
+  REDIS_HOST,
+  REDIS_PASSWORD,
+  REDIS_PORT,
+} from "../../lib/config/environment";
+import type { ArmStateStore } from "./arm-state";
+import type { ArmPhase, ArmState } from "./state-threshold";
+
+/**
+ * Redis-backed ArmStateStore. Split from `arm-state.ts` so `registry.ts` can
+ * depend on the interface without pulling `ioredis` into test environments
+ * that do not have it, matching the `dedup.ts` / `dedup-redis.ts` split.
+ *
+ * Deliberately unexpired, unlike the dedup keys' 24h TTL. A subscription can
+ * sit armed for months waiting on a threshold it never crosses, and an entry
+ * aged out underneath it would re-seed the generation on the next sample and
+ * dispatch again for an episode already dispatched. The key space is one entry
+ * per active state subscription, so it does not grow without bound; entries
+ * for deleted workflows are the leak, and are small enough to sweep later.
+ */
+
+function buildArmStateKey(subscriptionId: string): string {
+  return `${NODE_ENV}:keeper_state_arm:${subscriptionId}`;
+}
+
+function parseArmState(raw: string): ArmState | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  const phase = candidate.phase;
+  if (phase !== "ARMED" && phase !== "FIRED") {
+    return null;
+  }
+  if (typeof candidate.armGeneration !== "number") {
+    return null;
+  }
+  const lastFiredBlock =
+    typeof candidate.lastFiredBlock === "number"
+      ? candidate.lastFiredBlock
+      : null;
+  return {
+    phase: phase as ArmPhase,
+    armGeneration: candidate.armGeneration,
+    lastFiredBlock,
+  };
+}
+
+export class RedisArmStateStore implements ArmStateStore {
+  constructor(private readonly redis: Redis) {}
+
+  async load(subscriptionId: string): Promise<ArmState | null> {
+    // A read error propagates: the listener must not mistake it for a cold
+    // start. Unparseable stored data is a different matter - it cannot be
+    // resumed from, so it is treated as absent and re-seeded.
+    const raw = await this.redis.get(buildArmStateKey(subscriptionId));
+    if (raw === null) {
+      return null;
+    }
+    return parseArmState(raw);
+  }
+
+  async save(subscriptionId: string, state: ArmState): Promise<void> {
+    await this.redis.set(
+      buildArmStateKey(subscriptionId),
+      JSON.stringify(state),
+    );
+  }
+
+  async disconnect(): Promise<void> {
+    await this.redis.quit();
+  }
+}
+
+export function createRedisArmStateStore(): RedisArmStateStore {
+  const redis = new Redis({
+    host: REDIS_HOST,
+    port: REDIS_PORT,
+    ...(REDIS_PASSWORD && { password: REDIS_PASSWORD }),
+  });
+  return new RedisArmStateStore(redis);
+}

--- a/keeperhub-events/event-tracker/src/listener/arm-state.ts
+++ b/keeperhub-events/event-tracker/src/listener/arm-state.ts
@@ -1,0 +1,29 @@
+import type { ArmState } from "./state-threshold";
+
+/**
+ * Durable home for a state-threshold subscription's arming state.
+ *
+ * Only one thing needs to survive a process bounce: which arming episode a
+ * subscription is in. Everything else about a subscription is rebuilt from the
+ * workflow API on the next reconcile pass. A listener therefore reads this
+ * once at start and holds the state in memory afterwards, writing through on
+ * each transition - the read is a crash-resume, not a per-sample round trip.
+ *
+ * Kept behind an interface, and value-import-free, for the same reason
+ * `dedup.ts` is: `registry.ts` imports it and the registry's unit tests run
+ * without `ioredis` installed. The Redis implementation lives in
+ * `arm-state-redis.ts` and is loaded only through `factory.ts`.
+ *
+ * `load` distinguishes a miss from a failure. A miss is a cold start and the
+ * listener seeds a fresh generation. A failure must not be read as a cold
+ * start: re-seeding on a transient store error would open a new generation
+ * for a subscription that is already armed, and manufacture a duplicate
+ * dispatch out of a blip. Implementations throw instead, and the listener
+ * skips the sample.
+ */
+export interface ArmStateStore {
+  /** The stored state, or null when nothing is stored. Throws on failure. */
+  load(subscriptionId: string): Promise<ArmState | null>;
+  save(subscriptionId: string, state: ArmState): Promise<void>;
+  disconnect(): Promise<void>;
+}

--- a/keeperhub-events/event-tracker/src/listener/factory.ts
+++ b/keeperhub-events/event-tracker/src/listener/factory.ts
@@ -1,6 +1,7 @@
 import { SQS_QUEUE_URL } from "../../lib/config/environment";
 import { sqs } from "../../lib/sqs-client";
 import { chainProviderManager } from "../chains/provider-manager";
+import { createRedisArmStateStore } from "./arm-state-redis";
 import { createRedisDedupStore } from "./dedup-redis";
 import { ListenerRegistry } from "./registry";
 
@@ -16,6 +17,7 @@ export function createRegistry(): ListenerRegistry {
   return new ListenerRegistry({
     providerManager: chainProviderManager,
     dedup: createRedisDedupStore(),
+    armStore: createRedisArmStateStore(),
     sqs,
     sqsQueueUrl: SQS_QUEUE_URL,
   });

--- a/keeperhub-events/event-tracker/src/listener/registry.ts
+++ b/keeperhub-events/event-tracker/src/listener/registry.ts
@@ -2,12 +2,15 @@ import type { SQSClient } from "@aws-sdk/client-sqs";
 import { logger } from "../../lib/utils/logger";
 import type { ChainProviderManager } from "../chains/provider-manager";
 import type { AbiEvent } from "../chains/validation";
+import type { ArmStateStore } from "./arm-state";
 import type { DedupStore } from "./dedup";
 import { EventListener } from "./event-listener";
 import { formatError } from "./format-error";
 import { InFlightTracker } from "./in-flight";
 import { TokenBucketPacer } from "./pacer";
 import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "./shutdown";
+import type { StateThresholdSubscription } from "./state-threshold";
+import { StateThresholdListener } from "./state-threshold-listener";
 
 /**
  * In-process registry of EventListener instances, keyed by workflow ID.
@@ -58,15 +61,56 @@ export interface WorkflowRegistration {
   configHash: string;
 }
 
+/**
+ * A state-threshold registration (issue #2240). Kept as a separate type
+ * rather than as optional fields on `WorkflowRegistration`: the two triggers
+ * share only the workflow and connection fields, and every event-specific
+ * field (`eventName`, the ABI event list, the post-decode filters) is
+ * meaningless here.
+ */
+export interface StateThresholdRegistration {
+  kind: "state";
+  workflowId: string;
+  userId: string;
+  workflowName: string;
+  chainId: number;
+  wssUrl: string;
+  fallbackWssUrl?: string;
+  subscription: StateThresholdSubscription;
+  configHash: string;
+}
+
+export type AnyRegistration = WorkflowRegistration | StateThresholdRegistration;
+
+/**
+ * Discriminates the two registration shapes. A type predicate rather than an
+ * inline `in` check because the inline form narrows the matching branch but
+ * leaves the other as the full union.
+ */
+export function isStateRegistration(
+  reg: AnyRegistration,
+): reg is StateThresholdRegistration {
+  return "kind" in reg && reg.kind === "state";
+}
+
 export interface RegistryDeps {
   providerManager: ChainProviderManager;
   dedup: DedupStore;
   sqs: SQSClient;
   sqsQueueUrl: string;
+  /**
+   * Durable arming state for state-threshold triggers. Optional so that
+   * constructions which only ever register event triggers - unit tests, and
+   * any caller predating #2240 - need not supply one. A state registration
+   * arriving without it is refused rather than run without its guard: the
+   * arm generation is what stops a holding condition dispatching on every
+   * drain, and a listener with nowhere to keep it has no such guard.
+   */
+  armStore?: ArmStateStore;
 }
 
 interface RegistryEntry {
-  listener: EventListener;
+  listener: EventListener | StateThresholdListener;
   configHash: string;
 }
 
@@ -116,10 +160,14 @@ export class ListenerRegistry {
    * production code path. If a caller needs concurrent calls, wrap
    * Registry access in a serialising queue at the call site.
    */
-  async add(reg: WorkflowRegistration): Promise<void> {
+  async add(reg: AnyRegistration): Promise<void> {
     if (this.entries.has(reg.workflowId)) {
       // Idempotent: Phase 4 reconciler handles config changes via
       // remove+add rather than in-place mutation.
+      return;
+    }
+    if (isStateRegistration(reg)) {
+      await this.addStateThreshold(reg);
       return;
     }
     const listener = new EventListener({
@@ -137,6 +185,45 @@ export class ListenerRegistry {
     } catch (err) {
       logger.warn(
         `[ListenerRegistry] failed to start listener ${reg.workflowId}: ${formatError(err)}`,
+      );
+      return;
+    }
+    this.entries.set(reg.workflowId, {
+      listener,
+      configHash: reg.configHash,
+    });
+  }
+
+  private async addStateThreshold(
+    reg: StateThresholdRegistration,
+  ): Promise<void> {
+    const armStore = this.deps.armStore;
+    if (!armStore) {
+      logger.warn(
+        `[ListenerRegistry] refusing state-threshold listener ${reg.workflowId}: no arm-state store configured`,
+      );
+      return;
+    }
+    const listener = new StateThresholdListener({
+      workflowId: reg.workflowId,
+      userId: reg.userId,
+      workflowName: reg.workflowName,
+      chainId: reg.chainId,
+      wssUrl: reg.wssUrl,
+      fallbackWssUrl: reg.fallbackWssUrl,
+      subscription: reg.subscription,
+      sqs: this.deps.sqs,
+      sqsQueueUrl: this.deps.sqsQueueUrl,
+      armStore,
+      providerManager: this.deps.providerManager,
+      pacer: this.pacerFor(reg.chainId),
+      inFlight: this.inFlight,
+    });
+    try {
+      await listener.start();
+    } catch (err) {
+      logger.warn(
+        `[ListenerRegistry] failed to start state listener ${reg.workflowId}: ${formatError(err)}`,
       );
       return;
     }

--- a/keeperhub-events/event-tracker/src/listener/state-threshold-listener.ts
+++ b/keeperhub-events/event-tracker/src/listener/state-threshold-listener.ts
@@ -1,0 +1,291 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import {
+  createPhantomExecution,
+  failPhantomExecution,
+} from "../../lib/phantom";
+import { logger } from "../../lib/utils/logger";
+import { enqueueWorkflowEventTrigger } from "../../lib/workflow-sqs";
+import type { Aggregate3Result } from "../chains/multicall3";
+import type {
+  ChainProviderManager,
+  Unsubscribe,
+} from "../chains/provider-manager";
+import type { ArmStateStore } from "./arm-state";
+import { formatError } from "./format-error";
+import type { InFlightTracker } from "./in-flight";
+import type { TokenBucketPacer } from "./pacer";
+import {
+  type ArmState,
+  type StateThresholdSubscription,
+  decodeCallResult,
+  evaluateThreshold,
+  initialArmState,
+} from "./state-threshold";
+
+/**
+ * StateThresholdListener is the state-trigger counterpart of EventListener
+ * (issue #2240). It registers with ChainProviderManager's shared block
+ * subscription and drain loop, so many state subscriptions on one chain cost
+ * one batched `eth_call` per drain between them.
+ *
+ * Arming state is held in memory and written through to the store on every
+ * transition. The store is read exactly once, at start, which is the only
+ * moment a durable read answers a question the process cannot answer itself:
+ * "was this subscription already inside an arming episode before I existed?"
+ */
+
+export interface StateThresholdListenerOptions {
+  workflowId: string;
+  userId: string;
+  workflowName: string;
+  chainId: number;
+  wssUrl: string;
+  fallbackWssUrl?: string;
+  subscription: StateThresholdSubscription;
+
+  sqs: SQSClient;
+  sqsQueueUrl: string;
+  armStore: ArmStateStore;
+  providerManager: ChainProviderManager;
+
+  /** Shared per-chain pacer, as for EventListener. */
+  pacer?: TokenBucketPacer;
+  /** Registry-wide tracker so shutdown can drain a dispatch mid-flight. */
+  inFlight?: InFlightTracker;
+}
+
+export class StateThresholdListener {
+  private readonly opts: StateThresholdListenerOptions;
+  private unsubscribe: Unsubscribe | null = null;
+  private started = false;
+  /**
+   * Authoritative arming state while the process lives. Null only before the
+   * first sample resolves it - a cold start cannot pick a generation before
+   * it knows a block height to seed one from.
+   */
+  private armState: ArmState | null = null;
+  /**
+   * True once the store has been consulted. Separate from `armState` being
+   * non-null because "the store had nothing" is a resolved answer that still
+   * leaves the state to be seeded from the first sampled block.
+   */
+  private armStateLoaded = false;
+
+  constructor(opts: StateThresholdListenerOptions) {
+    this.opts = opts;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+
+    const sub = this.opts.subscription;
+    // Read before subscribing. A resume that landed after the first sample
+    // would evaluate against a cold-start generation and dispatch for an
+    // episode that was already dispatched before the restart.
+    try {
+      this.armState = await this.opts.armStore.load(sub.subscriptionId);
+      this.armStateLoaded = true;
+    } catch (err) {
+      // Left unloaded rather than seeded: `onSample` retries the read, and a
+      // store that never answers costs samples instead of manufacturing
+      // duplicate dispatches out of an outage.
+      logger.warn(
+        `[StateThresholdListener:${this.opts.workflowId}] arm-state load failed, will retry on first sample: ${formatError(err)}`,
+      );
+    }
+
+    this.unsubscribe = await this.opts.providerManager.subscribeToState({
+      chainId: this.opts.chainId,
+      wssUrl: this.opts.wssUrl,
+      fallbackWssUrl: this.opts.fallbackWssUrl,
+      contractAddress: sub.contractAddress,
+      callData: sub.callData,
+      handler: (result, blockNumber) => {
+        const dispatch = this.onSample(result, blockNumber);
+        return this.opts.inFlight
+          ? this.opts.inFlight.track(dispatch)
+          : dispatch;
+      },
+    });
+    this.started = true;
+    logger.log(
+      `[StateThresholdListener:${this.opts.workflowId}] started - name="${this.opts.workflowName}" chain=${this.opts.chainId} address=${sub.contractAddress} comparator=${sub.comparator} threshold=${sub.threshold}`,
+    );
+  }
+
+  stop(): void {
+    if (!this.started) {
+      return;
+    }
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.started = false;
+    logger.log(`[StateThresholdListener:${this.opts.workflowId}] stopped`);
+  }
+
+  isStarted(): boolean {
+    return this.started;
+  }
+
+  /** Current arming state, or null before the first sample. For tests. */
+  getArmState(): ArmState | null {
+    return this.armState;
+  }
+
+  private async onSample(
+    result: Aggregate3Result,
+    blockNumber: number,
+  ): Promise<void> {
+    try {
+      const sub = this.opts.subscription;
+
+      if (!this.armStateLoaded) {
+        try {
+          this.armState = await this.opts.armStore.load(sub.subscriptionId);
+          this.armStateLoaded = true;
+        } catch (err) {
+          logger.warn(
+            `[StateThresholdListener:${this.opts.workflowId}] arm-state load failed, skipping this sample: ${formatError(err)}`,
+          );
+          return;
+        }
+      }
+
+      const value = decodeCallResult(result, sub.outputTypes, sub.outputIndex);
+      if (value === null) {
+        // A reverting view function or a return that does not match the
+        // declared outputs. Not an observation, so not evidence either way
+        // about the threshold - the sample is dropped, not interpreted.
+        logger.warn(
+          `[StateThresholdListener:${this.opts.workflowId}] block=${blockNumber} call did not decode to a comparable value; skipping sample`,
+        );
+        return;
+      }
+
+      const priorState = this.armState ?? initialArmState(blockNumber);
+      const { fired, nextState } = evaluateThreshold(
+        sub,
+        value,
+        blockNumber,
+        priorState,
+      );
+
+      if (fired) {
+        if (this.opts.pacer) {
+          await this.opts.pacer.take();
+        }
+        try {
+          await this.sendToSqs(fired.dispatchKey, {
+            triggerType: "stateThreshold",
+            chainId: sub.chainId,
+            contractAddress: sub.contractAddress,
+            blockNumber,
+            comparator: sub.comparator,
+            threshold: sub.threshold.toString(),
+            observedValue: value.toString(),
+          });
+        } catch (err) {
+          // The state still advances to FIRED. The phantom row created above
+          // records the failure, and a retry under the same generation would
+          // be refused by the unique index anyway, so holding ARMED would buy
+          // a dispatch that cannot succeed and a re-evaluation every drain.
+          logger.warn(
+            `[StateThresholdListener:${this.opts.workflowId}] dispatch failed for ${fired.dispatchKey}: ${formatError(err)}`,
+          );
+        }
+      }
+
+      await this.persistArmState(nextState);
+    } catch (err) {
+      logger.warn(
+        `[StateThresholdListener:${this.opts.workflowId}] handler error: ${formatError(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Advance the in-memory state, then write it through. Memory first: a store
+   * write that fails must not leave this process re-evaluating against a
+   * state it has already moved past and dispatching again on the next drain.
+   * The cost of a lost write is a duplicate after a restart, which is the
+   * direction the whole design already fails in.
+   */
+  private async persistArmState(next: ArmState): Promise<void> {
+    const unchanged =
+      this.armState !== null &&
+      this.armState.phase === next.phase &&
+      this.armState.armGeneration === next.armGeneration &&
+      this.armState.lastFiredBlock === next.lastFiredBlock;
+    this.armState = next;
+    if (unchanged) {
+      return;
+    }
+    try {
+      await this.opts.armStore.save(
+        this.opts.subscription.subscriptionId,
+        next,
+      );
+    } catch (err) {
+      logger.warn(
+        `[StateThresholdListener:${this.opts.workflowId}] arm-state save failed: ${formatError(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Identical in shape to EventListener's, including the phantom pre-create
+   * whose unique index on the dispatch key is what makes the arm generation a
+   * durable guard rather than an in-memory convention.
+   */
+  private async sendToSqs(
+    dispatchKey: string,
+    payload: unknown,
+  ): Promise<void> {
+    const { executionId, alreadyExisted, refused } =
+      await createPhantomExecution(
+        this.opts.workflowId,
+        this.opts.userId,
+        dispatchKey,
+      );
+
+    if (refused) {
+      logger.log(
+        `[StateThresholdListener:${this.opts.workflowId}] skipping refused dispatch (${refused})`,
+      );
+      return;
+    }
+
+    // This arming episode already dispatched: a redelivery after a reorg, or
+    // a restart that resumed a generation whose dispatch had already landed.
+    if (alreadyExisted) {
+      logger.log(
+        `[StateThresholdListener:${this.opts.workflowId}] skipping duplicate dispatch for ${dispatchKey} (already enqueued)`,
+      );
+      return;
+    }
+
+    try {
+      await enqueueWorkflowEventTrigger(this.opts.sqs, this.opts.sqsQueueUrl, {
+        executionId,
+        workflowId: this.opts.workflowId,
+        userId: this.opts.userId,
+        triggerData: payload,
+      });
+    } catch (err) {
+      if (executionId) {
+        await failPhantomExecution(
+          executionId,
+          "ES-0001",
+          `State threshold trigger failed to dispatch: ${formatError(err)}`,
+        );
+      }
+      throw err;
+    }
+
+    logger.log(
+      `[StateThresholdListener:${this.opts.workflowId}] enqueued to SQS for ${dispatchKey}`,
+    );
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/state-threshold.ts
+++ b/keeperhub-events/event-tracker/src/listener/state-threshold.ts
@@ -1,136 +1,181 @@
-import type { ethers } from "ethers";
-
-/**
- * Local copy of the canonical Multicall3 address/ABI slice this module
- * needs (aggregate3 only). `@techops/events-tracker` is a standalone
- * package (`rootDir: "."`, `include: ["src/**", "lib/**"]` scoped to this
- * package's own `lib/`) and cannot resolve modules from the monorepo root's
- * `lib/contracts/multicall3.ts` - the same constraint `in-flight.ts` already
- * documents for its copy of the executor's InFlightTracker. Deployment
- * verified across all 11 CHAIN_CONFIG mainnets via direct eth_getCode calls,
- * see the follow-up comment on issue #2240.
- */
-export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
-const AGGREGATE3_ABI = [
-  {
-    inputs: [
-      {
-        components: [
-          { name: "target", type: "address" },
-          { name: "allowFailure", type: "bool" },
-          { name: "callData", type: "bytes" },
-        ],
-        name: "calls",
-        type: "tuple[]",
-      },
-    ],
-    name: "aggregate3",
-    outputs: [
-      {
-        components: [
-          { name: "success", type: "bool" },
-          { name: "returnData", type: "bytes" },
-        ],
-        name: "returnData",
-        type: "tuple[]",
-      },
-    ],
-    stateMutability: "payable",
-    type: "function",
-  },
-] as const;
+import { ethers } from "ethers";
+import type { Aggregate3Result } from "../chains/multicall3";
 
 /**
  * Core evaluation logic for issue #2240 - "Workflows cannot trigger on a
  * threshold over contract state, only on emitted events".
  *
- * This module is deliberately free of any provider/subscription wiring: it
- * takes decoded `eth_call` results in and produces ARMED/FIRED transitions
- * out, so it can be unit tested without a live chain and plugged into
- * `ChainProviderManager`'s existing per-block hook once the maintainers
- * confirm the design (see the two design-proposal comments on the issue).
+ * This module is free of provider/subscription wiring: it takes decoded
+ * `eth_call` results in and produces ARMED/FIRED transitions out, so it can be
+ * unit tested without a live chain. `ChainProviderManager.subscribeToState`
+ * does the I/O and `StateThresholdListener` owns the state and the dispatch.
  *
- * Design recap (per the issue's own request to settle these before code):
- *  - Dedup identity: (subscriptionId, blockNumber). A per-block eth_call
- *    result is uniquely identified by which subscription asked and which
- *    block it was evaluated against - this reuses the same block-scoped
- *    reasoning the event-tracker already applies for reorgs, rather than
- *    inventing a new key space.
- *  - Edge detection: fire only on the transition from "not armed" to
- *    "condition holds" (false -> true), not on every block the condition
- *    continues to hold. State is a single persisted boolean per subscription
- *    (`armed`), so a restart with no prior state treats the first observed
- *    "true" as an edge (fail-safe: a workflow author expects the first
- *    breach to fire, not to be silently swallowed because the process
- *    doesn't remember a "before" state).
- *  - Hysteresis / re-arm: an optional `clearThreshold`, asymmetric from the
- *    fire `threshold`, so a value oscillating right at the boundary does not
- *    produce a burst of fire/re-arm/fire cycles. Without `clearThreshold`
- *    the re-arm condition is simply "no longer past `threshold`" (no
- *    hysteresis band), which is the correct default for a strictly
- *    monotonic comparator like "balance below Y".
+ * Dedup identity - arm generation
+ * -------------------------------
+ * The Redis dedup store is explicitly not the authority (`event-listener.ts`
+ * says so above its own read). The durable guard is the dispatch key carried
+ * into `createPhantomExecution`, whose unique index turns a second create for
+ * the same key into an `alreadyExisted` no-op. So the question a state trigger
+ * has to answer is what dispatch key a *condition* produces, not what replaces
+ * `txHash` in Redis:
+ *
+ *   event:  event:{workflowId}:{chainId}:{txHash}:{logIndex}
+ *   state:  state:{workflowId}:{chainId}:{subscriptionId}:{armGeneration}
+ *
+ * `armGeneration` identifies one arming episode. It is fixed for as long as
+ * the subscription stays armed and changes when it re-arms, so:
+ *
+ *  - Edge detection falls out of the key. While the condition holds across
+ *    many samples the generation does not move, every evaluation produces the
+ *    same key, the unique index reports `alreadyExisted` and the enqueue is
+ *    skipped. "Fires on every sample while the condition holds" is not
+ *    guarded against, it is unrepresentable.
+ *  - Reorg-safe for the same reason. A crossing re-observed at a different
+ *    height still belongs to the same episode and yields the same key, where a
+ *    `blockNumber` term would fire twice.
+ *
+ * The generation's *value* is the block at which the subscription last became
+ * armed, rather than a counter incremented on each re-arm. Nothing in the
+ * event tracker persists per-subscription rows - subscriptions are rebuilt
+ * from the workflow API on every reconcile pass and held in memory, and the
+ * only durable stores this process reaches are Redis (best-effort, TTL'd) and
+ * the main app's DB behind the internal HTTP API. A counter that lost its
+ * store would restart at 0 and every key it then produced would collide with
+ * one already in the unique index, so every dispatch would be swallowed as a
+ * duplicate and the subscription would be wedged for good. Block heights
+ * advance, so a generation re-seeded after a total loss of state is always a
+ * value the index has not seen. The cost is the opposite failure - a process
+ * that dies while a condition is holding re-arms at a higher generation and
+ * fires once more - which is the direction a threshold alert should fail in.
+ *
+ * Exit predicate
+ * --------------
+ * The exit predicate is deliberately not `!enter`; that is the oscillation bug
+ * relocated. The band is explicit: enter at `x < threshold`, exit at
+ * `x > threshold + delta`, with `delta` supplied per subscription and
+ * defaulting to `DEFAULT_HYSTERESIS_BPS` of the threshold. Between the two the
+ * subscription stays FIRED and dispatches nothing.
+ *
+ * Sampling
+ * --------
+ * State is read once per drain at the head block, not once per block. A chain
+ * accumulating against the high-water mark does not have its intermediate
+ * blocks sampled, so a crossing that both enters and exits inside one
+ * accumulation window is not observed at all. This is a real semantic
+ * difference from the log path, whose ranged `eth_getLogs` is contiguous and
+ * therefore lossless, and a state trigger cannot inherit it.
  */
+
+/**
+ * Default width of the re-arm band, in basis points of the threshold. 200 bps
+ * (2%) is a prior, not a measurement - there is an open offer on issue #2240
+ * to derive it from historical Aave health-factor series, and this constant is
+ * where that number lands when it exists.
+ */
+export const DEFAULT_HYSTERESIS_BPS = 200n;
 
 export type ThresholdComparator = "lt" | "lte" | "gt" | "gte";
 
+export type ArmPhase = "ARMED" | "FIRED";
+
 export interface StateThresholdSubscription {
+  /**
+   * Stable identity of this subscription's *configuration*. Derived from the
+   * threshold config by `hashStateRegistration`, so editing the threshold
+   * yields a new id and therefore a fresh arming episode rather than
+   * inheriting a generation that would suppress the first dispatch.
+   */
   subscriptionId: string;
   workflowId: string;
   chainId: number;
-  /** Contract to eth_call against. */
+  /** Contract the view function is called on. */
   contractAddress: string;
-  /** ABI-encoded calldata for the view function (already encoded by the
-   * builder layer - this module does not know about function signatures). */
+  /** ABI-encoded calldata for the view function. */
   callData: string;
-  /** Decoded numeric value is compared against this threshold. */
+  /**
+   * ABI output types of the called function, in declaration order. Carried
+   * with the call because the decoder cannot recover them from `callData`:
+   * every 32-byte word decodes as a `uint256`, so a decoder that guesses
+   * would read an `int256` of -1 as 2^256 - 1 and turn a breach into a
+   * comfortable value on an `lt` threshold.
+   */
+  outputTypes: string[];
+  /** Which output to compare, as an index into `outputTypes`. */
+  outputIndex: number;
+  /** Scaled integer the decoded value is compared against. */
   threshold: bigint;
   comparator: ThresholdComparator;
   /**
-   * Optional distinct re-arm boundary. When set, once FIRED the
-   * subscription only re-arms after the value crosses back past
-   * `clearThreshold` (which must be on the "safe" side of `threshold`),
-   * not merely past `threshold` itself. Undefined means no hysteresis band:
-   * the re-arm condition is the exact negation of the fire condition.
+   * Width of the re-arm band in the same units as `threshold`. Must be >= 0.
+   * Defaults to `DEFAULT_HYSTERESIS_BPS` of `|threshold|` when undefined.
    */
-  clearThreshold?: bigint;
+  hysteresis?: bigint;
+  /**
+   * Optional floor on the number of blocks between two dispatches. A cooldown
+   * delays a dispatch, it does not cancel one: the subscription stays armed
+   * and fires at the first sample past the floor.
+   */
+  minBlocksBetweenFires?: number;
 }
 
-/** Persisted per-subscription state - the only thing that must survive a
- * restart for edge detection to behave correctly across a process bounce. */
-export interface SubscriptionArmState {
+/**
+ * Per-subscription state that must survive a process bounce for edge
+ * detection to hold across one.
+ */
+export interface ArmState {
+  phase: ArmPhase;
   /**
-   * true: condition observed as met at least once and not yet cleared, i.e.
-   * either currently FIRED-and-not-rearmed or mid-hysteresis-band.
-   *
-   * Naming: "armed" here means "the guard that prevents a duplicate fire is
-   * up", not "will fire on next check" - the issue's own vocabulary ("armed
-   * / fired") is a state name, not a predicate, so this field mirrors that
-   * rather than introducing a second name for the same concept.
+   * Block at which this arming episode began. Fixed while armed, and fixed
+   * across the FIRED stretch that follows so a redelivered dispatch rebuilds
+   * the same key. Moves only on re-arm.
    */
-  armed: boolean;
+  armGeneration: number;
+  /** Block of the last dispatch, for `minBlocksBetweenFires`. */
+  lastFiredBlock: number | null;
+}
+
+export interface ThresholdFire {
+  subscriptionId: string;
+  workflowId: string;
+  chainId: number;
+  /** Block the value was sampled at. Not part of the dispatch key. */
+  blockNumber: number;
+  /** `state:{workflowId}:{chainId}:{subscriptionId}:{armGeneration}`. */
+  dispatchKey: string;
+  observedValue: bigint;
+  threshold: bigint;
+  comparator: ThresholdComparator;
 }
 
 export interface EvaluationResult {
-  /** Present only when this evaluation should dispatch a workflow trigger. */
-  fired: {
-    subscriptionId: string;
-    workflowId: string;
-    chainId: number;
-    blockNumber: number;
-    /** Dedup key per the design above - (subscriptionId, blockNumber). */
-    dedupKey: string;
-    observedValue: bigint;
-  } | null;
-  /** The state to persist for this subscription after this evaluation,
-   * regardless of whether it fired. Callers must persist this before the
-   * next block's evaluation runs for the same subscription, or a crash
-   * between evaluation and persistence re-observes the same edge next block
-   * and fires twice - the same best-effort trade-off the existing Redis
-   * dedup store already makes for event-based triggers (see dedup.ts). */
-  nextState: SubscriptionArmState;
+  /** Present only when this sample should dispatch a workflow trigger. */
+  fired: ThresholdFire | null;
+  /**
+   * State to persist for this subscription after this sample, fired or not.
+   * Applied by the caller after the dispatch attempt regardless of its
+   * outcome: a dispatch that reached `createPhantomExecution` has a row
+   * recording it either way, and retrying under the same generation would be
+   * refused by the unique index anyway.
+   */
+  nextState: ArmState;
 }
 
-function comparatorHolds(
+/** The state a subscription starts in when nothing durable is known about it. */
+export function initialArmState(blockNumber: number): ArmState {
+  return { phase: "ARMED", armGeneration: blockNumber, lastFiredBlock: null };
+}
+
+export function buildStateDispatchKey(
+  sub: Pick<
+    StateThresholdSubscription,
+    "workflowId" | "chainId" | "subscriptionId"
+  >,
+  armGeneration: number,
+): string {
+  return `state:${sub.workflowId}:${sub.chainId}:${sub.subscriptionId}:${armGeneration}`;
+}
+
+function enterHolds(
   value: bigint,
   threshold: bigint,
   comparator: ThresholdComparator,
@@ -147,125 +192,132 @@ function comparatorHolds(
   }
 }
 
-/** The comparator that must hold for a FIRED subscription to re-arm, given
- * the fire comparator. Without a `clearThreshold` this is the exact
- * negation of `comparatorHolds` above; with one, it is evaluated against
- * `clearThreshold` instead of `threshold`. */
-function invertComparator(comparator: ThresholdComparator): ThresholdComparator {
-  switch (comparator) {
+function abs(value: bigint): bigint {
+  return value < 0n ? -value : value;
+}
+
+/** Band width, defaulting to `DEFAULT_HYSTERESIS_BPS` of `|threshold|`. */
+function resolveHysteresis(sub: StateThresholdSubscription): bigint {
+  if (sub.hysteresis !== undefined) {
+    return sub.hysteresis < 0n ? 0n : sub.hysteresis;
+  }
+  return (abs(sub.threshold) * DEFAULT_HYSTERESIS_BPS) / 10_000n;
+}
+
+/**
+ * Whether a FIRED subscription has cleared far enough to re-arm. Strictly
+ * beyond the threshold on the safe side by the band width, never merely the
+ * negation of the enter predicate - `!enter` is what lets a value resting on
+ * the boundary re-arm and fire on alternate samples indefinitely.
+ */
+export function exitHolds(
+  value: bigint,
+  sub: StateThresholdSubscription,
+): boolean {
+  const delta = resolveHysteresis(sub);
+  switch (sub.comparator) {
     case "lt":
-      return "gte";
     case "lte":
-      return "gt";
+      // Enter is below the threshold, so safety is above it.
+      return value > sub.threshold + delta;
     case "gt":
-      return "lte";
     case "gte":
-      return "lt";
+      return value < sub.threshold - delta;
   }
 }
 
 /**
- * Pure evaluation step - no I/O. Called once per block per subscription
- * with the already-decoded `eth_call` result for that block.
+ * Pure evaluation step for one sample of one subscription. No I/O.
  */
 export function evaluateThreshold(
   sub: StateThresholdSubscription,
   observedValue: bigint,
   blockNumber: number,
-  priorState: SubscriptionArmState,
+  priorState: ArmState,
 ): EvaluationResult {
-  const holds = comparatorHolds(observedValue, sub.threshold, sub.comparator);
-
-  if (!priorState.armed) {
-    if (!holds) {
-      // Condition not met, and we were not armed: nothing to do.
-      return { fired: null, nextState: { armed: false } };
+  if (priorState.phase === "ARMED") {
+    if (!enterHolds(observedValue, sub.threshold, sub.comparator)) {
+      return { fired: null, nextState: priorState };
     }
-    // Edge: false -> true. Fire, and become armed so the next block that
-    // still holds does not fire again.
+
+    const cooldown = sub.minBlocksBetweenFires;
+    if (
+      cooldown !== undefined &&
+      cooldown > 0 &&
+      priorState.lastFiredBlock !== null &&
+      blockNumber - priorState.lastFiredBlock < cooldown
+    ) {
+      // Held, not dropped: the subscription stays armed at the same
+      // generation and dispatches at the first sample past the floor.
+      return { fired: null, nextState: priorState };
+    }
+
     return {
       fired: {
         subscriptionId: sub.subscriptionId,
         workflowId: sub.workflowId,
         chainId: sub.chainId,
         blockNumber,
-        dedupKey: `state:${sub.subscriptionId}:${blockNumber}`,
+        dispatchKey: buildStateDispatchKey(sub, priorState.armGeneration),
         observedValue,
+        threshold: sub.threshold,
+        comparator: sub.comparator,
       },
-      nextState: { armed: true },
+      nextState: {
+        phase: "FIRED",
+        // Held at the arming block so a redelivery rebuilds the same key.
+        armGeneration: priorState.armGeneration,
+        lastFiredBlock: blockNumber,
+      },
     };
   }
 
-  // Already armed (fired and not yet re-armed). Check whether the re-arm
-  // boundary has been crossed. With no clearThreshold, re-arm is simply
-  // "condition no longer holds". With one, re-arm requires crossing back
-  // past clearThreshold specifically (hysteresis band).
-  const rearmThreshold = sub.clearThreshold ?? sub.threshold;
-  const rearmComparator = invertComparator(sub.comparator);
-  const rearms = comparatorHolds(observedValue, rearmThreshold, rearmComparator);
-
-  if (rearms) {
-    // Crossed back to safe territory: re-arm, but do not fire (re-arming
-    // is not itself an event a workflow should trigger on).
-    return { fired: null, nextState: { armed: false } };
+  // FIRED: dispatch nothing until the value clears the band, then open a new
+  // generation. Re-arming is not itself something a workflow triggers on.
+  if (exitHolds(observedValue, sub)) {
+    return {
+      fired: null,
+      nextState: {
+        phase: "ARMED",
+        armGeneration: blockNumber,
+        lastFiredBlock: priorState.lastFiredBlock,
+      },
+    };
   }
-
-  // Still in breach (or still inside the hysteresis band): stay armed,
-  // do not re-fire.
-  return { fired: null, nextState: { armed: true } };
+  return { fired: null, nextState: priorState };
 }
 
 /**
- * Batches several subscriptions' eth_call requests into one Multicall3
- * aggregate3 call, so the marginal on-chain cost is one RPC round-trip per
- * block regardless of how many state-threshold subscriptions are active on
- * that chain - matching the issue's stated cost target ("one RPC call per
- * block per subscription" become "one RPC call per block per BATCH", an
- * improvement over the issue's own floor).
+ * Decode one call's return data to the comparable value, using the output
+ * types the subscription carried from its ABI.
  *
- * `allowFailure: true` on every call so one subscription's revert (e.g. a
- * contract that reverts a view function under some conditions) does not
- * poison the batch for every other subscription sharing the block.
+ * Returns null rather than throwing when the call reverted, when the data
+ * does not match the declared outputs, when the selected output is not a
+ * numeric type, or when the index is out of range. The caller skips that
+ * subscription for that sample: a decode failure is an absence of
+ * observation, and treating it as either "condition holds" or "condition does
+ * not hold" would be inventing one.
  */
-export function buildMulticallPayload(
-  calls: Array<{ contractAddress: string; callData: string }>,
-): { target: string; abi: unknown; args: unknown[] } {
-  return {
-    target: MULTICALL3_ADDRESS,
-    abi: AGGREGATE3_ABI,
-    args: [
-      calls.map((c) => ({
-        target: c.contractAddress,
-        allowFailure: true,
-        callData: c.callData,
-      })),
-    ],
-  };
-}
-
-/**
- * Decode a single aggregate3 result slot. Returns null (rather than
- * throwing) when the call reverted (`success === false`) or the
- * `returnData` cannot be decoded as a single uint256/int256 - the caller
- * should skip evaluation for that subscription on that block rather than
- * treat a decode failure as "condition holds" or "condition does not hold".
- */
-export function decodeAggregate3Result(
-  result: { success: boolean; returnData: string },
-  abiCoder: ethers.AbiCoder,
+export function decodeCallResult(
+  result: Aggregate3Result,
+  outputTypes: string[],
+  outputIndex: number,
 ): bigint | null {
   if (!result.success) {
     return null;
   }
-  try {
-    const [decoded] = abiCoder.decode(["uint256"], result.returnData);
-    return decoded as bigint;
-  } catch {
-    try {
-      const [decoded] = abiCoder.decode(["int256"], result.returnData);
-      return decoded as bigint;
-    } catch {
-      return null;
-    }
+  if (outputIndex < 0 || outputIndex >= outputTypes.length) {
+    return null;
   }
+  let decoded: ethers.Result;
+  try {
+    decoded = ethers.AbiCoder.defaultAbiCoder().decode(
+      outputTypes,
+      result.returnData,
+    );
+  } catch {
+    return null;
+  }
+  const value: unknown = decoded[outputIndex];
+  return typeof value === "bigint" ? value : null;
 }

--- a/keeperhub-events/event-tracker/src/listener/state-threshold.ts
+++ b/keeperhub-events/event-tracker/src/listener/state-threshold.ts
@@ -1,0 +1,271 @@
+import type { ethers } from "ethers";
+
+/**
+ * Local copy of the canonical Multicall3 address/ABI slice this module
+ * needs (aggregate3 only). `@techops/events-tracker` is a standalone
+ * package (`rootDir: "."`, `include: ["src/**", "lib/**"]` scoped to this
+ * package's own `lib/`) and cannot resolve modules from the monorepo root's
+ * `lib/contracts/multicall3.ts` - the same constraint `in-flight.ts` already
+ * documents for its copy of the executor's InFlightTracker. Deployment
+ * verified across all 11 CHAIN_CONFIG mainnets via direct eth_getCode calls,
+ * see the follow-up comment on issue #2240.
+ */
+export const MULTICALL3_ADDRESS = "0xcA11bde05977b3631167028862bE2a173976CA11";
+const AGGREGATE3_ABI = [
+  {
+    inputs: [
+      {
+        components: [
+          { name: "target", type: "address" },
+          { name: "allowFailure", type: "bool" },
+          { name: "callData", type: "bytes" },
+        ],
+        name: "calls",
+        type: "tuple[]",
+      },
+    ],
+    name: "aggregate3",
+    outputs: [
+      {
+        components: [
+          { name: "success", type: "bool" },
+          { name: "returnData", type: "bytes" },
+        ],
+        name: "returnData",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "payable",
+    type: "function",
+  },
+] as const;
+
+/**
+ * Core evaluation logic for issue #2240 - "Workflows cannot trigger on a
+ * threshold over contract state, only on emitted events".
+ *
+ * This module is deliberately free of any provider/subscription wiring: it
+ * takes decoded `eth_call` results in and produces ARMED/FIRED transitions
+ * out, so it can be unit tested without a live chain and plugged into
+ * `ChainProviderManager`'s existing per-block hook once the maintainers
+ * confirm the design (see the two design-proposal comments on the issue).
+ *
+ * Design recap (per the issue's own request to settle these before code):
+ *  - Dedup identity: (subscriptionId, blockNumber). A per-block eth_call
+ *    result is uniquely identified by which subscription asked and which
+ *    block it was evaluated against - this reuses the same block-scoped
+ *    reasoning the event-tracker already applies for reorgs, rather than
+ *    inventing a new key space.
+ *  - Edge detection: fire only on the transition from "not armed" to
+ *    "condition holds" (false -> true), not on every block the condition
+ *    continues to hold. State is a single persisted boolean per subscription
+ *    (`armed`), so a restart with no prior state treats the first observed
+ *    "true" as an edge (fail-safe: a workflow author expects the first
+ *    breach to fire, not to be silently swallowed because the process
+ *    doesn't remember a "before" state).
+ *  - Hysteresis / re-arm: an optional `clearThreshold`, asymmetric from the
+ *    fire `threshold`, so a value oscillating right at the boundary does not
+ *    produce a burst of fire/re-arm/fire cycles. Without `clearThreshold`
+ *    the re-arm condition is simply "no longer past `threshold`" (no
+ *    hysteresis band), which is the correct default for a strictly
+ *    monotonic comparator like "balance below Y".
+ */
+
+export type ThresholdComparator = "lt" | "lte" | "gt" | "gte";
+
+export interface StateThresholdSubscription {
+  subscriptionId: string;
+  workflowId: string;
+  chainId: number;
+  /** Contract to eth_call against. */
+  contractAddress: string;
+  /** ABI-encoded calldata for the view function (already encoded by the
+   * builder layer - this module does not know about function signatures). */
+  callData: string;
+  /** Decoded numeric value is compared against this threshold. */
+  threshold: bigint;
+  comparator: ThresholdComparator;
+  /**
+   * Optional distinct re-arm boundary. When set, once FIRED the
+   * subscription only re-arms after the value crosses back past
+   * `clearThreshold` (which must be on the "safe" side of `threshold`),
+   * not merely past `threshold` itself. Undefined means no hysteresis band:
+   * the re-arm condition is the exact negation of the fire condition.
+   */
+  clearThreshold?: bigint;
+}
+
+/** Persisted per-subscription state - the only thing that must survive a
+ * restart for edge detection to behave correctly across a process bounce. */
+export interface SubscriptionArmState {
+  /**
+   * true: condition observed as met at least once and not yet cleared, i.e.
+   * either currently FIRED-and-not-rearmed or mid-hysteresis-band.
+   *
+   * Naming: "armed" here means "the guard that prevents a duplicate fire is
+   * up", not "will fire on next check" - the issue's own vocabulary ("armed
+   * / fired") is a state name, not a predicate, so this field mirrors that
+   * rather than introducing a second name for the same concept.
+   */
+  armed: boolean;
+}
+
+export interface EvaluationResult {
+  /** Present only when this evaluation should dispatch a workflow trigger. */
+  fired: {
+    subscriptionId: string;
+    workflowId: string;
+    chainId: number;
+    blockNumber: number;
+    /** Dedup key per the design above - (subscriptionId, blockNumber). */
+    dedupKey: string;
+    observedValue: bigint;
+  } | null;
+  /** The state to persist for this subscription after this evaluation,
+   * regardless of whether it fired. Callers must persist this before the
+   * next block's evaluation runs for the same subscription, or a crash
+   * between evaluation and persistence re-observes the same edge next block
+   * and fires twice - the same best-effort trade-off the existing Redis
+   * dedup store already makes for event-based triggers (see dedup.ts). */
+  nextState: SubscriptionArmState;
+}
+
+function comparatorHolds(
+  value: bigint,
+  threshold: bigint,
+  comparator: ThresholdComparator,
+): boolean {
+  switch (comparator) {
+    case "lt":
+      return value < threshold;
+    case "lte":
+      return value <= threshold;
+    case "gt":
+      return value > threshold;
+    case "gte":
+      return value >= threshold;
+  }
+}
+
+/** The comparator that must hold for a FIRED subscription to re-arm, given
+ * the fire comparator. Without a `clearThreshold` this is the exact
+ * negation of `comparatorHolds` above; with one, it is evaluated against
+ * `clearThreshold` instead of `threshold`. */
+function invertComparator(comparator: ThresholdComparator): ThresholdComparator {
+  switch (comparator) {
+    case "lt":
+      return "gte";
+    case "lte":
+      return "gt";
+    case "gt":
+      return "lte";
+    case "gte":
+      return "lt";
+  }
+}
+
+/**
+ * Pure evaluation step - no I/O. Called once per block per subscription
+ * with the already-decoded `eth_call` result for that block.
+ */
+export function evaluateThreshold(
+  sub: StateThresholdSubscription,
+  observedValue: bigint,
+  blockNumber: number,
+  priorState: SubscriptionArmState,
+): EvaluationResult {
+  const holds = comparatorHolds(observedValue, sub.threshold, sub.comparator);
+
+  if (!priorState.armed) {
+    if (!holds) {
+      // Condition not met, and we were not armed: nothing to do.
+      return { fired: null, nextState: { armed: false } };
+    }
+    // Edge: false -> true. Fire, and become armed so the next block that
+    // still holds does not fire again.
+    return {
+      fired: {
+        subscriptionId: sub.subscriptionId,
+        workflowId: sub.workflowId,
+        chainId: sub.chainId,
+        blockNumber,
+        dedupKey: `state:${sub.subscriptionId}:${blockNumber}`,
+        observedValue,
+      },
+      nextState: { armed: true },
+    };
+  }
+
+  // Already armed (fired and not yet re-armed). Check whether the re-arm
+  // boundary has been crossed. With no clearThreshold, re-arm is simply
+  // "condition no longer holds". With one, re-arm requires crossing back
+  // past clearThreshold specifically (hysteresis band).
+  const rearmThreshold = sub.clearThreshold ?? sub.threshold;
+  const rearmComparator = invertComparator(sub.comparator);
+  const rearms = comparatorHolds(observedValue, rearmThreshold, rearmComparator);
+
+  if (rearms) {
+    // Crossed back to safe territory: re-arm, but do not fire (re-arming
+    // is not itself an event a workflow should trigger on).
+    return { fired: null, nextState: { armed: false } };
+  }
+
+  // Still in breach (or still inside the hysteresis band): stay armed,
+  // do not re-fire.
+  return { fired: null, nextState: { armed: true } };
+}
+
+/**
+ * Batches several subscriptions' eth_call requests into one Multicall3
+ * aggregate3 call, so the marginal on-chain cost is one RPC round-trip per
+ * block regardless of how many state-threshold subscriptions are active on
+ * that chain - matching the issue's stated cost target ("one RPC call per
+ * block per subscription" become "one RPC call per block per BATCH", an
+ * improvement over the issue's own floor).
+ *
+ * `allowFailure: true` on every call so one subscription's revert (e.g. a
+ * contract that reverts a view function under some conditions) does not
+ * poison the batch for every other subscription sharing the block.
+ */
+export function buildMulticallPayload(
+  calls: Array<{ contractAddress: string; callData: string }>,
+): { target: string; abi: unknown; args: unknown[] } {
+  return {
+    target: MULTICALL3_ADDRESS,
+    abi: AGGREGATE3_ABI,
+    args: [
+      calls.map((c) => ({
+        target: c.contractAddress,
+        allowFailure: true,
+        callData: c.callData,
+      })),
+    ],
+  };
+}
+
+/**
+ * Decode a single aggregate3 result slot. Returns null (rather than
+ * throwing) when the call reverted (`success === false`) or the
+ * `returnData` cannot be decoded as a single uint256/int256 - the caller
+ * should skip evaluation for that subscription on that block rather than
+ * treat a decode failure as "condition holds" or "condition does not hold".
+ */
+export function decodeAggregate3Result(
+  result: { success: boolean; returnData: string },
+  abiCoder: ethers.AbiCoder,
+): bigint | null {
+  if (!result.success) {
+    return null;
+  }
+  try {
+    const [decoded] = abiCoder.decode(["uint256"], result.returnData);
+    return decoded as bigint;
+  } catch {
+    try {
+      const [decoded] = abiCoder.decode(["int256"], result.returnData);
+      return decoded as bigint;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
+++ b/keeperhub-events/event-tracker/src/listener/workflow-mapper.ts
@@ -1,10 +1,22 @@
 import { createHash } from "node:crypto";
-import type { NetworksMap, RawWorkflow } from "../../lib/types";
+import { ethers } from "ethers";
+import type {
+  NetworksMap,
+  RawWorkflow,
+  RawWorkflowNodeConfig,
+} from "../../lib/types";
 import { logger } from "../../lib/utils/logger";
 import { buildEventAbi } from "../chains/event-serializer";
 import { redactRpcUrl } from "../chains/provider-manager";
 import type { AbiEvent } from "../chains/validation";
-import type { WorkflowRegistration } from "./registry";
+import type {
+  StateThresholdRegistration,
+  WorkflowRegistration,
+} from "./registry";
+import type {
+  StateThresholdSubscription,
+  ThresholdComparator,
+} from "./state-threshold";
 
 /**
  * Maps the KeeperHub API workflow response shape into a WorkflowRegistration
@@ -22,7 +34,7 @@ import type { WorkflowRegistration } from "./registry";
 export function buildRegistration(
   workflow: RawWorkflow,
   networks: NetworksMap,
-): WorkflowRegistration | null {
+): WorkflowRegistration | StateThresholdRegistration | null {
   const workflowId = typeof workflow.id === "string" ? workflow.id : null;
   if (!workflowId) {
     logger.warn("[workflow-mapper] workflow missing id; skipping");
@@ -107,6 +119,17 @@ export function buildRegistration(
       `[workflow-mapper] workflow ${workflowId} missing contractAddress; skipping`,
     );
     return null;
+  }
+
+  // State-threshold trigger (issue #2240). Branches after the connection
+  // fields because it shares every one of them and nothing below.
+  if (config.triggerType === "stateThreshold") {
+    return buildStateThresholdRegistration(workflow, workflowId, config, {
+      chainId,
+      wssUrl,
+      fallbackWssUrl,
+      contractAddress,
+    });
   }
 
   const eventName =
@@ -211,4 +234,268 @@ export function hashRegistration(
     memoFilter: reg.memoFilter ?? null,
   });
   return createHash("sha256").update(canonical).digest("hex");
+}
+
+const COMPARATORS: readonly ThresholdComparator[] = ["lt", "lte", "gt", "gte"];
+
+/** `uint8` .. `uint256`, `int8` .. `int256`, and the bare aliases. */
+const NUMERIC_BASE_TYPE = /^u?int\d*$/;
+
+function isComparator(value: unknown): value is ThresholdComparator {
+  return (
+    typeof value === "string" &&
+    (COMPARATORS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Map a `stateThreshold` trigger node into a registration.
+ *
+ * The view call is resolved here, once, rather than in the listener: the
+ * calldata, the output types and the comparable output index are all fixed
+ * properties of the config, and resolving them at map time means a
+ * misconfigured workflow is refused with one log line instead of failing to
+ * decode on every drain forever.
+ *
+ * The output types in particular have to travel with the call. The decoder
+ * gets raw return data and cannot recover the signature from it, and every
+ * 32-byte word decodes cleanly as a `uint256` - so a decoder left to guess
+ * would read an `int256` of -1 as 2^256 - 1 and silently turn a breach into a
+ * comfortable value under an `lt` threshold.
+ */
+function buildStateThresholdRegistration(
+  workflow: RawWorkflow,
+  workflowId: string,
+  config: RawWorkflowNodeConfig,
+  connection: {
+    chainId: number;
+    wssUrl: string;
+    fallbackWssUrl?: string;
+    contractAddress: string;
+  },
+): StateThresholdRegistration | null {
+  const abiRaw =
+    typeof config.contractABI === "string" ? config.contractABI : null;
+  if (!abiRaw) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} stateThreshold trigger missing contractABI; skipping`,
+    );
+    return null;
+  }
+  const abiFunction =
+    typeof config.abiFunction === "string" ? config.abiFunction : null;
+  if (!abiFunction) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} stateThreshold trigger missing abiFunction; skipping`,
+    );
+    return null;
+  }
+  if (!isComparator(config.comparator)) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} stateThreshold comparator "${String(config.comparator)}" is not one of ${COMPARATORS.join(", ")}; skipping`,
+    );
+    return null;
+  }
+  const comparator = config.comparator;
+
+  let iface: ethers.Interface;
+  let fragment: ethers.FunctionFragment | null;
+  let callData: string;
+  try {
+    iface = new ethers.Interface(JSON.parse(abiRaw));
+    fragment = iface.getFunction(abiFunction);
+    if (!fragment) {
+      logger.warn(
+        `[workflow-mapper] workflow ${workflowId} contractABI has no function "${abiFunction}"; skipping`,
+      );
+      return null;
+    }
+    callData = iface.encodeFunctionData(
+      fragment,
+      Array.isArray(config.functionArgs) ? config.functionArgs : [],
+    );
+  } catch (err) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} could not encode "${abiFunction}": ${String(err)}; skipping`,
+    );
+    return null;
+  }
+
+  const outputs = fragment.outputs;
+  if (outputs.length === 0) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} function "${abiFunction}" returns nothing to compare; skipping`,
+    );
+    return null;
+  }
+  // "full" rather than the bare `type`: a tuple output formats as `tuple`
+  // alone, which carries none of its components and cannot be decoded.
+  const outputTypes = outputs.map((output) => output.format("full"));
+
+  const outputIndex = resolveOutputIndex(outputs, config.outputPath);
+  if (outputIndex === null) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} outputPath "${String(config.outputPath)}" does not name an output of "${abiFunction}"; skipping`,
+    );
+    return null;
+  }
+  const selected = outputs[outputIndex];
+  // `baseType` is the type name itself for a simple type ("uint256"), and
+  // "array"/"tuple" otherwise, so the integer widths are matched rather than
+  // compared to a bare "uint"/"int".
+  if (!NUMERIC_BASE_TYPE.test(selected.baseType)) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} output "${selected.format("full")}" of "${abiFunction}" is not a numeric type; skipping`,
+    );
+    return null;
+  }
+
+  const decimals =
+    typeof config.decimals === "number" && Number.isFinite(config.decimals)
+      ? config.decimals
+      : 0;
+  const threshold = parseScaled(config.threshold, decimals);
+  if (threshold === null) {
+    logger.warn(
+      `[workflow-mapper] workflow ${workflowId} stateThreshold threshold "${String(config.threshold)}" is not a decimal number; skipping`,
+    );
+    return null;
+  }
+  // Undefined leaves the band at the module default. An unparseable value is
+  // refused rather than defaulted: silently substituting a band the user did
+  // not ask for is how an oscillating value becomes a burst of executions.
+  let hysteresis: bigint | undefined;
+  if (config.hysteresis !== undefined) {
+    const parsed = parseScaled(config.hysteresis, decimals);
+    if (parsed === null || parsed < 0n) {
+      logger.warn(
+        `[workflow-mapper] workflow ${workflowId} stateThreshold hysteresis "${String(config.hysteresis)}" is not a non-negative decimal number; skipping`,
+      );
+      return null;
+    }
+    hysteresis = parsed;
+  }
+
+  const minBlocksBetweenFires =
+    typeof config.minBlocksBetweenFires === "number" &&
+    Number.isFinite(config.minBlocksBetweenFires) &&
+    config.minBlocksBetweenFires > 0
+      ? Math.floor(config.minBlocksBetweenFires)
+      : undefined;
+
+  const subscription: StateThresholdSubscription = {
+    // Placeholder until the semantic fields below are hashed into it.
+    subscriptionId: "",
+    workflowId,
+    chainId: connection.chainId,
+    contractAddress: connection.contractAddress,
+    callData,
+    outputTypes,
+    outputIndex,
+    threshold,
+    comparator,
+    hysteresis,
+    minBlocksBetweenFires,
+  };
+  subscription.subscriptionId = hashStateSubscription(subscription);
+
+  const userId = typeof workflow.userId === "string" ? workflow.userId : "";
+  const workflowName = typeof workflow.name === "string" ? workflow.name : "";
+
+  return {
+    kind: "state",
+    workflowId,
+    userId,
+    workflowName,
+    chainId: connection.chainId,
+    wssUrl: connection.wssUrl,
+    fallbackWssUrl: connection.fallbackWssUrl,
+    subscription,
+    configHash: hashStateRegistration({
+      subscriptionId: subscription.subscriptionId,
+      wssUrl: connection.wssUrl,
+      fallbackWssUrl: connection.fallbackWssUrl ?? null,
+      userId,
+    }),
+  };
+}
+
+/** `outputPath` as an index, an output name, or absent (the first output). */
+function resolveOutputIndex(
+  outputs: readonly ethers.ParamType[],
+  outputPath: string | number | undefined,
+): number | null {
+  if (outputPath === undefined || outputPath === "") {
+    return 0;
+  }
+  if (typeof outputPath === "number") {
+    return Number.isInteger(outputPath) &&
+      outputPath >= 0 &&
+      outputPath < outputs.length
+      ? outputPath
+      : null;
+  }
+  const byName = outputs.findIndex((output) => output.name === outputPath);
+  if (byName >= 0) {
+    return byName;
+  }
+  // A numeric string is an index, so the builder can send either shape.
+  const asIndex = Number(outputPath);
+  return Number.isInteger(asIndex) && asIndex >= 0 && asIndex < outputs.length
+    ? asIndex
+    : null;
+}
+
+/** Decimal string (or number) scaled by `decimals` into an integer. */
+function parseScaled(
+  value: string | number | undefined,
+  decimals: number,
+): bigint | null {
+  if (value === undefined || value === null || value === "") {
+    return null;
+  }
+  try {
+    return ethers.parseUnits(String(value), decimals);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Identity of a state subscription's *trigger semantics*, and therefore of
+ * its arming episodes. Deliberately excludes connection fields: rotating an
+ * RPC URL must not open a new generation and re-dispatch a condition that is
+ * already holding. Changing what is watched or where the line sits must, which
+ * is why every one of those fields is in here.
+ */
+export function hashStateSubscription(
+  sub: Omit<StateThresholdSubscription, "subscriptionId">,
+): string {
+  const canonical = JSON.stringify({
+    workflowId: sub.workflowId,
+    chainId: sub.chainId,
+    contractAddress: sub.contractAddress.toLowerCase(),
+    callData: sub.callData.toLowerCase(),
+    outputTypes: sub.outputTypes,
+    outputIndex: sub.outputIndex,
+    threshold: sub.threshold.toString(),
+    comparator: sub.comparator,
+    hysteresis: sub.hysteresis?.toString() ?? null,
+    minBlocksBetweenFires: sub.minBlocksBetweenFires ?? null,
+  });
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Content hash over everything that should restart a state listener, which is
+ * the subscription identity plus the connection fields it is served over.
+ * Counterpart to `hashRegistration` for the event path.
+ */
+export function hashStateRegistration(parts: {
+  subscriptionId: string;
+  wssUrl: string;
+  fallbackWssUrl: string | null;
+  userId: string;
+}): string {
+  return createHash("sha256").update(JSON.stringify(parts)).digest("hex");
 }

--- a/keeperhub-events/event-tracker/tests/unit/provider-manager-state.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/provider-manager-state.test.ts
@@ -1,0 +1,334 @@
+import { ethers } from "ethers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../lib/utils/logger";
+import {
+  MULTICALL3_ADDRESS,
+  STATE_CALL_MAX_BATCH,
+} from "../../src/chains/multicall3";
+import {
+  ChainProviderManager,
+  GETLOGS_MIN_INTERVAL_MS,
+  type ProviderFactory,
+} from "../../src/chains/provider-manager";
+
+/**
+ * State sampling on the shared block subscription (issue #2240). Covers the
+ * two paths the reviewer asked to see exercised - the batch, and the chain
+ * that cannot batch - plus the chunk ceiling that keeps one oversized
+ * `eth_call` from failing every subscription on a chain at once.
+ */
+
+const CHAIN_ID = 31_337;
+const WSS_URL = "ws://localhost:8546";
+const CONTRACT = "0x1111111111111111111111111111111111111111";
+const CALLDATA = "0xdeadbeef";
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const aggregate3Interface = new ethers.Interface([
+  "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[] returnData)",
+]);
+
+interface SendCall {
+  method: string;
+  params: unknown[];
+}
+
+class MockProvider {
+  public sendCalls: SendCall[] = [];
+  /** Empty bytecode at the Multicall3 address - the not-deployed case. */
+  public multicall3Code = "0x60806040";
+  /** When set, the next `eth_call` to Multicall3 rejects. */
+  public aggregate3Failures = 0;
+  public getCodeFailure: Error | null = null;
+  public ethCallResult: string | null = null;
+  private blockHandler: ((n: number) => void | Promise<void>) | null = null;
+
+  on(event: string, handler: (n: number) => void | Promise<void>): void {
+    if (event === "block") {
+      this.blockHandler = handler;
+    }
+  }
+
+  off(event: string, handler: (n: number) => void | Promise<void>): void {
+    if (event === "block" && this.blockHandler === handler) {
+      this.blockHandler = null;
+    }
+  }
+
+  async getBlockNumber(): Promise<number> {
+    return 0x1234;
+  }
+
+  async send(method: string, params: unknown[]): Promise<unknown> {
+    this.sendCalls.push({ method, params });
+    if (method === "eth_subscribe") {
+      return "0xprobe";
+    }
+    if (method === "eth_unsubscribe") {
+      return true;
+    }
+    if (method === "eth_blockNumber") {
+      return 0x1234;
+    }
+    if (method === "eth_getLogs") {
+      return [];
+    }
+    if (method === "eth_getCode") {
+      if (this.getCodeFailure) {
+        throw this.getCodeFailure;
+      }
+      return this.multicall3Code;
+    }
+    if (method === "eth_call") {
+      const target = (params[0] as { to: string }).to;
+      if (target.toLowerCase() === MULTICALL3_ADDRESS.toLowerCase()) {
+        if (this.aggregate3Failures > 0) {
+          this.aggregate3Failures -= 1;
+          throw new Error("execution reverted: out of gas");
+        }
+        const data = (params[0] as { data: string }).data;
+        const [calls] = aggregate3Interface.decodeFunctionData(
+          "aggregate3",
+          data,
+        );
+        const slots = (calls as unknown[]).map(() => [
+          true,
+          coder.encode(["uint256"], [7n]),
+        ]);
+        return aggregate3Interface.encodeFunctionResult("aggregate3", [slots]);
+      }
+      return this.ethCallResult ?? coder.encode(["uint256"], [7n]);
+    }
+    return [];
+  }
+
+  async destroy(): Promise<void> {}
+
+  async emitBlock(blockNumber: number): Promise<void> {
+    await this.blockHandler?.(blockNumber);
+  }
+}
+
+function makeFactory(): { factory: ProviderFactory; created: MockProvider[] } {
+  const created: MockProvider[] = [];
+  const factory: ProviderFactory = () => {
+    const mock = new MockProvider();
+    created.push(mock);
+    return mock as unknown as ethers.WebSocketProvider;
+  };
+  return { factory, created };
+}
+
+function ethCalls(provider: MockProvider): SendCall[] {
+  return provider.sendCalls.filter((call) => call.method === "eth_call");
+}
+
+function aggregate3Batches(provider: MockProvider): number[] {
+  return ethCalls(provider)
+    .filter(
+      (call) =>
+        (call.params[0] as { to: string }).to.toLowerCase() ===
+        MULTICALL3_ADDRESS.toLowerCase(),
+    )
+    .map((call) => {
+      const [calls] = aggregate3Interface.decodeFunctionData(
+        "aggregate3",
+        (call.params[0] as { data: string }).data,
+      );
+      return (calls as unknown[]).length;
+    });
+}
+
+describe("ChainProviderManager state sampling", () => {
+  let manager: ChainProviderManager;
+  let created: MockProvider[];
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const f = makeFactory();
+    created = f.created;
+    manager = new ChainProviderManager({
+      factory: f.factory,
+      onPermanentFailure: () => undefined,
+    });
+    warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+    vi.spyOn(logger, "log").mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    await manager.destroy();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function subscribeState(
+    count: number,
+    onSample?: (value: string, block: number) => void,
+  ): Promise<MockProvider> {
+    for (let i = 0; i < count; i += 1) {
+      await manager.subscribeToState({
+        chainId: CHAIN_ID,
+        wssUrl: WSS_URL,
+        contractAddress: CONTRACT,
+        callData: `${CALLDATA}${i.toString(16).padStart(2, "0")}`,
+        handler: (result, blockNumber) => {
+          onSample?.(result.returnData, blockNumber);
+        },
+      });
+    }
+    return created[0];
+  }
+
+  it("batches every subscription on a chain into one aggregate3 per drain", async () => {
+    const samples: number[] = [];
+    const provider = await subscribeState(5, (_v, block) => {
+      samples.push(block);
+    });
+
+    await provider.emitBlock(100);
+
+    expect(aggregate3Batches(provider)).toEqual([5]);
+    expect(samples).toEqual([100, 100, 100, 100, 100]);
+    // One additional RPC call for the chain, not one per subscription.
+    expect(ethCalls(provider)).toHaveLength(1);
+  });
+
+  it("probes Multicall3 once and pins the block tag to the sampled height", async () => {
+    const provider = await subscribeState(2);
+
+    await provider.emitBlock(0x100);
+    await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS);
+    await provider.emitBlock(0x101);
+
+    const codeCalls = provider.sendCalls.filter(
+      (call) => call.method === "eth_getCode",
+    );
+    expect(codeCalls).toHaveLength(1);
+    expect(codeCalls[0].params[0]).toBe(MULTICALL3_ADDRESS);
+
+    // The block tag is the head, not "latest": the observation is attributed
+    // to the height it was read at.
+    const tags = ethCalls(provider).map((call) => call.params[1]);
+    expect(tags).toEqual(["0x100", "0x101"]);
+  });
+
+  it("falls back to one call per subscription where Multicall3 is absent", async () => {
+    const samples: number[] = [];
+    const provider = await subscribeState(3, (_v, block) => {
+      samples.push(block);
+    });
+    provider.multicall3Code = "0x";
+
+    await provider.emitBlock(100);
+
+    expect(aggregate3Batches(provider)).toEqual([]);
+    expect(ethCalls(provider)).toHaveLength(3);
+    for (const call of ethCalls(provider)) {
+      expect((call.params[0] as { to: string }).to).toBe(CONTRACT);
+    }
+    // Degrading is logged rather than silent: a batching design that quietly
+    // becomes an N-call design is worse than one that says so.
+    expect(
+      warn.mock.calls.some((args) => String(args[0]).includes("no Multicall3")),
+    ).toBe(true);
+    expect(samples).toHaveLength(3);
+  });
+
+  it("re-probes after a probe error rather than pinning to the fallback", async () => {
+    const provider = await subscribeState(2);
+    provider.getCodeFailure = new Error("upstream 502");
+
+    await provider.emitBlock(100);
+    // Probe failed, so this drain sampled one call per subscription.
+    expect(ethCalls(provider)).toHaveLength(2);
+
+    provider.getCodeFailure = null;
+    await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS);
+    await provider.emitBlock(101);
+
+    expect(
+      provider.sendCalls.filter((call) => call.method === "eth_getCode"),
+    ).toHaveLength(2);
+    expect(aggregate3Batches(provider)).toEqual([2]);
+  });
+
+  it("chunks above the batch ceiling so one oversized call cannot fail the chain", async () => {
+    const count = STATE_CALL_MAX_BATCH * 2 + 7;
+    const samples: string[] = [];
+    const provider = await subscribeState(count, (value) => {
+      samples.push(value);
+    });
+
+    await provider.emitBlock(100);
+
+    expect(aggregate3Batches(provider)).toEqual([
+      STATE_CALL_MAX_BATCH,
+      STATE_CALL_MAX_BATCH,
+      7,
+    ]);
+    expect(samples).toHaveLength(count);
+  });
+
+  it("costs a failed chunk its own subscriptions and no others", async () => {
+    const count = STATE_CALL_MAX_BATCH + 4;
+    const sampled: number[] = [];
+    const provider = await subscribeState(count, (_v, block) => {
+      sampled.push(block);
+    });
+    // Only the first chunk fails.
+    provider.aggregate3Failures = 1;
+
+    await provider.emitBlock(100);
+
+    expect(aggregate3Batches(provider)).toEqual([STATE_CALL_MAX_BATCH, 4]);
+    expect(sampled).toHaveLength(4);
+  });
+
+  it("advances the high-water mark on a chain with no log subscribers", async () => {
+    // Without this the mark never moves, the catch-up timer is armed on a gap
+    // nothing will close, and the drain spins at the rate limit forever.
+    const provider = await subscribeState(1);
+
+    await provider.emitBlock(100);
+    await vi.advanceTimersByTimeAsync(GETLOGS_MIN_INTERVAL_MS * 3);
+
+    expect(
+      provider.sendCalls.filter((call) => call.method === "eth_getLogs"),
+    ).toHaveLength(0);
+    expect(manager.getHealth(CHAIN_ID)?.blocksBehindHead).toBe(0);
+    expect(ethCalls(provider)).toHaveLength(1);
+  });
+
+  it("keeps the block subscription while either kind of subscriber remains", async () => {
+    const unsubState = await manager.subscribeToState({
+      chainId: CHAIN_ID,
+      wssUrl: WSS_URL,
+      contractAddress: CONTRACT,
+      callData: CALLDATA,
+      handler: () => undefined,
+    });
+    const unsubLogs = await manager.subscribeToLogs({
+      chainId: CHAIN_ID,
+      wssUrl: WSS_URL,
+      address: CONTRACT,
+      topic0: `0x${"11".repeat(32)}`,
+      handler: () => undefined,
+    });
+    expect(manager.stateSubscriberCount(CHAIN_ID)).toBe(1);
+    expect(manager.subscriberCount(CHAIN_ID)).toBe(1);
+
+    const provider = created[0];
+    unsubState();
+    await provider.emitBlock(100);
+    // The log subscriber alone keeps the block listener attached.
+    expect(
+      provider.sendCalls.filter((call) => call.method === "eth_getLogs").length,
+    ).toBeGreaterThan(0);
+
+    unsubLogs();
+    const before = provider.sendCalls.length;
+    await provider.emitBlock(101);
+    expect(provider.sendCalls).toHaveLength(before);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/state-threshold-listener.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/state-threshold-listener.test.ts
@@ -1,0 +1,296 @@
+import type { SQSClient } from "@aws-sdk/client-sqs";
+import { ethers } from "ethers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Aggregate3Result } from "../../src/chains/multicall3";
+import type {
+  ChainProviderManager,
+  StateCallHandler,
+  SubscribeStateOptions,
+  Unsubscribe,
+} from "../../src/chains/provider-manager";
+import type { ArmStateStore } from "../../src/listener/arm-state";
+import type { ArmState } from "../../src/listener/state-threshold";
+import type { StateThresholdSubscription } from "../../src/listener/state-threshold";
+import { StateThresholdListener } from "../../src/listener/state-threshold-listener";
+
+const { createPhantomExecution, failPhantomExecution } = vi.hoisted(() => ({
+  createPhantomExecution: vi.fn(),
+  failPhantomExecution: vi.fn(),
+}));
+vi.mock("../../lib/phantom", () => ({
+  createPhantomExecution,
+  failPhantomExecution,
+}));
+
+const { enqueueWorkflowEventTrigger } = vi.hoisted(() => ({
+  enqueueWorkflowEventTrigger: vi.fn(),
+}));
+vi.mock("../../lib/workflow-sqs", () => ({ enqueueWorkflowEventTrigger }));
+
+const coder = ethers.AbiCoder.defaultAbiCoder();
+const WORKFLOW_ID = "wf-1";
+const SUBSCRIPTION_ID = "sub-1";
+
+function uint(value: bigint): Aggregate3Result {
+  return { success: true, returnData: coder.encode(["uint256"], [value]) };
+}
+
+const SUBSCRIPTION: StateThresholdSubscription = {
+  subscriptionId: SUBSCRIPTION_ID,
+  workflowId: WORKFLOW_ID,
+  chainId: 1,
+  contractAddress: "0x1111111111111111111111111111111111111111",
+  callData: "0xdeadbeef",
+  outputTypes: ["uint256"],
+  outputIndex: 0,
+  threshold: 100n,
+  comparator: "lt",
+  hysteresis: 10n,
+};
+
+function makeArmStore(initial: ArmState | null = null): {
+  store: ArmStateStore;
+  saved: ArmState[];
+  loadError: { value: Error | null };
+} {
+  const saved: ArmState[] = [];
+  const loadError = { value: null as Error | null };
+  let current = initial;
+  const store: ArmStateStore = {
+    load: vi.fn(async () => {
+      if (loadError.value) {
+        throw loadError.value;
+      }
+      return current;
+    }),
+    save: vi.fn(async (_id: string, state: ArmState) => {
+      current = state;
+      saved.push(state);
+    }),
+    disconnect: vi.fn(async () => undefined),
+  };
+  return { store, saved, loadError };
+}
+
+function makeListener(
+  armStore: ArmStateStore,
+  overrides: Partial<StateThresholdSubscription> = {},
+): {
+  listener: StateThresholdListener;
+  sample: (result: Aggregate3Result, block: number) => Promise<void>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+} {
+  let handler: StateCallHandler | null = null;
+  const unsubscribe = vi.fn() as unknown as Unsubscribe;
+  const providerManager = {
+    subscribeToState: vi.fn(async (opts: SubscribeStateOptions) => {
+      handler = opts.handler;
+      return unsubscribe;
+    }),
+  } as unknown as ChainProviderManager;
+
+  const listener = new StateThresholdListener({
+    workflowId: WORKFLOW_ID,
+    userId: "user-1",
+    workflowName: "Health factor",
+    chainId: 1,
+    wssUrl: "ws://localhost:8546",
+    subscription: { ...SUBSCRIPTION, ...overrides },
+    sqs: { send: vi.fn() } as unknown as SQSClient,
+    sqsQueueUrl: "https://sqs.test/queue",
+    armStore,
+    providerManager,
+  });
+
+  return {
+    listener,
+    sample: async (result, block) => {
+      if (!handler) {
+        throw new Error("listener not started");
+      }
+      await handler(result, block);
+    },
+    unsubscribe: unsubscribe as unknown as ReturnType<typeof vi.fn>,
+  };
+}
+
+function dispatchKeys(): string[] {
+  return createPhantomExecution.mock.calls.map((args) => String(args[2]));
+}
+
+describe("StateThresholdListener", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPhantomExecution.mockResolvedValue({
+      executionId: "exec-1",
+      alreadyExisted: false,
+    });
+    enqueueWorkflowEventTrigger.mockResolvedValue(undefined);
+  });
+
+  it("dispatches once on the crossing and not again while it holds", async () => {
+    const { store, saved } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 100);
+    await sample(uint(40n), 101);
+    await sample(uint(45n), 102);
+
+    expect(enqueueWorkflowEventTrigger).toHaveBeenCalledTimes(1);
+    expect(dispatchKeys()).toEqual(["state:wf-1:1:sub-1:100"]);
+    expect(saved.at(-1)).toEqual({
+      phase: "FIRED",
+      armGeneration: 100,
+      lastFiredBlock: 100,
+    });
+  });
+
+  it("resumes a FIRED episode across a restart without re-dispatching", async () => {
+    // The crash-resume case: the process died mid-breach. A listener that
+    // seeded a fresh generation would open a new episode and dispatch for a
+    // condition that was already dispatched before the restart.
+    const { store } = makeArmStore({
+      phase: "FIRED",
+      armGeneration: 100,
+      lastFiredBlock: 100,
+    });
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(40n), 500);
+    await sample(uint(45n), 501);
+
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+    expect(listener.getArmState()).toEqual({
+      phase: "FIRED",
+      armGeneration: 100,
+      lastFiredBlock: 100,
+    });
+  });
+
+  it("resumes an ARMED episode at its stored generation, not at the resume block", async () => {
+    const { store } = makeArmStore({
+      phase: "ARMED",
+      armGeneration: 90,
+      lastFiredBlock: null,
+    });
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 500);
+
+    expect(dispatchKeys()).toEqual(["state:wf-1:1:sub-1:90"]);
+  });
+
+  it("skips the enqueue when the dispatch key already exists", async () => {
+    // The durable guard: a redelivery under the same generation is refused by
+    // the unique index behind createPhantomExecution, so nothing is enqueued.
+    createPhantomExecution.mockResolvedValue({
+      executionId: undefined,
+      alreadyExisted: true,
+    });
+    const { store } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 100);
+
+    expect(createPhantomExecution).toHaveBeenCalledTimes(1);
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+  });
+
+  it("skips a refused dispatch without enqueuing", async () => {
+    createPhantomExecution.mockResolvedValue({
+      executionId: undefined,
+      alreadyExisted: false,
+      refused: "plan_feature",
+    });
+    const { store } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 100);
+
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+  });
+
+  it("skips a sample that does not decode rather than reading it as a breach", async () => {
+    const { store, saved } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample({ success: false, returnData: "0x" }, 100);
+    await sample({ success: true, returnData: "0x1234" }, 101);
+
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+    expect(saved).toEqual([]);
+    expect(listener.getArmState()).toBeNull();
+  });
+
+  it("skips the sample when the arm-state store cannot be read", async () => {
+    // A store failure must not be read as a cold start: re-seeding would open
+    // a new generation and manufacture a duplicate out of an outage.
+    const { store, loadError } = makeArmStore({
+      phase: "FIRED",
+      armGeneration: 100,
+      lastFiredBlock: 100,
+    });
+    loadError.value = new Error("redis down");
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 500);
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+
+    // Once the store answers, the stored episode is resumed as normal.
+    loadError.value = null;
+    await sample(uint(50n), 501);
+    expect(enqueueWorkflowEventTrigger).not.toHaveBeenCalled();
+    expect(listener.getArmState()?.phase).toBe("FIRED");
+  });
+
+  it("advances to FIRED even when the enqueue fails", async () => {
+    enqueueWorkflowEventTrigger.mockRejectedValue(new Error("sqs down"));
+    const { store } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 100);
+
+    expect(failPhantomExecution).toHaveBeenCalledTimes(1);
+    expect(listener.getArmState()?.phase).toBe("FIRED");
+
+    // No second attempt on the next sample: retrying under the same
+    // generation would be refused by the unique index anyway.
+    enqueueWorkflowEventTrigger.mockResolvedValue(undefined);
+    await sample(uint(50n), 101);
+    expect(createPhantomExecution).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a second episode after the band is cleared", async () => {
+    const { store } = makeArmStore();
+    const { listener, sample } = makeListener(store);
+    await listener.start();
+
+    await sample(uint(50n), 100);
+    await sample(uint(105n), 101); // inside the band, still FIRED
+    await sample(uint(120n), 102); // clears it, re-arms at 102
+    await sample(uint(50n), 103);
+
+    expect(dispatchKeys()).toEqual([
+      "state:wf-1:1:sub-1:100",
+      "state:wf-1:1:sub-1:102",
+    ]);
+  });
+
+  it("stops delivering after stop()", async () => {
+    const { store } = makeArmStore();
+    const { listener, unsubscribe } = makeListener(store);
+    await listener.start();
+    expect(listener.isStarted()).toBe(true);
+    listener.stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(listener.isStarted()).toBe(false);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/state-threshold.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/state-threshold.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMulticallPayload,
+  evaluateThreshold,
+  type StateThresholdSubscription,
+  type SubscriptionArmState,
+} from "../../src/listener/state-threshold";
+
+const BASE: StateThresholdSubscription = {
+  subscriptionId: "sub-1",
+  workflowId: "wf-1",
+  chainId: 1,
+  contractAddress: "0x1111111111111111111111111111111111111111",
+  callData: "0xdeadbeef",
+  threshold: 100n,
+  comparator: "lt",
+};
+
+const UNARMED: SubscriptionArmState = { armed: false };
+
+describe("evaluateThreshold", () => {
+  it("does not fire when the condition does not hold and was not armed", () => {
+    const r = evaluateThreshold(BASE, 200n, 10, UNARMED);
+    expect(r.fired).toBeNull();
+    expect(r.nextState).toEqual({ armed: false });
+  });
+
+  it("fires on the false->true edge and becomes armed", () => {
+    const r = evaluateThreshold(BASE, 50n, 10, UNARMED);
+    expect(r.fired).not.toBeNull();
+    expect(r.fired?.dedupKey).toBe("state:sub-1:10");
+    expect(r.fired?.observedValue).toBe(50n);
+    expect(r.nextState).toEqual({ armed: true });
+  });
+
+  it("does not re-fire on the next block while still in breach", () => {
+    const armed: SubscriptionArmState = { armed: true };
+    const r = evaluateThreshold(BASE, 40n, 11, armed);
+    expect(r.fired).toBeNull();
+    expect(r.nextState).toEqual({ armed: true });
+  });
+
+  it("re-arms (without firing) once the condition clears, no hysteresis", () => {
+    const armed: SubscriptionArmState = { armed: true };
+    const r = evaluateThreshold(BASE, 150n, 12, armed);
+    expect(r.fired).toBeNull();
+    expect(r.nextState).toEqual({ armed: false });
+  });
+
+  it("fires again on the next false->true edge after re-arming", () => {
+    const r1 = evaluateThreshold(BASE, 150n, 12, { armed: true });
+    expect(r1.nextState).toEqual({ armed: false });
+    const r2 = evaluateThreshold(BASE, 90n, 13, r1.nextState);
+    expect(r2.fired).not.toBeNull();
+    expect(r2.fired?.dedupKey).toBe("state:sub-1:13");
+  });
+
+  it("honors an asymmetric clearThreshold (hysteresis band)", () => {
+    const withHysteresis: StateThresholdSubscription = {
+      ...BASE,
+      threshold: 100n, // fires when value < 100
+      clearThreshold: 120n, // re-arms only once value >= 120
+    };
+    const armed: SubscriptionArmState = { armed: true };
+    // Value crossed back above 100 but not yet past clearThreshold=120:
+    // stays armed, no re-fire, no re-arm yet.
+    const r1 = evaluateThreshold(withHysteresis, 110n, 20, armed);
+    expect(r1.fired).toBeNull();
+    expect(r1.nextState).toEqual({ armed: true });
+
+    // Now past clearThreshold: re-arms.
+    const r2 = evaluateThreshold(withHysteresis, 125n, 21, r1.nextState);
+    expect(r2.fired).toBeNull();
+    expect(r2.nextState).toEqual({ armed: false });
+  });
+
+  it("supports gt/gte/lte comparators symmetrically", () => {
+    const gt: StateThresholdSubscription = { ...BASE, comparator: "gt", threshold: 100n };
+    const fireGt = evaluateThreshold(gt, 101n, 1, UNARMED);
+    expect(fireGt.fired).not.toBeNull();
+
+    const gte: StateThresholdSubscription = { ...BASE, comparator: "gte", threshold: 100n };
+    const fireGte = evaluateThreshold(gte, 100n, 1, UNARMED);
+    expect(fireGte.fired).not.toBeNull();
+
+    const lte: StateThresholdSubscription = { ...BASE, comparator: "lte", threshold: 100n };
+    const fireLte = evaluateThreshold(lte, 100n, 1, UNARMED);
+    expect(fireLte.fired).not.toBeNull();
+  });
+});
+
+describe("buildMulticallPayload", () => {
+  it("wraps calls with allowFailure:true so one revert cannot poison the batch", () => {
+    const payload = buildMulticallPayload([
+      { contractAddress: "0xaaaa000000000000000000000000000000000a", callData: "0x1111" },
+      { contractAddress: "0xbbbb000000000000000000000000000000000b", callData: "0x2222" },
+    ]);
+    const calls = payload.args[0] as Array<{ target: string; allowFailure: boolean; callData: string }>;
+    expect(calls).toHaveLength(2);
+    expect(calls[0].allowFailure).toBe(true);
+    expect(calls[1].allowFailure).toBe(true);
+  });
+});

--- a/keeperhub-events/event-tracker/tests/unit/state-threshold.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/state-threshold.test.ts
@@ -1,103 +1,337 @@
+import { ethers } from "ethers";
 import { describe, expect, it } from "vitest";
 import {
-  buildMulticallPayload,
-  evaluateThreshold,
+  type Aggregate3Call,
+  type Aggregate3Result,
+  MULTICALL3_ADDRESS,
+  STATE_CALL_MAX_BATCH,
+  chunkCalls,
+  decodeAggregate3,
+  encodeAggregate3,
+} from "../../src/chains/multicall3";
+import {
+  type ArmState,
+  DEFAULT_HYSTERESIS_BPS,
+  type EvaluationResult,
   type StateThresholdSubscription,
-  type SubscriptionArmState,
+  type ThresholdFire,
+  buildStateDispatchKey,
+  decodeCallResult,
+  evaluateThreshold,
+  exitHolds,
+  initialArmState,
 } from "../../src/listener/state-threshold";
 
-const BASE: StateThresholdSubscription = {
-  subscriptionId: "sub-1",
-  workflowId: "wf-1",
-  chainId: 1,
-  contractAddress: "0x1111111111111111111111111111111111111111",
-  callData: "0xdeadbeef",
-  threshold: 100n,
-  comparator: "lt",
-};
+const coder = ethers.AbiCoder.defaultAbiCoder();
 
-const UNARMED: SubscriptionArmState = { armed: false };
+/** A health-factor style subscription: fire below 1.05, 18 decimals. */
+function makeSub(
+  overrides: Partial<StateThresholdSubscription> = {},
+): StateThresholdSubscription {
+  return {
+    subscriptionId: "sub-1",
+    workflowId: "wf-1",
+    chainId: 1,
+    contractAddress: "0x1111111111111111111111111111111111111111",
+    callData: "0xdeadbeef",
+    outputTypes: ["uint256"],
+    outputIndex: 0,
+    threshold: 100n,
+    comparator: "lt",
+    ...overrides,
+  };
+}
 
-describe("evaluateThreshold", () => {
-  it("does not fire when the condition does not hold and was not armed", () => {
-    const r = evaluateThreshold(BASE, 200n, 10, UNARMED);
-    expect(r.fired).toBeNull();
-    expect(r.nextState).toEqual({ armed: false });
+function ok(returnData: string): Aggregate3Result {
+  return { success: true, returnData };
+}
+
+describe("decodeCallResult", () => {
+  it("decodes a uint256 output", () => {
+    const value = decodeCallResult(
+      ok(coder.encode(["uint256"], [42n])),
+      ["uint256"],
+      0,
+    );
+    expect(value).toBe(42n);
   });
 
-  it("fires on the false->true edge and becomes armed", () => {
-    const r = evaluateThreshold(BASE, 50n, 10, UNARMED);
-    expect(r.fired).not.toBeNull();
-    expect(r.fired?.dedupKey).toBe("state:sub-1:10");
-    expect(r.fired?.observedValue).toBe(50n);
-    expect(r.nextState).toEqual({ armed: true });
+  it("decodes a negative int256 as negative, not as 2^256 - 1", () => {
+    // The defect this test exists for: `decode(["uint256"], data)` succeeds
+    // for any 32-byte word, so a decoder that tries uint256 first and only
+    // falls back to int256 on a throw never reaches the fallback. An int256
+    // of -1 then reads as 2^256 - 1, which on an `lt` threshold turns a
+    // breach into the most comfortable value representable.
+    const encoded = coder.encode(["int256"], [-1n]);
+    expect(decodeCallResult(ok(encoded), ["int256"], 0)).toBe(-1n);
+    // Same bytes under the wrong declared type - shown so the reason the
+    // type must travel with the call is on the record, not inferred.
+    expect(decodeCallResult(ok(encoded), ["uint256"], 0)).toBe(2n ** 256n - 1n);
   });
 
-  it("does not re-fire on the next block while still in breach", () => {
-    const armed: SubscriptionArmState = { armed: true };
-    const r = evaluateThreshold(BASE, 40n, 11, armed);
-    expect(r.fired).toBeNull();
-    expect(r.nextState).toEqual({ armed: true });
+  it("selects the requested output from a multi-output return", () => {
+    // Aave's getUserAccountData shape: healthFactor is the last of six.
+    const outputs = [
+      "uint256",
+      "uint256",
+      "uint256",
+      "uint256",
+      "uint256",
+      "uint256",
+    ];
+    const encoded = coder.encode(outputs, [1n, 2n, 3n, 4n, 5n, 1_050n]);
+    expect(decodeCallResult(ok(encoded), outputs, 5)).toBe(1_050n);
+    expect(decodeCallResult(ok(encoded), outputs, 0)).toBe(1n);
   });
 
-  it("re-arms (without firing) once the condition clears, no hysteresis", () => {
-    const armed: SubscriptionArmState = { armed: true };
-    const r = evaluateThreshold(BASE, 150n, 12, armed);
-    expect(r.fired).toBeNull();
-    expect(r.nextState).toEqual({ armed: false });
+  it("decodes a named tuple output formatted in full", () => {
+    const type = "tuple(uint256 a, uint256 b) result";
+    const encoded = coder.encode([type], [[7n, 9n]]);
+    // The tuple itself is not a comparable scalar, so it decodes to no value
+    // rather than to something arbitrary.
+    expect(decodeCallResult(ok(encoded), [type], 0)).toBeNull();
   });
 
-  it("fires again on the next false->true edge after re-arming", () => {
-    const r1 = evaluateThreshold(BASE, 150n, 12, { armed: true });
-    expect(r1.nextState).toEqual({ armed: false });
-    const r2 = evaluateThreshold(BASE, 90n, 13, r1.nextState);
-    expect(r2.fired).not.toBeNull();
-    expect(r2.fired?.dedupKey).toBe("state:sub-1:13");
+  it("returns null for a reverted call", () => {
+    expect(
+      decodeCallResult({ success: false, returnData: "0x" }, ["uint256"], 0),
+    ).toBeNull();
   });
 
-  it("honors an asymmetric clearThreshold (hysteresis band)", () => {
-    const withHysteresis: StateThresholdSubscription = {
-      ...BASE,
-      threshold: 100n, // fires when value < 100
-      clearThreshold: 120n, // re-arms only once value >= 120
-    };
-    const armed: SubscriptionArmState = { armed: true };
-    // Value crossed back above 100 but not yet past clearThreshold=120:
-    // stays armed, no re-fire, no re-arm yet.
-    const r1 = evaluateThreshold(withHysteresis, 110n, 20, armed);
-    expect(r1.fired).toBeNull();
-    expect(r1.nextState).toEqual({ armed: true });
-
-    // Now past clearThreshold: re-arms.
-    const r2 = evaluateThreshold(withHysteresis, 125n, 21, r1.nextState);
-    expect(r2.fired).toBeNull();
-    expect(r2.nextState).toEqual({ armed: false });
+  it("returns null when the data does not match the declared outputs", () => {
+    expect(decodeCallResult(ok("0x1234"), ["uint256"], 0)).toBeNull();
   });
 
-  it("supports gt/gte/lte comparators symmetrically", () => {
-    const gt: StateThresholdSubscription = { ...BASE, comparator: "gt", threshold: 100n };
-    const fireGt = evaluateThreshold(gt, 101n, 1, UNARMED);
-    expect(fireGt.fired).not.toBeNull();
+  it("returns null when the output index is out of range", () => {
+    const encoded = coder.encode(["uint256"], [1n]);
+    expect(decodeCallResult(ok(encoded), ["uint256"], 1)).toBeNull();
+    expect(decodeCallResult(ok(encoded), ["uint256"], -1)).toBeNull();
+  });
 
-    const gte: StateThresholdSubscription = { ...BASE, comparator: "gte", threshold: 100n };
-    const fireGte = evaluateThreshold(gte, 100n, 1, UNARMED);
-    expect(fireGte.fired).not.toBeNull();
-
-    const lte: StateThresholdSubscription = { ...BASE, comparator: "lte", threshold: 100n };
-    const fireLte = evaluateThreshold(lte, 100n, 1, UNARMED);
-    expect(fireLte.fired).not.toBeNull();
+  it("returns null when the selected output is not numeric", () => {
+    const encoded = coder.encode(["address"], [MULTICALL3_ADDRESS]);
+    expect(decodeCallResult(ok(encoded), ["address"], 0)).toBeNull();
   });
 });
 
-describe("buildMulticallPayload", () => {
-  it("wraps calls with allowFailure:true so one revert cannot poison the batch", () => {
-    const payload = buildMulticallPayload([
-      { contractAddress: "0xaaaa000000000000000000000000000000000a", callData: "0x1111" },
-      { contractAddress: "0xbbbb000000000000000000000000000000000b", callData: "0x2222" },
+describe("aggregate3 encoding", () => {
+  it("round-trips through encode and decode with allowFailure set", () => {
+    const calls: Aggregate3Call[] = [
+      {
+        target: "0x1111111111111111111111111111111111111111",
+        callData: "0xaa",
+      },
+      {
+        target: "0x2222222222222222222222222222222222222222",
+        callData: "0xbb",
+      },
+    ];
+    const data = encodeAggregate3(calls);
+
+    // Decode the calldata back through the same ABI to assert the batch
+    // actually carries what was asked, rather than asserting on a plain
+    // object that nothing sends.
+    const iface = new ethers.Interface([
+      "function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[] returnData)",
     ]);
-    const calls = payload.args[0] as Array<{ target: string; allowFailure: boolean; callData: string }>;
-    expect(calls).toHaveLength(2);
-    expect(calls[0].allowFailure).toBe(true);
-    expect(calls[1].allowFailure).toBe(true);
+    const [decodedCalls] = iface.decodeFunctionData("aggregate3", data);
+    expect(decodedCalls).toHaveLength(2);
+    for (const [index, call] of (
+      decodedCalls as Array<[string, boolean, string]>
+    ).entries()) {
+      expect(call[0].toLowerCase()).toBe(calls[index].target.toLowerCase());
+      expect(call[1]).toBe(true);
+      expect(call[2]).toBe(calls[index].callData);
+    }
+
+    const returned = iface.encodeFunctionResult("aggregate3", [
+      [
+        [true, coder.encode(["uint256"], [1n])],
+        [false, "0x"],
+      ],
+    ]);
+    const slots = decodeAggregate3(returned);
+    expect(slots).toHaveLength(2);
+    expect(slots[0].success).toBe(true);
+    expect(slots[1].success).toBe(false);
+    expect(decodeCallResult(slots[0], ["uint256"], 0)).toBe(1n);
+    expect(decodeCallResult(slots[1], ["uint256"], 0)).toBeNull();
+  });
+});
+
+describe("chunkCalls", () => {
+  it("splits at the batch ceiling and leaves a remainder chunk", () => {
+    const items = Array.from({ length: STATE_CALL_MAX_BATCH + 3 }, (_, i) => i);
+    const chunks = chunkCalls(items);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toHaveLength(STATE_CALL_MAX_BATCH);
+    expect(chunks[1]).toHaveLength(3);
+    expect(chunks.flat()).toEqual(items);
+  });
+
+  it("produces no chunks for an empty list", () => {
+    expect(chunkCalls([])).toEqual([]);
+  });
+
+  it("falls back to the ceiling for a non-positive size", () => {
+    const items = Array.from({ length: 3 }, (_, i) => i);
+    expect(chunkCalls(items, 0)).toEqual([items]);
+  });
+});
+
+describe("evaluateThreshold", () => {
+  it("fires on the first sample in breach and disarms", () => {
+    const sub = makeSub();
+    const result: EvaluationResult = evaluateThreshold(
+      sub,
+      50n,
+      10,
+      initialArmState(10),
+    );
+    const fired = result.fired as ThresholdFire;
+    expect(fired.dispatchKey).toBe("state:wf-1:1:sub-1:10");
+    expect(fired.observedValue).toBe(50n);
+    expect(fired.threshold).toBe(sub.threshold);
+    expect(fired.comparator).toBe("lt");
+    // The sampled height is reported, but is not what the key is built from.
+    expect(fired.blockNumber).toBe(10);
+    expect(result.nextState).toEqual({
+      phase: "FIRED",
+      armGeneration: 10,
+      lastFiredBlock: 10,
+    });
+  });
+
+  it("does not fire while the condition does not hold", () => {
+    const sub = makeSub();
+    const armed = initialArmState(10);
+    const result = evaluateThreshold(sub, 200n, 11, armed);
+    expect(result.fired).toBeNull();
+    expect(result.nextState).toBe(armed);
+  });
+
+  it("does not re-fire across the blocks the condition keeps holding", () => {
+    const sub = makeSub();
+    let state = initialArmState(10);
+    const keys: string[] = [];
+    for (const [block, value] of [
+      [10, 50n],
+      [11, 40n],
+      [12, 30n],
+      [13, 45n],
+    ] as const) {
+      const result = evaluateThreshold(sub, value, block, state);
+      if (result.fired) {
+        keys.push(result.fired.dispatchKey);
+      }
+      state = result.nextState;
+    }
+    expect(keys).toEqual(["state:wf-1:1:sub-1:10"]);
+    expect(state.phase).toBe("FIRED");
+  });
+
+  it("re-arms at a new generation once the band is cleared, without firing", () => {
+    const sub = makeSub({ hysteresis: 10n });
+    const fired = evaluateThreshold(sub, 50n, 10, initialArmState(10));
+    // Back above the threshold but still inside the band: no re-arm.
+    const inBand = evaluateThreshold(sub, 105n, 11, fired.nextState);
+    expect(inBand.fired).toBeNull();
+    expect(inBand.nextState.phase).toBe("FIRED");
+    expect(inBand.nextState.armGeneration).toBe(10);
+    // Past the band: re-arms silently at the current block.
+    const cleared = evaluateThreshold(sub, 111n, 12, inBand.nextState);
+    expect(cleared.fired).toBeNull();
+    expect(cleared.nextState).toEqual({
+      phase: "ARMED",
+      armGeneration: 12,
+      lastFiredBlock: 10,
+    });
+    // The next breach is a different episode, so a different key.
+    const again = evaluateThreshold(sub, 50n, 13, cleared.nextState);
+    expect(again.fired?.dispatchKey).toBe("state:wf-1:1:sub-1:12");
+  });
+
+  it("does not oscillate on a value resting on the threshold", () => {
+    // The exit predicate is not `!enter`. A value alternating either side of
+    // the threshold by one unit would fire on every other sample if it were.
+    const sub = makeSub({ hysteresis: 10n });
+    let state: ArmState = initialArmState(1);
+    let fires = 0;
+    for (let block = 1; block <= 40; block += 1) {
+      const value = block % 2 === 0 ? 99n : 101n;
+      const result = evaluateThreshold(sub, value, block, state);
+      if (result.fired) {
+        fires += 1;
+      }
+      state = result.nextState;
+    }
+    expect(fires).toBe(1);
+  });
+
+  it("defaults the band to DEFAULT_HYSTERESIS_BPS of the threshold", () => {
+    const sub = makeSub({ threshold: 10_000n });
+    expect(DEFAULT_HYSTERESIS_BPS).toBe(200n);
+    // 2% of 10000 is 200, so 10200 is on the boundary and does not clear it.
+    expect(exitHolds(10_200n, sub)).toBe(false);
+    expect(exitHolds(10_201n, sub)).toBe(true);
+  });
+
+  it("mirrors the band below the threshold for gt/gte", () => {
+    const sub = makeSub({ comparator: "gt", threshold: 10_000n });
+    const fired = evaluateThreshold(sub, 10_001n, 5, initialArmState(5));
+    expect(fired.fired).not.toBeNull();
+    expect(exitHolds(9_800n, sub)).toBe(false);
+    expect(exitHolds(9_799n, sub)).toBe(true);
+  });
+
+  it("holds a dispatch inside the cooldown without losing it", () => {
+    const sub = makeSub({ hysteresis: 10n, minBlocksBetweenFires: 5 });
+    const first = evaluateThreshold(sub, 50n, 10, initialArmState(10));
+    expect(first.fired).not.toBeNull();
+    const cleared = evaluateThreshold(sub, 200n, 11, first.nextState);
+    expect(cleared.nextState.phase).toBe("ARMED");
+
+    // Back in breach two blocks later: inside the cooldown, so held, and the
+    // generation does not move - the episode is still the one opened at 11.
+    const held = evaluateThreshold(sub, 50n, 12, cleared.nextState);
+    expect(held.fired).toBeNull();
+    expect(held.nextState).toBe(cleared.nextState);
+
+    // Past the floor: the held dispatch goes out, under that same generation.
+    const released = evaluateThreshold(sub, 50n, 16, held.nextState);
+    expect(released.fired?.dispatchKey).toBe("state:wf-1:1:sub-1:11");
+  });
+
+  it("supports every comparator at its boundary", () => {
+    const cases: Array<
+      [StateThresholdSubscription["comparator"], bigint, boolean]
+    > = [
+      ["lt", 100n, false],
+      ["lt", 99n, true],
+      ["lte", 100n, true],
+      ["gt", 100n, false],
+      ["gt", 101n, true],
+      ["gte", 100n, true],
+    ];
+    for (const [comparator, value, shouldFire] of cases) {
+      const sub = makeSub({ comparator, threshold: 100n });
+      const result = evaluateThreshold(sub, value, 1, initialArmState(1));
+      expect(result.fired !== null, `${comparator} at ${value}`).toBe(
+        shouldFire,
+      );
+    }
+  });
+
+  it("rebuilds the same key for a crossing re-observed at another height", () => {
+    // Reorg safety: the key carries the arming generation, not the block the
+    // value was sampled at, so the same episode cannot dispatch twice.
+    const sub = makeSub();
+    const state = initialArmState(10);
+    const atBlock12 = evaluateThreshold(sub, 50n, 12, state);
+    const atBlock11 = evaluateThreshold(sub, 50n, 11, state);
+    expect(atBlock12.fired?.dispatchKey).toBe(atBlock11.fired?.dispatchKey);
+    expect(atBlock12.fired?.dispatchKey).toBe(
+      buildStateDispatchKey(sub, state.armGeneration),
+    );
   });
 });

--- a/keeperhub-events/event-tracker/tests/unit/workflow-mapper-state.test.ts
+++ b/keeperhub-events/event-tracker/tests/unit/workflow-mapper-state.test.ts
@@ -1,0 +1,233 @@
+import { ethers } from "ethers";
+import { describe, expect, it } from "vitest";
+import type { NetworkConfig, NetworksMap, RawWorkflow } from "../../lib/types";
+import { isStateRegistration } from "../../src/listener/registry";
+import { buildRegistration } from "../../src/listener/workflow-mapper";
+
+/**
+ * Mapping of a `stateThreshold` trigger node (issue #2240). The load-bearing
+ * assertion is that the ABI output types travel with the call: the decoder is
+ * handed raw return data and cannot recover them from the calldata.
+ */
+
+const CHAIN_ID = 31_337;
+
+const NETWORK: NetworkConfig = {
+  id: "local",
+  chainId: CHAIN_ID,
+  name: "Anvil",
+  symbol: "ETH",
+  chainType: "evm",
+  defaultPrimaryRpc: "http://localhost:8546",
+  defaultFallbackRpc: "http://localhost:8546",
+  defaultPrimaryWss: "ws://localhost:8546",
+  defaultFallbackWss: "ws://localhost:8546",
+  isTestnet: true,
+  isEnabled: true,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const NETWORKS: NetworksMap = { [CHAIN_ID]: NETWORK };
+
+const USER = "0x2222222222222222222222222222222222222222";
+
+// Aave V3's getUserAccountData: six uint256 outputs, healthFactor last.
+const POOL_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "getUserAccountData",
+    stateMutability: "view",
+    inputs: [{ name: "user", type: "address" }],
+    outputs: [
+      { name: "totalCollateralBase", type: "uint256" },
+      { name: "totalDebtBase", type: "uint256" },
+      { name: "availableBorrowsBase", type: "uint256" },
+      { name: "currentLiquidationThreshold", type: "uint256" },
+      { name: "ltv", type: "uint256" },
+      { name: "healthFactor", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "paused",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    type: "function",
+    name: "poke",
+    stateMutability: "nonpayable",
+    inputs: [],
+    outputs: [],
+  },
+]);
+
+function makeWorkflow(
+  configOverrides: Record<string, unknown> = {},
+): RawWorkflow {
+  return {
+    id: "wf-1",
+    name: "Health factor guard",
+    userId: "user-1",
+    nodes: [
+      {
+        data: {
+          config: {
+            network: String(CHAIN_ID),
+            triggerType: "stateThreshold",
+            contractAddress: "0x1111111111111111111111111111111111111111",
+            contractABI: POOL_ABI,
+            abiFunction: "getUserAccountData",
+            functionArgs: [USER],
+            outputPath: "healthFactor",
+            comparator: "lt",
+            threshold: "1.05",
+            decimals: 18,
+            ...configOverrides,
+          },
+        },
+      },
+    ],
+  } as RawWorkflow;
+}
+
+function build(configOverrides: Record<string, unknown> = {}) {
+  const reg = buildRegistration(makeWorkflow(configOverrides), NETWORKS);
+  return reg !== null && isStateRegistration(reg) ? reg : null;
+}
+
+describe("buildRegistration - stateThreshold", () => {
+  it("resolves the call, its outputs and the selected index", () => {
+    const reg = build();
+    expect(reg).not.toBeNull();
+    const sub = reg?.subscription;
+    expect(sub?.callData).toBe(
+      new ethers.Interface(JSON.parse(POOL_ABI)).encodeFunctionData(
+        "getUserAccountData",
+        [USER],
+      ),
+    );
+    expect(sub?.outputTypes).toHaveLength(6);
+    expect(sub?.outputTypes?.[5]).toContain("healthFactor");
+    expect(sub?.outputIndex).toBe(5);
+    // 1.05 at 18 decimals.
+    expect(sub?.threshold).toBe(1_050_000_000_000_000_000n);
+    expect(sub?.hysteresis).toBeUndefined();
+  });
+
+  it("accepts an output index as a number or a numeric string", () => {
+    expect(build({ outputPath: 5 })?.subscription.outputIndex).toBe(5);
+    expect(build({ outputPath: "5" })?.subscription.outputIndex).toBe(5);
+    expect(build({ outputPath: undefined })?.subscription.outputIndex).toBe(0);
+  });
+
+  it("scales the hysteresis band by the same decimals as the threshold", () => {
+    const reg = build({ hysteresis: "0.02" });
+    expect(reg?.subscription.hysteresis).toBe(20_000_000_000_000_000n);
+  });
+
+  it("gives a subscription id that moves with the threshold but not the RPC", () => {
+    const base = build();
+    const sameConfig = build();
+    const higher = build({ threshold: "1.10" });
+    expect(sameConfig?.subscription.subscriptionId).toBe(
+      base?.subscription.subscriptionId,
+    );
+    // A changed line is a different subscription, so the first breach under
+    // the new one opens a fresh arming episode instead of inheriting a
+    // generation that would suppress it.
+    expect(higher?.subscription.subscriptionId).not.toBe(
+      base?.subscription.subscriptionId,
+    );
+
+    const otherWss: NetworksMap = {
+      [CHAIN_ID]: { ...NETWORK, defaultPrimaryWss: "ws://other:8546" },
+    };
+    const rotated = buildRegistration(makeWorkflow(), otherWss);
+    expect(
+      rotated !== null && isStateRegistration(rotated)
+        ? rotated.subscription.subscriptionId
+        : null,
+    ).toBe(base?.subscription.subscriptionId);
+    // The connection is still part of what restarts the listener.
+    expect(
+      rotated !== null && isStateRegistration(rotated)
+        ? rotated.configHash
+        : null,
+    ).not.toBe(base?.configHash);
+  });
+
+  it("refuses a non-numeric output rather than decoding it at runtime", () => {
+    expect(build({ abiFunction: "paused", outputPath: 0 })).toBeNull();
+  });
+
+  it("refuses a function that returns nothing to compare", () => {
+    expect(build({ abiFunction: "poke", functionArgs: [] })).toBeNull();
+  });
+
+  it("refuses an outputPath that names no output", () => {
+    expect(build({ outputPath: "collateral" })).toBeNull();
+    expect(build({ outputPath: 9 })).toBeNull();
+  });
+
+  it("refuses an unknown comparator", () => {
+    expect(build({ comparator: "eq" })).toBeNull();
+    expect(build({ comparator: undefined })).toBeNull();
+  });
+
+  it("refuses a threshold that is not a decimal number", () => {
+    expect(build({ threshold: "not-a-number" })).toBeNull();
+    expect(build({ threshold: undefined })).toBeNull();
+  });
+
+  it("refuses a negative or unparseable hysteresis instead of defaulting it", () => {
+    expect(build({ hysteresis: "-0.02" })).toBeNull();
+    expect(build({ hysteresis: "wide" })).toBeNull();
+  });
+
+  it("refuses a function the ABI does not declare", () => {
+    expect(build({ abiFunction: "getReserveData" })).toBeNull();
+  });
+
+  it("refuses arguments that do not match the function signature", () => {
+    expect(build({ functionArgs: [] })).toBeNull();
+    expect(build({ functionArgs: ["not-an-address"] })).toBeNull();
+  });
+
+  it("leaves the event path untouched", () => {
+    const reg = buildRegistration(
+      {
+        id: "wf-2",
+        name: "Event",
+        userId: "user-1",
+        nodes: [
+          {
+            data: {
+              config: {
+                network: String(CHAIN_ID),
+                eventName: "Transfer",
+                contractAddress: "0x1111111111111111111111111111111111111111",
+                contractABI: JSON.stringify([
+                  {
+                    type: "event",
+                    name: "Transfer",
+                    inputs: [
+                      { name: "from", type: "address", indexed: true },
+                      { name: "to", type: "address", indexed: true },
+                      { name: "value", type: "uint256", indexed: false },
+                    ],
+                  },
+                ]),
+              },
+            },
+          },
+        ],
+      } as RawWorkflow,
+      NETWORKS,
+    );
+    expect(reg).not.toBeNull();
+    expect(reg !== null && isStateRegistration(reg)).toBe(false);
+  });
+});


### PR DESCRIPTION
Draft PR for #2240 ("Workflows cannot trigger on a threshold over contract state, only on emitted events").

This implements the **evaluation core only** for the design proposed in my earlier comments on the issue (dedup identity = `(subscriptionId, blockNumber)`, edge detection via a persisted per-subscription `armed` boolean, optional `clearThreshold` for hysteresis, Multicall3 `aggregate3` batching so N subscriptions cost one RPC call per block per chain rather than N). Opened as **draft** deliberately: it does not yet wire into `ChainProviderManager`'s block listener or `EventListener` - I wanted the pure evaluation logic (provider-agnostic, fully unit-testable without a live chain) reviewable/adjustable before doing the integration work, especially since @edycutjong proposed a different approach to the same dedup-identity question earlier on the issue and that hasn't been resolved by a maintainer yet.

**What's included:**
- `src/listener/state-threshold.ts` - `evaluateThreshold()` (pure function: prior state + observed value + block number -> fire decision + next state), `buildMulticallPayload()` / `decodeAggregate3Result()` helpers for the aggregate3 batching.
- `tests/unit/state-threshold.test.ts` - 8 new unit tests covering the false->true edge fire, no-refire-while-still-armed, plain re-arm, hysteresis band via `clearThreshold`, and all 4 comparators.

**Verified before opening:**
- `pnpm test:unit` - all 228 tests pass (14 files), including the 8 new ones.
- `npx tsc --noEmit` - no new type errors from this change (repo's `ethers` `.d.ts` pre-existing private-identifier noise is unrelated, present without this change too).
- Multicall3 deployment cross-checked via direct `eth_getCode` against `0xcA11bde05977b3631167028862bE2a173976CA11` on all 11 `CHAIN_CONFIG` mainnets (see my earlier comment on the issue for the per-chain table) - the aggregate3 batching design does not need a per-chain fallback.

**Not yet done / open for direction from a maintainer before I continue:**
- Wiring into `ChainProviderManager.attachBlockListener` / a new subscription type in `registry.ts` + `SubscribeOptions`.
- Where evaluation should live (existing event-tracker process vs. a new satellite), per the issue's own open question - I lean toward the existing process (reuses the block-subscription plumbing directly, no new deployment), but held off implementing that until the dedup-identity/edge-detection design in this PR is either confirmed or revised.
- The builder-side UI/schema for expressing the view-function call + comparator (out of scope for this PR, `callData` here is assumed already ABI-encoded upstream).

Happy to adjust the design based on feedback, and to fold in @edycutjong's alternative approach if a maintainer prefers it over what's implemented here.

Refs #2240.