### PR TITLE
fix(execute): refuse a caller-supplied executionId naming another workflow's row

### DIFF
--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -4,7 +4,11 @@ import { NextResponse } from "next/server";
 import { logAnonymousExecutionBlock } from "@/lib/auth-anonymous-guard";
 import { enforceExecutionLimit } from "@/lib/billing/execution-guard";
 import { chargePaygIfBillable } from "@/lib/billing/payg/charge";
-import { ErrorCategory, logSystemError } from "@/lib/logging";
+import {
+  ErrorCategory,
+  logSecurityEvent,
+  logSystemError,
+} from "@/lib/logging";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 import { getMetricsCollector } from "@/lib/metrics";
 import { LabelKeys, MetricNames } from "@/lib/metrics/types";
@@ -251,6 +255,30 @@ export async function POST(
     // and this one never double-count.
     let createdHere = false;
 
+    // The field exists so the scheduler and queue executor can pre-create the
+    // row and hand its id back. Nothing else has a reason to name a row that
+    // this request did not create, and the workflow access check above
+    // authorises the workflow, not the row, so a caller-supplied id from any
+    // other principal is refused outright.
+    if (executionId && !isInternalExecution) {
+      logSecurityEvent("execution_id_supplied_by_external_caller", {
+        workflowId,
+        organizationId: workflow.organizationId,
+        userId,
+      });
+      return recordIdempotentResponse(
+        idem,
+        NextResponse.json(
+          {
+            error: "executionId is reserved for internal dispatch",
+            code: "execution_id_not_allowed",
+          },
+          { status: HttpStatus.BAD_REQUEST }
+        ),
+        "release"
+      );
+    }
+
     if (executionId) {
       // Scheduler may pre-create a pending row and hand the id back here.
       // Refuse terminal / in-flight reuse before PAYG so a retry cannot
@@ -258,6 +286,36 @@ export async function POST(
       const existingExecution = await db.query.workflowExecutions.findFirst({
         where: eq(workflowExecutions.id, executionId),
       });
+
+      // The lookup is by primary key alone, so the row it returns is not
+      // necessarily this workflow's. Adopting a foreign row would write this
+      // run's status, logs and output over it, and falling through to the
+      // insert below would collide on the primary key. Refuse instead.
+      // organizationId is null on rows written before the column existed, so
+      // it is compared only when set; workflowId carries the tenancy.
+      if (
+        existingExecution &&
+        (existingExecution.workflowId !== workflowId ||
+          (existingExecution.organizationId !== null &&
+            existingExecution.organizationId !== workflow.organizationId))
+      ) {
+        logSecurityEvent("execution_id_workflow_mismatch", {
+          workflowId,
+          organizationId: workflow.organizationId,
+          rowWorkflowId: existingExecution.workflowId,
+        });
+        return recordIdempotentResponse(
+          idem,
+          NextResponse.json(
+            {
+              error: "executionId does not belong to this workflow",
+              code: "execution_id_mismatch",
+            },
+            { status: HttpStatus.CONFLICT }
+          ),
+          "release"
+        );
+      }
 
       if (existingExecution) {
         const existingStatus = existingExecution.status;

--- a/tests/unit/workflow-execute-redispatch.test.ts
+++ b/tests/unit/workflow-execute-redispatch.test.ts
@@ -20,6 +20,8 @@ const {
   mockChargePaygIfBillable,
   mockExecuteWorkflowInBackground,
   mockResolveExecutionOrgMetadata,
+  mockGetDualAuthContext,
+  mockGetWorkflowAccess,
 } = vi.hoisted(() => ({
   mockAuthenticateInternalService: vi.fn(),
   mockLoadWorkflowForExecution: vi.fn(),
@@ -34,6 +36,8 @@ const {
   mockChargePaygIfBillable: vi.fn(),
   mockExecuteWorkflowInBackground: vi.fn(),
   mockResolveExecutionOrgMetadata: vi.fn(),
+  mockGetDualAuthContext: vi.fn(),
+  mockGetWorkflowAccess: vi.fn(),
 }));
 
 vi.mock("@/lib/internal-service-auth", () => ({
@@ -125,14 +129,15 @@ vi.mock("@/lib/metrics/types", () => ({
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { WORKFLOW_ENGINE: "workflow_engine" },
   logSystemError: vi.fn(),
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/middleware/auth-helpers", () => ({
-  getDualAuthContext: vi.fn(),
+  getDualAuthContext: mockGetDualAuthContext,
 }));
 
 vi.mock("@/lib/workflow/access", () => ({
-  getWorkflowAccess: vi.fn(),
+  getWorkflowAccess: mockGetWorkflowAccess,
 }));
 
 vi.mock("@/lib/auth-anonymous-guard", () => ({
@@ -228,6 +233,8 @@ describe("workflow execute redispatch guard", () => {
     mockFindExecution.mockResolvedValue({
       id: "exec_term",
       status: "success",
+      workflowId: "wf_1",
+      organizationId: "org_1",
     });
 
     const response = await callExecute({ executionId: "exec_term" });
@@ -272,7 +279,12 @@ describe("workflow execute redispatch guard", () => {
         async (_idem: unknown, response: Response): Promise<Response> =>
           response
       );
-      mockFindExecution.mockResolvedValue({ id: `exec_${status}`, status });
+      mockFindExecution.mockResolvedValue({
+        id: `exec_${status}`,
+        status,
+        workflowId: "wf_1",
+        organizationId: "org_1",
+      });
 
       const response = await callExecute({ executionId: `exec_${status}` });
       expect(response.status).toBe(409);
@@ -285,6 +297,8 @@ describe("workflow execute redispatch guard", () => {
     mockFindExecution.mockResolvedValue({
       id: "exec_run",
       status: "running",
+      workflowId: "wf_1",
+      organizationId: "org_1",
     });
 
     const response = await callExecute({ executionId: "exec_run" });
@@ -305,6 +319,8 @@ describe("workflow execute redispatch guard", () => {
     mockFindExecution.mockResolvedValue({
       id: "exec_pend",
       status: "pending",
+      workflowId: "wf_1",
+      organizationId: "org_1",
     });
 
     const response = await callExecute({ executionId: "exec_pend" });
@@ -342,6 +358,94 @@ describe("workflow execute redispatch guard", () => {
     expect(body.status).toBe("running");
     expect(mockFindExecution).not.toHaveBeenCalled();
     expect(mockChargePaygIfBillable).toHaveBeenCalled();
+    expect(mockExecuteWorkflowInBackground).toHaveBeenCalled();
+  });
+  it("refuses a caller-supplied executionId from an external caller", async () => {
+    mockAuthenticateInternalService.mockResolvedValue({ authenticated: false });
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "session",
+      isAnonymous: false,
+      scope: "mcp:write",
+    });
+    mockGetWorkflowAccess.mockResolvedValue({ hasFullAccess: true });
+
+    const response = await callExecute({ executionId: "exec_foreign" });
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.code).toBe("execution_id_not_allowed");
+    expect(mockFindExecution).not.toHaveBeenCalled();
+    expect(mockChargePaygIfBillable).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflowInBackground).not.toHaveBeenCalled();
+  });
+
+  it("still creates a row for an external caller that supplies no id", async () => {
+    mockAuthenticateInternalService.mockResolvedValue({ authenticated: false });
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user_1",
+      organizationId: "org_1",
+      authMethod: "session",
+      isAnonymous: false,
+      scope: "mcp:write",
+    });
+    mockGetWorkflowAccess.mockResolvedValue({ hasFullAccess: true });
+
+    const response = await callExecute({});
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.executionId).toBe("exec_new");
+    expect(mockExecuteWorkflowInBackground).toHaveBeenCalled();
+  });
+
+  it("refuses a pending row that belongs to another organization", async () => {
+    mockFindExecution.mockResolvedValue({
+      id: "exec_victim",
+      status: "pending",
+      workflowId: "wf_other",
+      organizationId: "org_2",
+    });
+
+    const response = await callExecute({ executionId: "exec_victim" });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe("execution_id_mismatch");
+    expect(mockChargePaygIfBillable).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflowInBackground).not.toHaveBeenCalled();
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("refuses a row of another workflow inside the same organization", async () => {
+    mockFindExecution.mockResolvedValue({
+      id: "exec_sibling",
+      status: "pending",
+      workflowId: "wf_2",
+      organizationId: "org_1",
+    });
+
+    const response = await callExecute({ executionId: "exec_sibling" });
+
+    expect(response.status).toBe(409);
+    expect(mockExecuteWorkflowInBackground).not.toHaveBeenCalled();
+    expect(mockInsertValues).not.toHaveBeenCalled();
+  });
+
+  it("adopts a legacy row with a null organizationId on the same workflow", async () => {
+    mockFindExecution.mockResolvedValue({
+      id: "exec_legacy",
+      status: "pending",
+      workflowId: "wf_1",
+      organizationId: null,
+    });
+
+    const response = await callExecute({ executionId: "exec_legacy" });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ executionId: "exec_legacy", status: "running" });
     expect(mockExecuteWorkflowInBackground).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

`app/api/workflow/[workflowId]/execute/route.ts` resolved the caller-supplied `executionId` by primary key alone:

```ts
where: eq(workflowExecutions.id, executionId)
```

`executionId` is a body field on a route any authenticated principal can reach. The access check above it authorises the *workflow*, not the execution row. The re-dispatch guard rejects `success` / `error` / `cancelled` and short-circuits `running`, so everything else falls through and is adopted: `pending`, `phantom`, `unconfirmed`, `skipped` and `system_error`.

Once adopted, the row is used for the rest of the request. The PAYG settlement update, the `pending -> running` flip, the progress initialisation, the `runId` stamp, the error finaliser and every node log are keyed on that id with no scoping, so the run's status, output and logs land on a row that still carries another organization's `organization_id` and another workflow's `workflow_id`. That org's execution counters absorb the run and their real execution is orphaned.

Foreign ids are reachable without guessing: the webhook route inserts a `pending` row for the workflow's org and returns its `executionId` to whoever holds the webhook URL, and under SQS dispatch the row stays `pending` for the queue latency, or forever if dispatch never lands. The same gap also allows a caller to corrupt a row of their own other workflow, since `workflowId` was not compared either.

## Change

- The field exists only so the scheduler and queue executor can pre-create the row and hand the id back, so it is now accepted from internal-service callers only. Any other caller supplying it gets a 400 and a security event; callers that supply no id are unaffected.
- An id whose row belongs to a different workflow or organization is refused with 409 `execution_id_mismatch` instead of being adopted. Refusing rather than only scoping the lookup also avoids the primary-key collision that a scoped miss would hit on the insert branch below.
- `organization_id` is null on rows written before that column existed, so it is compared only when set; `workflow_id` carries the tenancy.
- Both refusals release the idempotency key, matching the other pre-execution validation failures on this route.

No in-repo caller sends `executionId` to this route on the external path, and the field is not part of the public API docs. The internal dispatch handoff is unchanged.
