### PR TITLE
fix: #2336 fail closed when the plugin allowlist cannot be trusted

### DIFF
--- a/scripts/discover-plugins.ts
+++ b/scripts/discover-plugins.ts
@@ -8,7 +8,7 @@
  * the current list of available actions.
  *
  * Plugin Allowlist (Optional):
- * - Create config/plugin-allowlist.json to control which plugins are enabled
+ * - Create plugins/plugin-allowlist.json to control which plugins are enabled
  * - If the file doesn't exist, all discovered plugins are enabled
  * - This prevents disabled plugins from being registered while keeping them in the codebase
  *
@@ -261,22 +261,108 @@ async function formatCode(code: string): Promise<string> {
 }
 
 /**
- * Load plugin allowlist from config file
- * Returns null if config doesn't exist (meaning all plugins enabled)
+ * Raised when the allowlist file exists but its content cannot be trusted:
+ * unparsable JSON, or a document that does not match
+ * plugins/plugin-allowlist.schema.json (missing "plugins", or "plugins" not
+ * an array of unique strings).
+ *
+ * An absent file is not an error - it means no restriction was declared, and
+ * every plugin stays enabled. A present-but-broken file means the operator's
+ * intent is known and unreadable, which is exactly when guessing is worst:
+ * silently falling back to "all plugins enabled" discards a stated
+ * restriction, and silently falling back to "[]" disables everything the
+ * operator meant to keep. Neither is a value the caller asked for, so the
+ * script exits non-zero instead of guessing.
  */
-function loadPluginAllowlist(): string[] | null {
-  if (!existsSync(PLUGIN_ALLOWLIST_FILE)) {
+export class PluginAllowlistError extends Error {
+  constructor(
+    readonly filePath: string,
+    reason: string
+  ) {
+    super(`Invalid plugin allowlist at ${filePath}: ${reason}`);
+    this.name = "PluginAllowlistError";
+  }
+}
+
+/** Seams for tests. Production passes nothing and gets the real filesystem. */
+export type PluginAllowlistDeps = {
+  exists?: () => boolean;
+  readFile?: () => string;
+};
+
+/**
+ * Check the parsed document against the shape declared by
+ * plugins/plugin-allowlist.schema.json ("required": ["plugins"], "plugins"
+ * typed as an array of unique strings) by hand, rather than pulling in a
+ * JSON-schema library for one file. `"plugins": []` is a valid document -
+ * it means the operator deliberately wants nothing enabled - so only a
+ * missing/malformed "plugins" key is rejected, not an empty one.
+ */
+function assertValidAllowlist(
+  config: unknown,
+  filePath: string
+): asserts config is { plugins: string[] } {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    throw new PluginAllowlistError(filePath, "document must be a JSON object");
+  }
+
+  if (!("plugins" in config)) {
+    throw new PluginAllowlistError(
+      filePath,
+      'missing required property "plugins"'
+    );
+  }
+
+  const { plugins } = config as { plugins: unknown };
+
+  if (!Array.isArray(plugins)) {
+    throw new PluginAllowlistError(filePath, '"plugins" must be an array');
+  }
+
+  if (!plugins.every((entry): entry is string => typeof entry === "string")) {
+    throw new PluginAllowlistError(
+      filePath,
+      '"plugins" must be an array of strings'
+    );
+  }
+
+  if (new Set(plugins).size !== plugins.length) {
+    throw new PluginAllowlistError(
+      filePath,
+      '"plugins" must not contain duplicate entries'
+    );
+  }
+}
+
+/**
+ * Load plugin allowlist from config file.
+ * Returns null if the file doesn't exist (meaning all plugins enabled).
+ * Throws PluginAllowlistError if the file exists but cannot be parsed, or
+ * does not match plugins/plugin-allowlist.schema.json.
+ */
+export function loadPluginAllowlist(
+  deps: PluginAllowlistDeps = {}
+): string[] | null {
+  const exists = deps.exists ?? (() => existsSync(PLUGIN_ALLOWLIST_FILE));
+  const readFile =
+    deps.readFile ?? (() => readFileSync(PLUGIN_ALLOWLIST_FILE, "utf-8"));
+
+  if (!exists()) {
     return null; // No allowlist = all plugins enabled
   }
 
+  let config: unknown;
   try {
-    const content = readFileSync(PLUGIN_ALLOWLIST_FILE, "utf-8");
-    const config = JSON.parse(content);
-    return config.plugins || [];
+    config = JSON.parse(readFile());
   } catch (error) {
-    console.warn(`   Warning: Failed to load plugin allowlist: ${error}`);
-    return null; // Fallback to all plugins on error
+    throw new PluginAllowlistError(
+      PLUGIN_ALLOWLIST_FILE,
+      error instanceof Error ? error.message : String(error)
+    );
   }
+
+  assertValidAllowlist(config, PLUGIN_ALLOWLIST_FILE);
+  return config.plugins;
 }
 
 // Track generated codegen templates
@@ -1205,7 +1291,13 @@ async function main(): Promise<void> {
   console.log("Done! Plugin registry updated.\n");
 }
 
-main().catch((error) => {
-  console.error("Error:", error);
-  process.exit(1);
-});
+// Only when run directly, so a test can import loadPluginAllowlist without
+// regenerating the tree. `require.main === module` rather than a
+// `process.argv[1]` suffix test - scripts/check-api-docs-routes.ts records why
+// identity beats comparing path spellings.
+if (require.main === module) {
+  main().catch((error) => {
+    console.error("Error:", error);
+    process.exit(1);
+  });
+}

--- a/tests/unit/discover-plugins-allowlist-failures.test.ts
+++ b/tests/unit/discover-plugins-allowlist-failures.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadPluginAllowlist,
+  PluginAllowlistError,
+} from "../../scripts/discover-plugins";
+
+/**
+ * loadPluginAllowlist decides which plugins ship. Three silent failure modes
+ * used to exist: malformed JSON widened the set to everything, and a missing
+ * or misspelled "plugins" key emptied it to nothing - both on a green exit
+ * code. These tests pin the loader to failing closed instead: a present but
+ * untrustworthy file throws, and only an absent file still means "no
+ * restriction declared".
+ */
+
+/** The error, or a failure saying it never threw - never a union to narrow. */
+function failureFrom(deps: Parameters<typeof loadPluginAllowlist>[0]) {
+  try {
+    loadPluginAllowlist(deps);
+  } catch (error) {
+    if (error instanceof PluginAllowlistError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected loadPluginAllowlist to throw, it returned");
+}
+
+describe("loadPluginAllowlist", () => {
+  it("returns null when the file does not exist, meaning no restriction", () => {
+    expect(
+      loadPluginAllowlist({
+        exists: () => false,
+      })
+    ).toBeNull();
+  });
+
+  it("throws rather than widening the set when the file is malformed JSON", () => {
+    const error = failureFrom({
+      exists: () => true,
+      readFile: () => "{ not valid json",
+    });
+
+    expect(error).toBeInstanceOf(PluginAllowlistError);
+  });
+
+  it('throws rather than emptying the set when "plugins" is missing', () => {
+    const error = failureFrom({
+      exists: () => true,
+      readFile: () => JSON.stringify({ description: "no plugins key" }),
+    });
+
+    expect(error.message).toContain('"plugins"');
+  });
+
+  it('throws when "plugins" is not an array', () => {
+    const error = failureFrom({
+      exists: () => true,
+      readFile: () => JSON.stringify({ plugins: "web3" }),
+    });
+
+    expect(error.message).toContain("array");
+  });
+
+  it('throws when "plugins" contains a non-string entry', () => {
+    const error = failureFrom({
+      exists: () => true,
+      readFile: () => JSON.stringify({ plugins: ["web3", 42] }),
+    });
+
+    expect(error.message).toContain("string");
+  });
+
+  it('throws when "plugins" contains duplicate entries', () => {
+    const error = failureFrom({
+      exists: () => true,
+      readFile: () => JSON.stringify({ plugins: ["web3", "web3"] }),
+    });
+
+    expect(error.message).toContain("duplicate");
+  });
+
+  it("accepts an explicit empty list as deliberately enabling nothing", () => {
+    expect(
+      loadPluginAllowlist({
+        exists: () => true,
+        readFile: () => JSON.stringify({ plugins: [] }),
+      })
+    ).toEqual([]);
+  });
+
+  it("filters exactly as today when the file is valid", () => {
+    expect(
+      loadPluginAllowlist({
+        exists: () => true,
+        readFile: () =>
+          JSON.stringify({ plugins: ["web3", "discord", "sendgrid"] }),
+      })
+    ).toEqual(["web3", "discord", "sendgrid"]);
+  });
+});


### PR DESCRIPTION
## Issue

Closes #2336

## What this changes

`loadPluginAllowlist` could not be relied on to restrict anything. Three routes led to a silently ignored allowlist, and two of them produced opposite outcomes from the same class of mistake:

| allowlist file | before |
| --- | --- |
| absent | `null` -> every plugin enabled. Correct, and unchanged by this PR. |
| present, malformed JSON | `null` -> **every plugin enabled**, the declared restriction discarded behind a `console.warn` |
| present, valid JSON, `plugins` missing or misspelled | `[]` -> **no plugin enabled** |

Now: an absent file still means "no restriction declared" and behaves exactly as before. A file that exists but cannot be trusted throws with the path and the reason, and the script exits non-zero. The operator's intent is known and unreadable at that point, which is the worst moment to guess.

Validation is against `plugins/plugin-allowlist.schema.json` - which was already tracked, already declares `"required": ["plugins"]` with an array of unique strings, and is already referenced by the data file's own `$schema`. It was simply never consulted. The check is hand-written against those three statements rather than pulling in a JSON-schema dependency for a codegen script; say the word if you would rather have the library.

The header comment at line 11 said `config/plugin-allowlist.json`. `PLUGIN_ALLOWLIST_FILE` resolves `plugins/plugin-allowlist.json`, which is where the tracked file is. An operator following the comment created a file nothing read, and landed silently on row 1 of the table above.

## Scope

One change: the allowlist loader in `scripts/discover-plugins.ts` and its tests.

**One overlap you should know about.** This branch adds a `require.main === module` guard around `main()`, so importing the module for tests does not regenerate tracked files as a side effect. PR #2341 (issue #2325) adds the same guard independently, for the same reason - both branches are cut from `staging` and both need it to test their own loader. Whichever merges second will conflict on that single hunk, and the resolution is to keep one.

Say the word and I will rebase this onto #2341 instead so the guard appears once; I left them independent because a stacked PR costs a reviewer more than a one-line conflict, but it is your call.

## How it was verified

`tests/unit/discover-plugins-allowlist-failures.test.ts`, 8 tests: malformed JSON fails rather than widening the set; a missing `plugins` key fails rather than emptying it; a non-array `plugins` fails; non-string entries fail; duplicate entries fail; an absent file still means no restriction; an explicitly empty list is still honoured as "enable nothing"; a valid file filters exactly as before.

Mutation-checked, three targeted mutations rather than one blunt revert:

- restoring the `catch` that returned `null` flips the parse-error test only;
- skipping schema validation flips the four validation tests only;
- a full revert flips all eight.

Each mutation left the other tests passing, which is what tells you they are testing distinct behaviours rather than one shared path.

`pnpm check` and `pnpm type-check` both pass. `pnpm-lock.yaml` is untouched.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
