### PR TITLE
feat: #2110 gate the allowance preflight warning on upstream reachability

### DIFF
--- a/docs/agent/mcp-validate-workflow.md
+++ b/docs/agent/mcp-validate-workflow.md
@@ -140,7 +140,15 @@ Warnings do not set `valid: false`. They indicate something worth reviewing, but
 |------|--------------|---------------------|
 | `write-action-on-read-workflow` | `workflowType` is `"read"` but the workflow contains a write-action node | When the classification is intentional (for example, a simulate-then-read pattern) |
 | `low-confidence-abi-match` | (`deepCheck` only) The declared ABI's function signatures do not match those resolved from the contract's on-chain bytecode | Always safe to ignore for proxy contracts — Aave V3 Pool, Uniswap V3, WETH, and any EIP-1967 / EIP-1822 / EIP-2535 proxy. The platform's runtime ABI resolver handles proxies automatically; a deep-check mismatch here is informational only |
-| `missing-allowance-preflight` | A `write-contract` node calls an allowance-consuming method (`transferFrom`, `redeem`, `withdrawFrom`) without a preceding Check Allowance node | When the spender already has sufficient allowance, or allowance is granted outside this workflow |
+| `missing-allowance-preflight` | A `write-contract` node calls an allowance-consuming method (`transferFrom`, `redeem`, `withdrawFrom`) and no Check Allowance node is upstream of it | When the spender already has sufficient allowance, or allowance is granted outside this workflow |
+
+### What "upstream" means for `missing-allowance-preflight`
+
+A Check Allowance node suppresses this warning for a given write only when it can reach that write by following connections forward. A check on a parallel branch, or one placed after the write, does not suppress it: neither ordering runs before the write, so neither prevents the revert the warning is about. Each write node is assessed on its own, so one workflow can warn about an unchecked write while staying silent about a checked one.
+
+Both `web3/check-allowance` and the protocol-specific allowance reads — `chainlink/ccip-check-bridge-allowance` and `chainlink/ccip-check-fee-allowance` — count as a Check Allowance node.
+
+Workflows saved without connection data are exempt: with no graph to reason about, any Check Allowance node anywhere in the workflow suppresses the warning.
 
 ## deepCheck semantics
 

--- a/lib/mcp/validate-workflow.ts
+++ b/lib/mcp/validate-workflow.ts
@@ -407,13 +407,168 @@ function parseBatchCallAbiFunctions(callsValue: unknown): unknown[] {
   );
 }
 
-function workflowHasCheckAllowanceNode(nodes: unknown[]): boolean {
-  for (const node of nodes) {
-    const cfg = readNodeActionConfig(node);
-    if (
-      typeof cfg?.actionType === "string" &&
-      cfg.actionType.includes("check-allowance")
-    ) {
+// An action slug that reads an ERC-20 allowance, matched on the slug alone
+// because this module resolves no registry.
+//
+// The contiguous "check-allowance" test alone misses the two allowance reads
+// chainlink ships: `ccip-check-bridge-allowance` and `ccip-check-fee-allowance`
+// place a qualifier between the verb and the noun, so neither contains the
+// substring. Both are `allowance(owner, spender)` reads on an ERC-20
+// (protocols/chainlink.ts), the same call `web3/check-allowance` makes, so
+// both should gate.
+//
+// The pattern requires the `check` verb rather than only a terminal
+// "allowance". `deriveActionsFromAbi` slugs an un-overridden ABI function as
+// its kebab-cased name (lib/abi/protocol-derive.ts), so an ERC-20 extension
+// exposing `increaseAllowance` / `decreaseAllowance` would slug to
+// "increase-allowance" / "decrease-allowance". Those grant an allowance rather
+// than read one and must not gate.
+//
+// The substring test is kept alongside the pattern so this is purely additive:
+// no action type that gates today stops gating.
+const CHECK_ALLOWANCE_ACTION_FRAGMENT = "check-allowance";
+const CHECK_ALLOWANCE_SLUG_PATTERN = /(?:^|-)check(?:-[a-z0-9]+)*-allowance$/;
+
+function isCheckAllowanceActionType(actionType: unknown): boolean {
+  if (typeof actionType !== "string") {
+    return false;
+  }
+  if (actionType.includes(CHECK_ALLOWANCE_ACTION_FRAGMENT)) {
+    return true;
+  }
+  // Action types are "<plugin-or-protocol-slug>/<action-slug>"; match the
+  // action slug so a protocol slug can never satisfy the pattern by itself.
+  const slug = actionType.slice(actionType.lastIndexOf("/") + 1);
+  return CHECK_ALLOWANCE_SLUG_PATTERN.test(slug);
+}
+
+function readNodeId(node: unknown): string | null {
+  if (node === null || typeof node !== "object" || !("id" in node)) {
+    return null;
+  }
+  const { id } = node as { id?: unknown };
+  return typeof id === "string" && id !== "" ? id : null;
+}
+
+/**
+ * Whether an allowance-check node gates a given write node.
+ *
+ * The gate used to be presence-based: any allowance-check node anywhere in the
+ * workflow suppressed the warning for every write in the workflow, including a
+ * check sitting on a parallel branch that never reaches the write, or one
+ * placed after it. Neither ordering prevents the revert the warning is about.
+ * It is now reachability over `workflow.edges`: a write is gated only by a
+ * check that is actually upstream of it.
+ *
+ * `incoming` is null when the workflow carries no usable edges. The route
+ * passes `row.edges ?? []` (app/api/workflows/[workflowId]/validate/route.ts),
+ * so a workflow whose edges were never persisted arrives with an empty array
+ * rather than a graph, and under a strict reading nothing would be upstream of
+ * anything. The gate falls back to the presence test in that case: less
+ * information must not produce a more aggressive warning.
+ */
+type AllowanceGate = {
+  /** An allowance-check node exists somewhere in the workflow. */
+  present: boolean;
+  /** Ids of the allowance-check nodes. */
+  gateIds: Set<string>;
+  /** target node id -> source node ids, or null when there is no graph. */
+  incoming: Map<string, string[]> | null;
+  /** Memoised ancestor sets, keyed by node id. */
+  ancestors: Map<string, Set<string>>;
+};
+
+function buildIncomingEdges(edges: unknown): Map<string, string[]> | null {
+  if (!Array.isArray(edges)) {
+    return null;
+  }
+  const incoming = new Map<string, string[]>();
+  for (const rawEdge of edges) {
+    if (rawEdge === null || typeof rawEdge !== "object") {
+      continue;
+    }
+    const { source, target } = rawEdge as {
+      source?: unknown;
+      target?: unknown;
+    };
+    if (typeof source !== "string" || typeof target !== "string") {
+      continue;
+    }
+    const sources = incoming.get(target);
+    if (sources === undefined) {
+      incoming.set(target, [source]);
+    } else {
+      sources.push(source);
+    }
+  }
+  return incoming.size === 0 ? null : incoming;
+}
+
+function buildAllowanceGate(workflow: ValidatorWorkflow): AllowanceGate {
+  const gateIds = new Set<string>();
+  let present = false;
+  for (const node of workflow.nodes) {
+    if (!isCheckAllowanceActionType(readNodeActionConfig(node)?.actionType)) {
+      continue;
+    }
+    present = true;
+    const id = readNodeId(node);
+    if (id !== null) {
+      gateIds.add(id);
+    }
+  }
+  return {
+    present,
+    gateIds,
+    incoming: buildIncomingEdges(workflow.edges),
+    ancestors: new Map(),
+  };
+}
+
+// Every node that can reach `id` by following edges backwards. `seen` doubles
+// as the visited guard, so a cycle in the graph terminates instead of looping.
+function ancestorsOf(id: string, gate: AllowanceGate): Set<string> {
+  const cached = gate.ancestors.get(id);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const seen = new Set<string>();
+  const incoming = gate.incoming ?? new Map<string, string[]>();
+  const queue = [...(incoming.get(id) ?? [])];
+  let current = queue.pop();
+  while (current !== undefined) {
+    if (seen.has(current)) {
+      current = queue.pop();
+      continue;
+    }
+    seen.add(current);
+    for (const parent of incoming.get(current) ?? []) {
+      if (!seen.has(parent)) {
+        queue.push(parent);
+      }
+    }
+    current = queue.pop();
+  }
+  gate.ancestors.set(id, seen);
+  return seen;
+}
+
+function isAllowanceGated(gate: AllowanceGate, node: unknown): boolean {
+  if (!gate.present) {
+    return false;
+  }
+  // No graph, or gate nodes the graph cannot address by id: fall back to the
+  // presence test rather than warn on missing information.
+  if (gate.incoming === null || gate.gateIds.size === 0) {
+    return true;
+  }
+  const id = readNodeId(node);
+  if (id === null) {
+    return true;
+  }
+  const ancestors = ancestorsOf(id, gate);
+  for (const gateId of gate.gateIds) {
+    if (ancestors.has(gateId)) {
       return true;
     }
   }
@@ -427,22 +582,24 @@ function runAllowancePreflightCheck(
   if (!Array.isArray(workflow.nodes)) {
     return;
   }
-  if (workflowHasCheckAllowanceNode(workflow.nodes)) {
-    return;
-  }
+  const gate = buildAllowanceGate(workflow);
+
   for (const [idx, node] of workflow.nodes.entries()) {
     const cfg = readNodeActionConfig(node);
     if (cfg === null) {
       continue;
     }
     if (cfg.actionType === BATCH_WRITE_CONTRACT_ACTION_TYPE) {
+      if (isAllowanceGated(gate, node)) {
+        continue;
+      }
       const abiFunctions = parseBatchCallAbiFunctions(cfg.calls);
       for (const [callIdx, abiFunction] of abiFunctions.entries()) {
         const method = bareMethodName(abiFunction);
         if (method !== null && ALLOWANCE_SPEND_METHODS.has(method)) {
           warnings.push({
             code: VALIDATION_WARNING_CODES.MISSING_ALLOWANCE_PREFLIGHT,
-            message: `nodes[${idx}].config.calls[${callIdx}] calls "${method}", which moves tokens via an existing allowance, but the workflow has no web3/check-allowance node. Add an upstream web3/check-allowance node before this write to avoid an "insufficient allowance" revert at execution time. Note: batch calls run with msg.sender set to the Multicall3 contract, not your wallet, so a "${method}" call that relies on a wallet allowance will not work in a batch; keep it in a standalone write node instead.`,
+            message: `nodes[${idx}].config.calls[${callIdx}] calls "${method}", which moves tokens via an existing allowance, but no web3/check-allowance node is upstream of it. Add an upstream web3/check-allowance node before this write to avoid an "insufficient allowance" revert at execution time. Note: batch calls run with msg.sender set to the Multicall3 contract, not your wallet, so a "${method}" call that relies on a wallet allowance will not work in a batch; keep it in a standalone write node instead.`,
             parameterPath: `nodes[${idx}].config.calls[${callIdx}].abiFunction`,
           });
         }
@@ -453,10 +610,18 @@ function runAllowancePreflightCheck(
       continue;
     }
     const method = bareMethodName(cfg.abiFunction);
-    if (method !== null && ALLOWANCE_SPEND_METHODS.has(method)) {
+    // Gate last: the ancestor walk is the expensive half, and only a node that
+    // already resolved to a spend method can produce a warning. The batch
+    // branch consults it first instead, because every call in `calls[]` shares
+    // one gate result.
+    if (
+      method !== null &&
+      ALLOWANCE_SPEND_METHODS.has(method) &&
+      !isAllowanceGated(gate, node)
+    ) {
       warnings.push({
         code: VALIDATION_WARNING_CODES.MISSING_ALLOWANCE_PREFLIGHT,
-        message: `nodes[${idx}].config calls "${method}", which moves tokens via an existing allowance, but the workflow has no web3/check-allowance node. Add an upstream web3/check-allowance node before this write to avoid an "insufficient allowance" revert at execution time.`,
+        message: `nodes[${idx}].config calls "${method}", which moves tokens via an existing allowance, but no web3/check-allowance node is upstream of it. Add an upstream web3/check-allowance node before this write to avoid an "insufficient allowance" revert at execution time.`,
         parameterPath: `nodes[${idx}].config.abiFunction`,
       });
     }

--- a/tests/unit/validate-workflow-allowance.test.ts
+++ b/tests/unit/validate-workflow-allowance.test.ts
@@ -12,9 +12,17 @@ import {
 
 const CODE = "missing-allowance-preflight";
 
+const checkAllowanceNode = (id = "ca", actionType = "web3/check-allowance") =>
+  actionNode(id, { actionType });
+
+/**
+ * trigger-1 -> w1, with `extraNodes` appended and `extraEdges` added on top.
+ * An extra node with no edge to it is intentionally *not* upstream of w1.
+ */
 function writeWorkflow(
   overrides: Record<string, unknown>,
-  extraNodes: unknown[] = []
+  extraNodes: unknown[] = [],
+  extraEdges: unknown[] = []
 ) {
   return makeWorkflow({
     workflowType: "write",
@@ -23,9 +31,28 @@ function writeWorkflow(
       actionNode("w1", { actionType: "web3/write-contract", ...overrides }),
       ...extraNodes,
     ],
-    edges: [edge("e1", "trigger-1", "w1")],
+    edges: [edge("e1", "trigger-1", "w1"), ...extraEdges],
   });
 }
+
+/** trigger-1 -> ca -> w1: the check is genuinely upstream of the write. */
+function gatedWriteWorkflow(
+  overrides: Record<string, unknown>,
+  gateActionType = "web3/check-allowance"
+) {
+  return makeWorkflow({
+    workflowType: "write",
+    nodes: [
+      triggerNode(),
+      checkAllowanceNode("ca", gateActionType),
+      actionNode("w1", { actionType: "web3/write-contract", ...overrides }),
+    ],
+    edges: [edge("e1", "trigger-1", "ca"), edge("e2", "ca", "w1")],
+  });
+}
+
+const hasWarning = (result: { warnings: { code: string }[] }) =>
+  result.warnings.some((w) => w.code === CODE);
 
 describe("validateWorkflow - allowance preflight", () => {
   it("warns when write-contract calls transferFrom with no check-allowance node", () => {
@@ -43,21 +70,19 @@ describe("validateWorkflow - allowance preflight", () => {
     const result = validateWorkflow(
       writeWorkflow({ abiFunction: "redeem(uint256,address,address)" })
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(true);
+    expect(hasWarning(result)).toBe(true);
   });
 
   it("does not warn for a non-allowance method (transfer)", () => {
     const result = validateWorkflow(writeWorkflow({ abiFunction: "transfer" }));
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(false);
   });
 
-  it("is suppressed when a check-allowance node is present", () => {
+  it("is suppressed when a check-allowance node is upstream", () => {
     const result = validateWorkflow(
-      writeWorkflow({ abiFunction: "transferFrom" }, [
-        actionNode("ca", { actionType: "web3/check-allowance" }),
-      ])
+      gatedWriteWorkflow({ abiFunction: "transferFrom" })
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(false);
   });
 
   it("ignores allowance methods on a non-write action (read-contract)", () => {
@@ -73,7 +98,7 @@ describe("validateWorkflow - allowance preflight", () => {
         edges: [edge("e1", "trigger-1", "r1")],
       })
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(false);
   });
 
   it("ignores a top-level abiFunction on a batch-write-contract node (real batch nodes carry calls, not abiFunction)", () => {
@@ -83,7 +108,7 @@ describe("validateWorkflow - allowance preflight", () => {
         abiFunction: "transferFrom",
       })
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(false);
   });
 
   it("warns when a batch-write-contract node's calls[] includes transferFrom with no check-allowance node", () => {
@@ -112,21 +137,209 @@ describe("validateWorkflow - allowance preflight", () => {
         ]),
       })
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(false);
   });
 
-  it("suppresses the batch calls[] warning when a check-allowance node is present", () => {
+  it("suppresses the batch calls[] warning when a check-allowance node is upstream", () => {
+    const result = validateWorkflow(
+      gatedWriteWorkflow({
+        actionType: "web3/batch-write-contract",
+        calls: JSON.stringify([
+          { contractAddress: "0x1", abi: "[]", abiFunction: "transferFrom" },
+        ]),
+      })
+    );
+    expect(hasWarning(result)).toBe(false);
+  });
+});
+
+describe("validateWorkflow - allowance gate reachability", () => {
+  it("warns when the check-allowance node is on a parallel branch that never reaches the write", () => {
+    // trigger-1 -> ca (dead end), trigger-1 -> w1. Presence-based gating
+    // suppressed this; the check cannot affect w1's execution.
     const result = validateWorkflow(
       writeWorkflow(
-        {
-          actionType: "web3/batch-write-contract",
-          calls: JSON.stringify([
-            { contractAddress: "0x1", abi: "[]", abiFunction: "transferFrom" },
-          ]),
-        },
-        [actionNode("ca", { actionType: "web3/check-allowance" })]
+        { abiFunction: "transferFrom" },
+        [checkAllowanceNode()],
+        [edge("e2", "trigger-1", "ca")]
       )
     );
-    expect(result.warnings.some((w) => w.code === CODE)).toBe(false);
+    expect(hasWarning(result)).toBe(true);
+  });
+
+  it("warns when the check-allowance node runs downstream of the write", () => {
+    // trigger-1 -> w1 -> ca. Checking the allowance after spending it does not
+    // prevent the revert.
+    const result = validateWorkflow(
+      writeWorkflow(
+        { abiFunction: "transferFrom" },
+        [checkAllowanceNode()],
+        [edge("e2", "w1", "ca")]
+      )
+    );
+    expect(hasWarning(result)).toBe(true);
+  });
+
+  it("suppresses through a multi-hop upstream chain", () => {
+    // trigger-1 -> ca -> mid -> w1
+    const result = validateWorkflow(
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [
+          triggerNode(),
+          checkAllowanceNode(),
+          actionNode("mid", { actionType: "web3/read-contract" }),
+          actionNode("w1", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [
+          edge("e1", "trigger-1", "ca"),
+          edge("e2", "ca", "mid"),
+          edge("e3", "mid", "w1"),
+        ],
+      })
+    );
+    expect(hasWarning(result)).toBe(false);
+  });
+
+  it("gates each write independently: one branch checked, the other not", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [
+          triggerNode(),
+          checkAllowanceNode(),
+          actionNode("gated", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+          actionNode("ungated", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [
+          edge("e1", "trigger-1", "ca"),
+          edge("e2", "ca", "gated"),
+          edge("e3", "trigger-1", "ungated"),
+        ],
+      })
+    );
+    const warnings = result.warnings.filter((w) => w.code === CODE);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.parameterPath).toBe("nodes[3].config.abiFunction");
+  });
+
+  it("falls back to the presence test when the workflow carries no edges", () => {
+    // Workflows whose edges were never persisted arrive as []. Less
+    // information must not produce a more aggressive warning.
+    const result = validateWorkflow(
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [
+          triggerNode(),
+          checkAllowanceNode(),
+          actionNode("w1", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [],
+      })
+    );
+    expect(hasWarning(result)).toBe(false);
+  });
+
+  it("still warns with no edges when there is no check-allowance node at all", () => {
+    const result = validateWorkflow(
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [
+          triggerNode(),
+          actionNode("w1", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [],
+      })
+    );
+    expect(hasWarning(result)).toBe(true);
+  });
+
+  it("terminates on a cycle in the edge graph", () => {
+    // a -> b -> a, with w1 downstream of b and no check anywhere upstream.
+    const result = validateWorkflow(
+      makeWorkflow({
+        workflowType: "write",
+        nodes: [
+          triggerNode(),
+          checkAllowanceNode(),
+          actionNode("a", { actionType: "web3/read-contract" }),
+          actionNode("b", { actionType: "web3/read-contract" }),
+          actionNode("w1", {
+            actionType: "web3/write-contract",
+            abiFunction: "transferFrom",
+          }),
+        ],
+        edges: [
+          edge("e1", "trigger-1", "ca"),
+          edge("e2", "a", "b"),
+          edge("e3", "b", "a"),
+          edge("e4", "b", "w1"),
+        ],
+      })
+    );
+    expect(hasWarning(result)).toBe(true);
+  });
+});
+
+describe("validateWorkflow - allowance gate action-type matching", () => {
+  // chainlink/ccip-check-bridge-allowance and ccip-check-fee-allowance are
+  // allowance(owner, spender) reads on an ERC-20, exactly what
+  // web3/check-allowance does, but neither contains the contiguous substring
+  // "check-allowance". Before this fix they did not register as gates.
+  it.each([
+    "chainlink/ccip-check-bridge-allowance",
+    "chainlink/ccip-check-fee-allowance",
+    "web3/check-allowance",
+  ])("treats %s as an allowance gate when upstream", (actionType) => {
+    const result = validateWorkflow(
+      gatedWriteWorkflow({ abiFunction: "transferFrom" }, actionType)
+    );
+    expect(hasWarning(result)).toBe(false);
+  });
+
+  it.each([
+    "chainlink/ccip-check-bridge-allowance",
+    "chainlink/ccip-check-fee-allowance",
+    "web3/check-allowance",
+  ])("still warns when %s is not upstream of the write", (actionType) => {
+    const result = validateWorkflow(
+      writeWorkflow(
+        { abiFunction: "transferFrom" },
+        [checkAllowanceNode("ca", actionType)],
+        [edge("e2", "trigger-1", "ca")]
+      )
+    );
+    expect(hasWarning(result)).toBe(true);
+  });
+
+  it.each([
+    // Grant an allowance rather than read one: an ERC-20 extension exposing
+    // increaseAllowance / decreaseAllowance slugs to these.
+    "erc20/increase-allowance",
+    "erc20/decrease-allowance",
+    // Unrelated actions that merely mention one of the words.
+    "chainlink/ccip-approve-fee-token",
+    "web3/approve-token",
+    "aave-v3/supply",
+  ])("does not treat %s as an allowance gate", (actionType) => {
+    const result = validateWorkflow(
+      gatedWriteWorkflow({ abiFunction: "transferFrom" }, actionType)
+    );
+    expect(hasWarning(result)).toBe(true);
   });
 });

--- a/tests/unit/validate-workflow-seed-workflows.test.ts
+++ b/tests/unit/validate-workflow-seed-workflows.test.ts
@@ -1,0 +1,60 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { validateWorkflow } from "@/lib/mcp/validate-workflow";
+
+/**
+ * The workflows under scripts/seed/workflows are the shipped reference
+ * templates: what the seeder installs and what the MCP tests exercise. They are
+ * correct by construction, so any warning the validator raises against one of
+ * them is a false positive in the validator, not a defect in the template.
+ *
+ * This pins that contract. It is the cheapest guard against a widened check
+ * regressing on real node shapes: seed nodes are created by the seeder rather
+ * than the editor, so they carry the field shapes editor-built fixtures do not.
+ */
+const SEED_WORKFLOW_DIR = join("scripts", "seed", "workflows");
+
+function seedWorkflowFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      out.push(...seedWorkflowFiles(path));
+    } else if (entry.endsWith(".json")) {
+      out.push(path);
+    }
+  }
+  return out.sort();
+}
+
+const files = seedWorkflowFiles(SEED_WORKFLOW_DIR);
+
+describe("validateWorkflow - shipped seed workflows", () => {
+  it("finds seed workflows to check", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)("%s raises no allowance warning", (file) => {
+    const raw = JSON.parse(readFileSync(file, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    const result = validateWorkflow({
+      id: file,
+      nodes: Array.isArray(raw.nodes) ? raw.nodes : [],
+      edges: Array.isArray(raw.edges) ? raw.edges : [],
+      inputSchema: null,
+      outputMapping: null,
+      isListed: false,
+      workflowType: raw.type === "write" ? "write" : "read",
+    });
+    const allowanceWarnings = result.warnings.filter(
+      (w) => w.code === "missing-allowance-preflight"
+    );
+    expect(allowanceWarnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Issue

Part of #2110. This is the first of the three seams that issue's accepted plan
covers; it does not close the issue. See **Scope** below.

## What this changes

`missing-allowance-preflight` used to be gated on presence: if any node whose
action type contained the substring `check-allowance` existed anywhere in the
workflow, `runAllowancePreflightCheck` returned early and the warning was
suppressed for *every* write in the workflow. This replaces that with
reachability over `workflow.edges` -- a write is gated only by an allowance
check that is actually upstream of it -- and fixes which action types register
as a gate.

Two independent problems with the presence test:

1. **It suppressed on checks that cannot run before the write.** A check on a
   parallel branch, or one placed after the write, suppressed the warning just
   as well as a correctly-sequenced one. Neither ordering prevents the revert
   the warning exists to predict. It was also all-or-nothing across the
   workflow: one correctly-gated write silenced every other unchecked write
   next to it.

2. **The substring test missed two of the three allowance reads in the repo.**
   `chainlink/ccip-check-bridge-allowance` and `chainlink/ccip-check-fee-allowance`
   put a qualifier between the verb and the noun, so neither contains the
   contiguous substring `check-allowance`. Both are `allowance(owner, spender)`
   reads on an ERC-20 (`protocols/chainlink.ts`) -- the same call
   `web3/check-allowance` makes -- so both should gate and neither did.

   This one is not new in this PR; it reproduces on `staging` at e089f84. A
   `web3/write-contract` node calling `transferFrom`, correctly preceded by
   `chainlink/ccip-check-bridge-allowance`, warns today.

Matching is now `actionType.includes("check-allowance")` **or** an anchored
pattern on the action slug, `/(?:^|-)check(?:-[a-z0-9]+)*-allowance$/`. Keeping
the substring test alongside the pattern makes the change purely additive: no
action type that gates today stops gating. I chose the pattern over an explicit
allowlist because an allowlist would live in `lib/mcp/` while the slugs are
authored in `protocols/`, which is the coupling that let this bug exist in the
first place; a new `ccip-check-<x>-allowance` is covered without an edit here.
The pattern requires the `check` verb rather than only a terminal `allowance`,
because `deriveActionsFromAbi` slugs an un-overridden ABI function as its
kebab-cased name, so an ERC-20 extension exposing `increaseAllowance` /
`decreaseAllowance` would produce slugs ending in `-allowance` that grant an
allowance rather than read one.

I enumerated the built registry to check the pattern's reach: across all 24
registered protocols there are exactly two actions whose slug or ABI function
mentions an allowance, and they are the two chainlink reads above. The pattern
matches those two plus `web3/check-allowance` and nothing else.

**Behaviour change a reader would not predict from the title:** workflows that
were silent can now warn. A workflow with a `check-allowance` node on a branch
that never reaches the write returned no `warnings` key at all before
(`formatResult` omits `warnings` when empty,
`app/api/workflows/[workflowId]/validate/route.ts:88-98`) and now returns one.
`valid` is unchanged and nothing blocks execution -- these are advisory.

Workflows that arrive with no usable edges fall back to the old presence test.
The validate route passes `row.edges ?? []`, so a workflow whose edges were
never persisted arrives as an empty array rather than a graph; under a strict
reading nothing would be upstream of anything and every write would warn. Less
information must not produce a more aggressive warning.

`ALLOWANCE_SPEND_METHODS` is untouched, still the same three methods.

## Scope

One change. The gate is correct with everything else in #2110 absent: it
neither reads nor depends on protocol metadata, the widened method set, or the
approve warning.

The other two seams #2110's plan covers -- the method-set widening with its
protocol resolution, and the `ungated-approve` warning -- are removed from this
branch and will come as their own pull requests. Applying ISSUES.md's own test,
each of the three ships and is correct with the other two reverted, so they are
three changes rather than one. That was wrong in the previous revision of this
PR and the review was right to say so.

## How it was verified

New tests, and what each catches if the fix regresses:

- **Reachability** (7 tests). Gate on a parallel branch warns; gate downstream
  of the write warns; multi-hop upstream chain suppresses; two writes in one
  workflow assessed independently; no-edges fallback suppresses; no-edges with
  no gate still warns; a cycle in the edge graph terminates. Reverting
  `isAllowanceGated` to presence-only fails 7 of these.

- **Action-type matching** (11 cases). Each of the three allowance reads
  asserted in both directions -- suppresses when upstream, still warns when
  present but not upstream. Plus five negative cases that must *not* gate:
  `increase-allowance`, `decrease-allowance`, `ccip-approve-fee-token`,
  `web3/approve-token`, `aave-v3/supply`. Making the slug pattern never match
  fails the two chainlink cases.

- **`tests/unit/validate-workflow-seed-workflows.test.ts`** (new). Asserts all
  43 workflows under `scripts/seed/workflows/**` stay free of
  `missing-allowance-preflight`. These are the shipped reference templates, so
  a warning against one of them is a false positive in the validator rather
  than a defect in the template.

  Being straight about this one's reach today: the seed corpus contains no
  `web3/write-contract` or `web3/batch-write-contract` nodes -- every write in
  it is a protocol node, which this check does not resolve. So it currently
  exercises gate construction across 43 real graphs without reaching the spend
  branch, and its value is forward-looking: it pins the clean baseline before
  the method-set widening lands, which is exactly when it starts having teeth.
  I ran the previous four-part revision of this branch against it and 12 of the
  43 failed, so it does catch the class of regression it was asked for.

The two existing tests that relied on presence-only suppression were updated to
connect the check-allowance node upstream of the write; the un-connected shape
they used to assert is now covered explicitly as a warning case.

Commands run locally: `npx vitest run tests/unit` (full suite),
`npx tsgo --noEmit`, `npx biome check`.

Upstream CI was released on 2026-09-10 and has now run on `f590702`. `PR Checks`
is green: `test-unit` (612 files, 22270 tests, 0 failures), `test-integration`,
`lint`, `typecheck`, `build`, `migrate-check`. `Maintainability`,
`PR Title Check`, `Decision Label Check`, `DB Prep Check`,
`Metrics DB Review Gate`, `PR Docs Site Build` and `PR Issue Link` are green
too.

One red mark remains in the checks list: `e2e-tests / e2e-gate` in `CI Pipeline`
run `34237185721`. That is the 14:16 run, which the concurrency group cancelled
when the 18:43 run superseded it; the gate job reports failure because every job
it evaluates was cancelled. The live `CI Pipeline` run for this head,
`34264779563`, is green and its `e2e-gate` passed. I have no write access here,
so I cannot re-run or clear the superseded one.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed

