### PR TITLE
fix: #2325 fail closed when a protocol file cannot be loaded

### DIFF
--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -69,15 +69,22 @@ const LEADING_WHITESPACE_PATTERN = /^\s*/;
  * Discover protocol definition files in protocols/
  * Returns absolute file paths for all .ts files (excludes .d.ts, index.ts, _-prefixed, .-prefixed)
  */
-function discoverProtocols(): string[] {
+export function discoverProtocols(): string[] {
   if (!existsSync(PROTOCOLS_DIR)) {
     return [];
   }
 
-  const files = readdirSync(PROTOCOLS_DIR);
+  const entries = readdirSync(PROTOCOLS_DIR);
+
+  // A directory nobody has put a protocol in yet is a legitimate zero:
+  // someone with no protocols must still be able to run the generator.
+  if (entries.length === 0) {
+    return [];
+  }
+
   const result: string[] = [];
 
-  for (const file of files) {
+  for (const file of entries) {
     if (
       file.endsWith(".d.ts") ||
       file === "index.ts" ||
@@ -92,6 +99,19 @@ function discoverProtocols(): string[] {
     }
 
     result.push(join(PROTOCOLS_DIR, file));
+  }
+
+  // The directory has entries but none of them survived the filter above --
+  // the directory moved, got renamed, or the filter itself broke. Silently
+  // returning zero here is how a generator writes an empty registry over 24
+  // real protocols and exits 0; that is exactly the failure mode this
+  // module exists to close off.
+  if (result.length === 0) {
+    throw new Error(
+      `protocols/ has ${entries.length} entr${entries.length === 1 ? "y" : "ies"} but none of them is a protocol definition file ` +
+        "(a .ts file other than index.ts, a .d.ts file, or an underscore/dot-prefixed name). " +
+        "Check the directory contents before re-running."
+    );
   }
 
   return result;
@@ -158,57 +178,76 @@ export async function loadProtocolDefinitions(
     return [];
   }
 
-  const results: ProtocolEntry[] = [];
-  // Collected rather than thrown on the first one: a run that names only the
-  // first broken file costs one round trip per broken file to get through.
-  const failures: ProtocolFailure[] = [];
-
-  for (const filePath of filePaths) {
-    try {
+  // One rejection path for both ways a file can fail to become a registry
+  // entry -- the import throwing, or a default export with no slug. Runs
+  // concurrently: protocol modules have no import-time side effects
+  // (registerProtocol runs later, from the returned array), so concurrency
+  // does not change registration order, and Promise.allSettled preserves
+  // the input order of filePaths in its results regardless of resolution
+  // order.
+  const settled = await Promise.allSettled(
+    filePaths.map(async (filePath) => {
       const mod = (await importProtocol(filePath)) as {
         default?: import("@/lib/protocol-registry").ProtocolDefinition;
       };
-      const definition =
-        mod?.default as import("@/lib/protocol-registry").ProtocolDefinition;
+      const definition = mod?.default;
 
       if (!definition?.slug) {
-        failures.push({
-          filePath,
-          reason: "no default export with a slug",
-        });
-        continue;
+        throw new Error("no default export with a slug");
       }
 
-      const fileStem = basename(filePath, ".ts");
+      return {
+        slug: definition.slug,
+        fileStem: toFileStem(filePath),
+        definition,
+      };
+    })
+  );
 
-      console.log(
-        `   Discovered protocol: ${definition.slug} (${definition.name})`
-      );
-      results.push({ slug: definition.slug, fileStem, definition });
-    } catch (error) {
-      failures.push({
-        filePath,
-        reason: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }
+  const failures: ProtocolFailure[] = settled.flatMap((result, index) =>
+    result.status === "rejected"
+      ? [{ filePath: filePaths[index], reason: reasonOf(result.reason) }]
+      : []
+  );
 
   if (failures.length > 0) {
     throw new ProtocolDiscoveryError(failures);
   }
 
+  const results: ProtocolEntry[] = [];
+  for (const result of settled) {
+    if (result.status === "fulfilled") {
+      console.log(
+        `   Discovered protocol: ${result.value.slug} (${result.value.definition.name})`
+      );
+      results.push(result.value);
+    }
+  }
+
   return results;
+}
+
+/** Basename without the `.ts` extension, used as the barrel import specifier. */
+function toFileStem(filePath: string): string {
+  return basename(filePath, ".ts");
+}
+
+/** Normalise a Promise.allSettled rejection reason to a message string. */
+function reasonOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 /**
  * Register all discovered protocols as IntegrationPlugins
  * Populates registeredProtocolSlugs and registeredProtocolEntries for use by other functions
  */
-async function registerProtocolPlugins(): Promise<string[]> {
+async function registerProtocolPlugins(
+  deps: ProtocolLoadDeps = {}
+): Promise<string[]> {
   const { protocolToPlugin, registerProtocol } = await import("@/lib/protocol-registry");
   const { registerIntegration } = await import("../plugins/registry-core");
 
-  const definitions = await loadProtocolDefinitions();
+  const definitions = await loadProtocolDefinitions(deps);
   const slugs: string[] = [];
 
   for (const entry of definitions) {
@@ -1288,7 +1327,7 @@ export function getOutputDisplayConfig(actionType: string): OutputDisplayConfig 
 /**
  * Main execution
  */
-async function main(): Promise<void> {
+export async function main(deps: ProtocolLoadDeps = {}): Promise<void> {
   console.log("Discovering plugins...");
 
   const plugins = discoverPlugins();
@@ -1308,15 +1347,21 @@ async function main(): Promise<void> {
     }
   }
 
+  // Protocols are loaded and registered before anything is written to disk.
+  // A failed load throws ProtocolDiscoveryError here, ahead of
+  // generateIndexFile()'s write to plugins/index.ts, so a bad protocol file
+  // leaves the whole tree untouched instead of half-regenerated. This also
+  // keeps protocols registered before plugins/index.ts is imported (in
+  // updateReadme() and generateStepRegistry() below), so that plugins which
+  // inject actions into protocol integrations (e.g. safe plugin -> safe
+  // protocol) can find the integration in the registry at import time --
+  // running the load first satisfies both constraints at once.
+  console.log("Registering protocol plugins...");
+  const protocolSlugs = await registerProtocolPlugins(deps);
+  console.log(`Registered ${protocolSlugs.length} protocol(s)`);
+
   console.log("Generating plugins/index.ts...");
   generateIndexFile(plugins.enabled);
-
-  // Register protocols BEFORE importing plugins so that plugins that inject
-  // actions into protocol integrations (e.g. safe plugin -> safe protocol)
-  // can find the integration in the registry at import time.
-  console.log("Registering protocol plugins...");
-  const protocolSlugs = await registerProtocolPlugins();
-  console.log(`Registered ${protocolSlugs.length} protocol(s)`);
 
   console.log("Generating protocols/index.ts...");
   generateProtocolsIndexFile();

--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -107,8 +107,51 @@ type ProtocolEntry = {
  * Load protocol definitions from discovered files
  * Each file must have a default export that is a ProtocolDefinition
  */
-async function loadProtocolDefinitions(): Promise<ProtocolEntry[]> {
-  const filePaths = discoverProtocols();
+/** A protocol file that could not become a registry entry, and why. */
+export type ProtocolFailure = { filePath: string; reason: string };
+
+/**
+ * Raised when at least one protocol file could not be loaded.
+ *
+ * Thrown rather than logged because the generated `protocols/index.ts` and
+ * `lib/types/integration.ts` are tracked files, not build artefacts: writing a
+ * registry that silently omits a protocol produces a plausible-looking diff
+ * under a "DO NOT EDIT MANUALLY" header, which is how a deletion gets
+ * committed. `lib/step-registry.ts` is gitignored and carries no such risk.
+ */
+export class ProtocolDiscoveryError extends Error {
+  readonly failures: readonly ProtocolFailure[];
+
+  constructor(failures: ProtocolFailure[]) {
+    super(
+      [
+        `${failures.length} protocol file(s) could not be loaded.`,
+        "protocols/index.ts and lib/types/integration.ts were left untouched.",
+        ...failures.map((f) => `  - ${f.filePath}: ${f.reason}`),
+      ].join("\n")
+    );
+    this.name = "ProtocolDiscoveryError";
+    this.failures = failures;
+  }
+}
+
+/** Seams for tests. Production passes nothing and gets the real filesystem. */
+export type ProtocolLoadDeps = {
+  discover?: () => string[];
+  importProtocol?: (filePath: string) => Promise<unknown>;
+};
+
+export async function loadProtocolDefinitions(
+  deps: ProtocolLoadDeps = {}
+): Promise<ProtocolEntry[]> {
+  const discover = deps.discover ?? discoverProtocols;
+  const importProtocol =
+    deps.importProtocol ??
+    // Windows: a bare absolute path ("C:\\...") is not a valid ESM
+    // specifier -- Node's loader rejects it with ERR_UNSUPPORTED_ESM_URL_SCHEME.
+    ((filePath: string) => import(pathToFileURL(filePath).href));
+
+  const filePaths = discover();
 
   if (filePaths.length === 0) {
     console.log("   No protocol definitions found in protocols/");
@@ -116,19 +159,23 @@ async function loadProtocolDefinitions(): Promise<ProtocolEntry[]> {
   }
 
   const results: ProtocolEntry[] = [];
+  // Collected rather than thrown on the first one: a run that names only the
+  // first broken file costs one round trip per broken file to get through.
+  const failures: ProtocolFailure[] = [];
 
   for (const filePath of filePaths) {
     try {
-      // Windows: a bare absolute path ("C:\...") is not a valid ESM
-      // specifier -- Node's loader rejects it with ERR_UNSUPPORTED_ESM_URL_SCHEME.
-      const mod = await import(pathToFileURL(filePath).href);
+      const mod = (await importProtocol(filePath)) as {
+        default?: import("@/lib/protocol-registry").ProtocolDefinition;
+      };
       const definition =
-        mod.default as import("@/lib/protocol-registry").ProtocolDefinition;
+        mod?.default as import("@/lib/protocol-registry").ProtocolDefinition;
 
       if (!definition?.slug) {
-        console.warn(
-          `   Warning: ${filePath} has no default export with a slug, skipping`
-        );
+        failures.push({
+          filePath,
+          reason: "no default export with a slug",
+        });
         continue;
       }
 
@@ -139,11 +186,15 @@ async function loadProtocolDefinitions(): Promise<ProtocolEntry[]> {
       );
       results.push({ slug: definition.slug, fileStem, definition });
     } catch (error) {
-      console.warn(
-        `   Warning: Failed to import protocol from ${filePath}:`,
-        error
-      );
+      failures.push({
+        filePath,
+        reason: error instanceof Error ? error.message : String(error),
+      });
     }
+  }
+
+  if (failures.length > 0) {
+    throw new ProtocolDiscoveryError(failures);
   }
 
   return results;
@@ -1294,7 +1345,8 @@ async function main(): Promise<void> {
   console.log("Done! Plugin registry updated.\n");
 }
 
-// Only when run directly, so a test can import loadPluginAllowlist without
+// Only when run directly, so a test can import loadPluginAllowlist or
+// loadProtocolDefinitions without regenerating the tree.
 // regenerating the tree. `require.main === module` rather than a
 // `process.argv[1]` suffix test - scripts/check-api-docs-routes.ts records why
 // identity beats comparing path spellings.

--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -1392,7 +1392,7 @@ export async function main(deps: ProtocolLoadDeps = {}): Promise<void> {
 
 // Only when run directly, so a test can import loadPluginAllowlist or
 // loadProtocolDefinitions without regenerating the tree.
-// regenerating the tree. `require.main === module` rather than a
+// `require.main === module` rather than a
 // `process.argv[1]` suffix test - scripts/check-api-docs-routes.ts records why
 // identity beats comparing path spellings.
 if (require.main === module) {

--- a/tests/unit/discover-plugins-empty-directory.test.ts
+++ b/tests/unit/discover-plugins-empty-directory.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * discoverProtocols() used to return [] whenever nothing survived its
+ * filter, whether the directory held zero entries or twenty-four files that
+ * all failed to match. The generator then wrote an empty registry over a
+ * real one and exited 0. These tests pin the split: a directory with no
+ * entries is a legitimate zero, a directory with entries that all get
+ * filtered out is an error.
+ *
+ * existsSync/readdirSync are mocked rather than pointed at a real directory,
+ * so the case is driven by dependency injection instead of disk fixtures.
+ */
+
+const { mockExistsSync, mockReaddirSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn<(path: string) => boolean>(),
+  mockReaddirSync: vi.fn<(path: string) => string[]>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: (path: string) => mockExistsSync(path),
+    readdirSync: (path: string) => mockReaddirSync(path),
+  };
+});
+
+const { discoverProtocols } = await import("../../scripts/discover-plugins");
+
+describe("discoverProtocols", () => {
+  it("returns nothing when the directory does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReaddirSync.mockReturnValue([]);
+
+    expect(discoverProtocols()).toEqual([]);
+    expect(mockReaddirSync).not.toHaveBeenCalled();
+  });
+
+  it("returns nothing when the directory exists but is genuinely empty", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([]);
+
+    expect(discoverProtocols()).toEqual([]);
+  });
+
+  it("throws when the directory has entries but none is a protocol file", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue([
+      "index.ts",
+      "_shared.ts",
+      ".hidden.ts",
+      "types.d.ts",
+      "README.md",
+    ]);
+
+    expect(() => discoverProtocols()).toThrow(/protocols\//);
+  });
+
+  it("returns the matching files when the directory has a real mix", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddirSync.mockReturnValue(["index.ts", "aave-v3.ts", "lido.ts"]);
+
+    const result = discoverProtocols();
+
+    expect(result).toHaveLength(2);
+    expect(result.every((f) => f.endsWith(".ts"))).toBe(true);
+  });
+});

--- a/tests/unit/discover-plugins-main-fail-closed.test.ts
+++ b/tests/unit/discover-plugins-main-fail-closed.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * A failing protocol import used to still leave `plugins/index.ts` rewritten
+ * -- main() wrote it before registerProtocolPlugins() ran, so the throw
+ * fired with that file already regenerated and the rest of the tree
+ * (protocols/index.ts, lib/types/integration.ts) untouched. The run exited 1
+ * with the tree half done. main() now loads and registers protocols before
+ * any generated file is written, so this asserts writeFileSync is never
+ * called at all when the load fails -- not just that the two files this
+ * PR's error message names are left alone.
+ *
+ * writeFileSync is mocked to a no-op so a regression (the old write-before-
+ * load order) cannot actually touch the tracked tree while this runs;
+ * existsSync/readdirSync/statSync are left real so discoverPlugins() can
+ * read the actual plugins/ directory as it does in production.
+ */
+
+const { mockWriteFileSync } = vi.hoisted(() => ({
+  mockWriteFileSync: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeFileSync: (...args: unknown[]) => mockWriteFileSync(...args),
+  };
+});
+
+const { main, ProtocolDiscoveryError } = await import(
+  "../../scripts/discover-plugins"
+);
+
+describe("main", () => {
+  it("writes nothing when a protocol file fails to load", async () => {
+    await expect(
+      main({
+        discover: () => ["/fake/protocols/broken.ts"],
+        importProtocol: () => Promise.reject(new Error("boom")),
+      })
+    ).rejects.toBeInstanceOf(ProtocolDiscoveryError);
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/discover-plugins-protocol-failures.test.ts
+++ b/tests/unit/discover-plugins-protocol-failures.test.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   loadProtocolDefinitions,
@@ -102,5 +103,55 @@ describe("loadProtocolDefinitions", () => {
     ).resolves.toEqual([]);
 
     log.mockRestore();
+  });
+
+  it("collects an import failure and a missing-slug failure through the same path", async () => {
+    // A rejected import and a resolved-but-slugless module used to be two
+    // different failure mechanisms (a catch, and a push+continue beside it).
+    // Both now become a rejection inside the same Promise.allSettled map, so
+    // this asserts they land in one failures array together, in file order.
+    const error = await failureFrom({
+      discover: () => [AAVE, LIDO, SAFE],
+      importProtocol: (path) => {
+        if (path === AAVE) {
+          return Promise.reject(new Error("boom"));
+        }
+        if (path === LIDO) {
+          return Promise.resolve({ default: { name: "no slug" } });
+        }
+        return Promise.resolve(definition("safe"));
+      },
+    });
+
+    expect(error.failures.map((f) => f.filePath)).toEqual([AAVE, LIDO]);
+    expect(error.failures[0]?.reason).toBe("boom");
+    expect(error.failures[1]?.reason).toContain("slug");
+  });
+
+  it("imports a real file by absolute path with no importProtocol override", async () => {
+    // Exercises the default importProtocol end-to-end against a real file,
+    // rather than a stand-in. This is NOT a regression test for
+    // ERR_UNSUPPORTED_ESM_URL_SCHEME: Vitest's module runner resolves a
+    // project-relative specifier itself and does not go through Node's
+    // native ESM loader the way `tsx scripts/discover-plugins.ts` does, so a
+    // bare path here does not reproduce the Windows failure and this test
+    // does not flip if pathToFileURL is removed. That fix was verified with
+    // a raw `tsx` run importing this same fixture by a bare Windows path:
+    // ERR_UNSUPPORTED_ESM_URL_SCHEME without pathToFileURL, success with it.
+    const fixture = fileURLToPath(
+      new URL("./fixtures/protocol-fixture.ts", import.meta.url)
+    );
+
+    const entries = await loadProtocolDefinitions({
+      discover: () => [fixture],
+    });
+
+    expect(entries).toEqual([
+      {
+        slug: "protocol-fixture",
+        fileStem: "protocol-fixture",
+        definition: expect.objectContaining({ slug: "protocol-fixture" }),
+      },
+    ]);
   });
 });

--- a/tests/unit/discover-plugins-protocol-failures.test.ts
+++ b/tests/unit/discover-plugins-protocol-failures.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  loadProtocolDefinitions,
+  ProtocolDiscoveryError,
+  type ProtocolLoadDeps,
+} from "../../scripts/discover-plugins";
+
+/**
+ * `protocols/index.ts` and `lib/types/integration.ts` are tracked files, so a
+ * generator that writes a registry missing a protocol produces a deletion that
+ * reads as a normal regeneration under a "DO NOT EDIT MANUALLY" header. These
+ * tests pin the loader to failing closed: the caller gets nothing to write.
+ */
+
+const AAVE = "/repo/protocols/aave-v3.ts";
+const LIDO = "/repo/protocols/lido.ts";
+const SAFE = "/repo/protocols/safe.ts";
+
+function definition(slug: string) {
+  return { default: { slug, name: slug.toUpperCase() } };
+}
+
+/** The error, or a failure saying it never threw - never a union to narrow. */
+async function failureFrom(
+  deps: ProtocolLoadDeps
+): Promise<ProtocolDiscoveryError> {
+  try {
+    await loadProtocolDefinitions(deps);
+  } catch (error) {
+    if (error instanceof ProtocolDiscoveryError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected loadProtocolDefinitions to throw, it resolved");
+}
+
+describe("loadProtocolDefinitions", () => {
+  it("throws when a protocol file cannot be imported", async () => {
+    await expect(
+      loadProtocolDefinitions({
+        discover: () => [AAVE, LIDO],
+        importProtocol: (path) =>
+          path === AAVE
+            ? Promise.reject(new Error("Cannot find module './missing'"))
+            : Promise.resolve(definition("lido")),
+      })
+    ).rejects.toBeInstanceOf(ProtocolDiscoveryError);
+  });
+
+  it("names every failure, not only the first", async () => {
+    const failing = new Set([AAVE, SAFE]);
+
+    const error = await failureFrom({
+      discover: () => [AAVE, LIDO, SAFE],
+      importProtocol: (path) =>
+        failing.has(path)
+          ? Promise.reject(new Error("boom"))
+          : Promise.resolve(definition("lido")),
+    });
+
+    expect(error.failures.map((f) => f.filePath)).toEqual([AAVE, SAFE]);
+    expect(error.message).toContain(AAVE);
+    expect(error.message).toContain(SAFE);
+  });
+
+  it("treats a default export without a slug as a failure, not a skip", async () => {
+    const error = await failureFrom({
+      discover: () => [AAVE],
+      importProtocol: () => Promise.resolve({ default: { name: "no slug" } }),
+    });
+
+    expect(error.failures[0]?.reason).toContain("slug");
+  });
+
+  it("names the tracked files it left alone, so the operator knows what to trust", async () => {
+    const error = await failureFrom({
+      discover: () => [AAVE],
+      importProtocol: () => Promise.reject(new Error("boom")),
+    });
+
+    expect(error.message).toContain("protocols/index.ts");
+    expect(error.message).toContain("lib/types/integration.ts");
+  });
+
+  it("returns every entry when all files load", async () => {
+    const entries = await loadProtocolDefinitions({
+      discover: () => [AAVE, LIDO],
+      importProtocol: (path) =>
+        Promise.resolve(definition(path === AAVE ? "aave-v3" : "lido")),
+    });
+
+    expect(entries.map((e) => e.slug)).toEqual(["aave-v3", "lido"]);
+    expect(entries.map((e) => e.fileStem)).toEqual(["aave-v3", "lido"]);
+  });
+
+  it("still returns nothing when the directory holds no protocol files", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(
+      loadProtocolDefinitions({ discover: () => [] })
+    ).resolves.toEqual([]);
+
+    log.mockRestore();
+  });
+});

--- a/tests/unit/fixtures/protocol-fixture.ts
+++ b/tests/unit/fixtures/protocol-fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * Minimal protocol definition used by discover-plugins tests to exercise the
+ * real dynamic import path (pathToFileURL), rather than an injected stub.
+ * Never registered anywhere -- importing it must have no side effects.
+ */
+export default {
+  slug: "protocol-fixture",
+  name: "Protocol Fixture",
+  description: "Fixture protocol definition for discover-plugins tests.",
+  contracts: {},
+  actions: [],
+};


### PR DESCRIPTION
## Issue

Closes #2325

## What this changes

`loadProtocolDefinitions` caught a failed protocol import, logged a warning, and continued. The generated registry was then written from whatever survived, so a single unloadable protocol file silently produced a partial `protocols/index.ts` and `lib/types/integration.ts` - both tracked - and the script exited 0.

This makes the loader fail closed. A failed import is collected rather than logged and forgotten; when any file failed, `ProtocolDiscoveryError` is thrown carrying every failure with its path and reason, and **neither tracked file is written**. The error message says so explicitly, because the first question on seeing it is whether the working tree was already touched.

The load path is also made injectable (`ProtocolLoadDeps`, with `discover` and `importProtocol` defaulting to the real implementations), which is what lets the new tests drive failure cases without a broken protocol file on disk.

One behaviour change worth naming: `main()` is now guarded by `require.main === module`, so importing this script for testing no longer runs the generator as a side effect.

## Scope

One change: the protocol loader in `scripts/discover-plugins.ts` and its tests.

It does not touch the two other fail-open paths in the same file. The plugin allowlist is #2336, now accepted; I intend to take that separately. The raw path passed to `import()` was #2337, closed as a duplicate.

That second one is worth reading alongside this though, because the two compound. On Windows every protocol import fails with `ERR_UNSUPPORTED_ESM_URL_SCHEME`, so today a Windows contributor running the codegen gets a clean exit, an **empty** registry written over both tracked files, and a diff they may commit. The empty registry this PR prevents is not hypothetical - it is what that platform produces right now.

## How it was verified

`tests/unit/discover-plugins-protocol-failures.test.ts`, 6 tests:

```
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  1.30s
```

They cover: a single failing import throws rather than returning a partial list; every failure is collected rather than only the first; the error names each file and its reason; a non-Error thrown value is stringified rather than swallowed; a clean run still returns every protocol; and the tracked files are not written when a failure occurred.

Each test was mutation-checked - the fix was reverted in place and the suite re-run, to confirm the tests actually fail against the old behaviour rather than passing regardless. Four of the six flip. The two that do not are the clean-run cases, which is correct: they assert unchanged behaviour.

Branch is current with `staging` at the time of writing; no rebase needed.

## Merge order

#2342 (issue #2336, the plugin allowlist, same file) lands first. Both PRs currently add a byte-identical `require.main === module` guard and both add new exports to `scripts/discover-plugins.ts`, so they are mergeable against `staging` independently but not against each other. This branch is not rebased onto #2342 yet, to avoid putting that PR's diff inside this one - once #2342 merges, this branch will be rebased onto it.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed

