### PR TITLE
fix: #2333 propagate generation stream errors and cancel failed reads

### DIFF
--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -165,7 +165,6 @@ type StreamMessage = {
 
 type StreamState = {
   buffer: string;
-  complete: boolean;
   currentData: WorkflowData;
 };
 
@@ -312,8 +311,6 @@ function processStreamLine(
   } else if (message.type === "error") {
     console.error("[API Client] Error:", message.error);
     throw new Error(message.error || "Failed to generate workflow");
-  } else if (message.type === "complete") {
-    state.complete = true;
   }
 }
 
@@ -376,7 +373,6 @@ export const aiApi = {
     const decoder = new TextDecoder();
     const state: StreamState = {
       buffer: "",
-      complete: false,
       currentData: existingWorkflow
         ? {
             nodes: existingWorkflow.nodes || [],
@@ -397,12 +393,14 @@ export const aiApi = {
         processStreamChunk(value, decoder, onUpdate, state);
       }
 
-      processStreamLine(state.buffer + decoder.decode(), onUpdate, state);
-      if (!state.complete) {
-        throw new Error("Workflow generation stream ended before completion");
-      }
-
       return state.currentData;
+    } catch (error) {
+      try {
+        await reader.cancel(error);
+      } catch {
+        // Preserve the original stream or callback error if cleanup fails.
+      }
+      throw error;
     } finally {
       reader.releaseLock();
     }

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -165,6 +165,7 @@ type StreamMessage = {
 
 type StreamState = {
   buffer: string;
+  complete: boolean;
   currentData: WorkflowData;
 };
 
@@ -293,18 +294,26 @@ function processStreamLine(
     return;
   }
 
+  let message: StreamMessage;
   try {
-    const message = JSON.parse(line) as StreamMessage;
-
-    if (message.type === "operation" && message.operation) {
-      applyOperation(message.operation, state);
-      onUpdate({ ...state.currentData });
-    } else if (message.type === "error") {
-      console.error("[API Client] Error:", message.error);
-      throw new Error(message.error);
-    }
+    message = JSON.parse(line) as StreamMessage;
   } catch (error) {
     console.error("[API Client] Failed to parse JSONL line:", error);
+    return;
+  }
+
+  if (!message || typeof message !== "object") {
+    return;
+  }
+
+  if (message.type === "operation" && message.operation) {
+    applyOperation(message.operation, state);
+    onUpdate({ ...state.currentData });
+  } else if (message.type === "error") {
+    console.error("[API Client] Error:", message.error);
+    throw new Error(message.error || "Failed to generate workflow");
+  } else if (message.type === "complete") {
+    state.complete = true;
   }
 }
 
@@ -367,6 +376,7 @@ export const aiApi = {
     const decoder = new TextDecoder();
     const state: StreamState = {
       buffer: "",
+      complete: false,
       currentData: existingWorkflow
         ? {
             nodes: existingWorkflow.nodes || [],
@@ -385,6 +395,11 @@ export const aiApi = {
         }
 
         processStreamChunk(value, decoder, onUpdate, state);
+      }
+
+      processStreamLine(state.buffer + decoder.decode(), onUpdate, state);
+      if (!state.complete) {
+        throw new Error("Workflow generation stream ended before completion");
       }
 
       return state.currentData;

--- a/tests/unit/api-client-generate-stream.test.ts
+++ b/tests/unit/api-client-generate-stream.test.ts
@@ -3,14 +3,25 @@ import { aiApi } from "@/lib/api-client";
 
 const encoder = new TextEncoder();
 
-function mockStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+type MockStreamOptions = {
+  keepOpen?: boolean;
+  cancel?: (reason: unknown) => void | Promise<void>;
+};
+
+function mockStream(
+  chunks: Uint8Array[],
+  options: MockStreamOptions = {}
+): ReadableStream<Uint8Array> {
   const stream = new ReadableStream<Uint8Array>({
     start(controller): void {
       for (const chunk of chunks) {
         controller.enqueue(chunk);
       }
-      controller.close();
+      if (!options.keepOpen) {
+        controller.close();
+      }
     },
+    cancel: options.cancel,
   });
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(stream)));
   return stream;
@@ -18,14 +29,16 @@ function mockStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 
 function mockLines(
   lines: unknown[],
-  trailingNewline = true
+  options: MockStreamOptions = {}
 ): ReadableStream<Uint8Array> {
-  return mockStream([
-    encoder.encode(
-      lines.map((line) => JSON.stringify(line)).join("\n") +
-        (trailingNewline ? "\n" : "")
-    ),
-  ]);
+  return mockStream(
+    [
+      encoder.encode(
+        `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`
+      ),
+    ],
+    options
+  );
 }
 
 describe("aiApi.generateStream", () => {
@@ -38,12 +51,16 @@ describe("aiApi.generateStream", () => {
     vi.restoreAllMocks();
   });
 
-  it("rejects an in-band server error instead of returning partial data", async () => {
-    const stream = mockLines([
-      { type: "operation", operation: { op: "setName", name: "Partial" } },
-      { type: "error", error: "Model provider unavailable" },
-      { type: "operation", operation: { op: "setName", name: "Ignored" } },
-    ]);
+  it("rejects an in-band server error and cancels the still-open response body", async () => {
+    const cancel = vi.fn();
+    const stream = mockLines(
+      [
+        { type: "operation", operation: { op: "setName", name: "Partial" } },
+        { type: "error", error: "Model provider unavailable" },
+        { type: "operation", operation: { op: "setName", name: "Ignored" } },
+      ],
+      { keepOpen: true, cancel }
+    );
     const onUpdate = vi.fn();
 
     await expect(
@@ -59,6 +76,9 @@ describe("aiApi.generateStream", () => {
       "[API Client] Error:",
       "Model provider unavailable"
     );
+    expect(cancel).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: "Model provider unavailable" })
+    );
     expect(stream.locked).toBe(false);
   });
 
@@ -73,8 +93,8 @@ describe("aiApi.generateStream", () => {
     expect(stream.locked).toBe(false);
   });
 
-  it("accumulates operations across byte boundaries and a final line without newline", async () => {
-    const text = [
+  it("accumulates newline-delimited operations across byte boundaries without canceling", async () => {
+    const text = `${[
       { type: "operation", operation: { op: "setName", name: "Café" } },
       {
         type: "operation",
@@ -83,10 +103,12 @@ describe("aiApi.generateStream", () => {
       { type: "complete" },
     ]
       .map((line) => JSON.stringify(line))
-      .join("\n");
+      .join("\n")}\n`;
     const bytes = encoder.encode(text);
+    const cancel = vi.fn();
     const stream = mockStream(
-      Array.from(bytes, (byte) => new Uint8Array([byte]))
+      Array.from(bytes, (byte) => new Uint8Array([byte])),
+      { cancel }
     );
     const onUpdate = vi.fn();
 
@@ -100,6 +122,7 @@ describe("aiApi.generateStream", () => {
     });
     expect(onUpdate).toHaveBeenCalledTimes(2);
     expect(console.error).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
     expect(stream.locked).toBe(false);
   });
 
@@ -124,45 +147,73 @@ describe("aiApi.generateStream", () => {
   });
 
   it.each([
-    { label: "empty", messages: [] },
+    { label: "empty", messages: [], expected: { nodes: [], edges: [] } },
     {
       label: "partial",
       messages: [
         { type: "operation", operation: { op: "setName", name: "Partial" } },
       ],
+      expected: { nodes: [], edges: [], name: "Partial" },
     },
   ])(
-    "rejects a $label stream without the completion message",
-    async ({ messages }) => {
+    "preserves the existing EOF behavior for a $label stream without a completion message",
+    async ({ messages, expected }) => {
       const stream = mockLines(messages);
 
       await expect(
         aiApi.generateStream("Build a workflow", vi.fn())
-      ).rejects.toThrow("Workflow generation stream ended before completion");
+      ).resolves.toEqual(expected);
       expect(stream.locked).toBe(false);
     }
   );
 
-  it("propagates an error in the final line without a newline", async () => {
-    mockLines([{ type: "error", error: "Generation stopped" }], false);
-
-    await expect(
-      aiApi.generateStream("Build a workflow", vi.fn())
-    ).rejects.toThrow("Generation stopped");
-  });
-
-  it("propagates update-callback failures without mislabeling them as parse errors", async () => {
-    const stream = mockLines([
-      { type: "operation", operation: { op: "setName", name: "Workflow" } },
-      { type: "complete" },
+  it("preserves the existing handling of an unterminated final line", async () => {
+    mockStream([
+      encoder.encode(
+        '{"type":"operation","operation":{"op":"setName","name":"Kept"}}\n{"type":"error","error":"Unterminated"}'
+      ),
     ]);
 
     await expect(
+      aiApi.generateStream("Build a workflow", vi.fn())
+    ).resolves.toEqual({ nodes: [], edges: [], name: "Kept" });
+  });
+
+  it("propagates update-callback failures and cancels the still-open response body", async () => {
+    const cancel = vi.fn();
+    const stream = mockLines(
+      [
+        { type: "operation", operation: { op: "setName", name: "Workflow" } },
+        { type: "complete" },
+      ],
+      { keepOpen: true, cancel }
+    );
+    const error = new Error("Update failed");
+
+    await expect(
       aiApi.generateStream("Build a workflow", () => {
-        throw new Error("Update failed");
+        throw error;
       })
-    ).rejects.toThrow("Update failed");
+    ).rejects.toBe(error);
     expect(console.error).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledExactlyOnceWith(error);
+    expect(stream.locked).toBe(false);
+  });
+
+  it("preserves the original failure and releases the lock when cancellation rejects", async () => {
+    const error = new Error("Update failed");
+    const cancel = vi.fn().mockRejectedValue(new Error("Cleanup failed"));
+    const stream = mockLines(
+      [{ type: "operation", operation: { op: "setName", name: "Workflow" } }],
+      { keepOpen: true, cancel }
+    );
+
+    await expect(
+      aiApi.generateStream("Build a workflow", () => {
+        throw error;
+      })
+    ).rejects.toBe(error);
+    expect(cancel).toHaveBeenCalledExactlyOnceWith(error);
     expect(stream.locked).toBe(false);
   });
 

--- a/tests/unit/api-client-generate-stream.test.ts
+++ b/tests/unit/api-client-generate-stream.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { aiApi } from "@/lib/api-client";
+
+const encoder = new TextEncoder();
+
+function mockStream(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller): void {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(stream)));
+  return stream;
+}
+
+function mockLines(
+  lines: unknown[],
+  trailingNewline = true
+): ReadableStream<Uint8Array> {
+  return mockStream([
+    encoder.encode(
+      lines.map((line) => JSON.stringify(line)).join("\n") +
+        (trailingNewline ? "\n" : "")
+    ),
+  ]);
+}
+
+describe("aiApi.generateStream", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("rejects an in-band server error instead of returning partial data", async () => {
+    const stream = mockLines([
+      { type: "operation", operation: { op: "setName", name: "Partial" } },
+      { type: "error", error: "Model provider unavailable" },
+      { type: "operation", operation: { op: "setName", name: "Ignored" } },
+    ]);
+    const onUpdate = vi.fn();
+
+    await expect(
+      aiApi.generateStream("Build a workflow", onUpdate)
+    ).rejects.toThrow("Model provider unavailable");
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith({
+      nodes: [],
+      edges: [],
+      name: "Partial",
+    });
+    expect(console.error).toHaveBeenCalledExactlyOnceWith(
+      "[API Client] Error:",
+      "Model provider unavailable"
+    );
+    expect(stream.locked).toBe(false);
+  });
+
+  it("rejects an error before any operation and provides a fallback reason", async () => {
+    const stream = mockLines([{ type: "error" }]);
+    const onUpdate = vi.fn();
+
+    await expect(
+      aiApi.generateStream("Build a workflow", onUpdate)
+    ).rejects.toThrow("Failed to generate workflow");
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("accumulates operations across byte boundaries and a final line without newline", async () => {
+    const text = [
+      { type: "operation", operation: { op: "setName", name: "Café" } },
+      {
+        type: "operation",
+        operation: { op: "setDescription", description: "Complete workflow" },
+      },
+      { type: "complete" },
+    ]
+      .map((line) => JSON.stringify(line))
+      .join("\n");
+    const bytes = encoder.encode(text);
+    const stream = mockStream(
+      Array.from(bytes, (byte) => new Uint8Array([byte]))
+    );
+    const onUpdate = vi.fn();
+
+    await expect(
+      aiApi.generateStream("Build a workflow", onUpdate)
+    ).resolves.toEqual({
+      nodes: [],
+      edges: [],
+      name: "Café",
+      description: "Complete workflow",
+    });
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("skips malformed and blank lines but processes subsequent valid messages", async () => {
+    mockStream([
+      encoder.encode(
+        '\ninvalid JSON\nnull\n42\n"ignored"\n{"type":"operation","operation":{"op":"setName","name":"Recovered"}}\n{"type":"complete"}\n'
+      ),
+    ]);
+
+    await expect(
+      aiApi.generateStream("Build a workflow", vi.fn())
+    ).resolves.toEqual({
+      nodes: [],
+      edges: [],
+      name: "Recovered",
+    });
+    expect(console.error).toHaveBeenCalledExactlyOnceWith(
+      "[API Client] Failed to parse JSONL line:",
+      expect.any(SyntaxError)
+    );
+  });
+
+  it.each([
+    { label: "empty", messages: [] },
+    {
+      label: "partial",
+      messages: [
+        { type: "operation", operation: { op: "setName", name: "Partial" } },
+      ],
+    },
+  ])(
+    "rejects a $label stream without the completion message",
+    async ({ messages }) => {
+      const stream = mockLines(messages);
+
+      await expect(
+        aiApi.generateStream("Build a workflow", vi.fn())
+      ).rejects.toThrow("Workflow generation stream ended before completion");
+      expect(stream.locked).toBe(false);
+    }
+  );
+
+  it("propagates an error in the final line without a newline", async () => {
+    mockLines([{ type: "error", error: "Generation stopped" }], false);
+
+    await expect(
+      aiApi.generateStream("Build a workflow", vi.fn())
+    ).rejects.toThrow("Generation stopped");
+  });
+
+  it("propagates update-callback failures without mislabeling them as parse errors", async () => {
+    const stream = mockLines([
+      { type: "operation", operation: { op: "setName", name: "Workflow" } },
+      { type: "complete" },
+    ]);
+
+    await expect(
+      aiApi.generateStream("Build a workflow", () => {
+        throw new Error("Update failed");
+      })
+    ).rejects.toThrow("Update failed");
+    expect(console.error).not.toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("preserves the existing workflow when the server completes without changes", async () => {
+    mockLines([{ type: "complete" }]);
+    const existingWorkflow = { nodes: [], edges: [], name: "Existing" };
+
+    await expect(
+      aiApi.generateStream("Keep it", vi.fn(), existingWorkflow)
+    ).resolves.toEqual(existingWorkflow);
+    expect(fetch).toHaveBeenCalledWith("/api/ai/generate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "Keep it", existingWorkflow }),
+    });
+  });
+});


### PR DESCRIPTION
Closes #2333. Original report and accepted plan by @Yoh5.

When the generation server sends an error after partial operations, `generateStream` now rejects instead of catching that error as a JSON parsing failure and returning partial workflow data. Only JSON decoding is caught as a parse error; malformed and non-object records remain skippable. The caller's generic failure toast remains unchanged.

Early failures now cancel the response reader before releasing its lock. Cancellation is awaited, and a cleanup rejection does not replace the original stream or callback error.

The PR is limited to the accepted server-error propagation fix and cleanup of its early-exit path. Completion-message enforcement and final-buffer flushing have been removed following review. Existing EOF behavior is retained; this PR does not claim to detect truncation without a server-declared error or to process an unterminated final record.

Validation with pnpm 9.15.9:

- `pnpm test tests/unit/api-client-generate-stream.test.ts`: 10 passed.
- `pnpm type-check`, `pnpm fix`, and `pnpm check`: passed. Biome retains its preexisting oversized-fixture warning for `workflow-import-oversize-payload.json`.
- Tests cover cancellation of still-open bodies on server/callback errors, preservation of the original failure if cancellation rejects, valid incremental operations across UTF-8 byte boundaries, malformed input, existing workflow data, and unchanged EOF behavior.
- Latest `staging` checked at `812c691755427b5a55188b4f73748eca0ddbae1d`; the affected client source is unchanged from this PR's base.

These are local mocked-stream tests. Live model providers and staging/production deployment were not exercised. This is an AI-assisted contribution.

- [x] Targets `staging`
- [x] References accepted issue #2333
- [x] Type and formatting checks pass
- [x] No secrets, environment files, or credentials committed
