### PR TITLE
fix(safe): preserve pending transaction gas fields

### DIFF
--- a/docs/plugins/safe.md
+++ b/docs/plugins/safe.md
@@ -146,7 +146,7 @@ Fetch pending multisig transactions that have not been executed yet. Optionally 
 
 **Outputs:** `success`, `transactions` (array), `count`, `error`
 
-Each transaction includes: `safeTxHash`, `to`, `value`, `data`, `operation` (0=CALL, 1=DELEGATECALL), `operationLabel`, `nonce`, `confirmations`, `confirmationsRequired`, `confirmationsCollected`, `dataDecoded`, `submissionDate`, `safe`
+Each transaction includes: `safeTxHash`, `to`, `value`, `data`, `operation` (0=CALL, 1=DELEGATECALL), `operationLabel`, `nonce`, `confirmations`, `confirmationsRequired`, `confirmationsCollected`, `dataDecoded`, `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`, `submissionDate`, `safe`
 
 **When to use:** Monitor your Safe for new transactions awaiting your signature, verify transaction calldata before signing, detect suspicious proposals (DELEGATECALL, proxy upgrades, unknown targets).
 

--- a/docs/plugins/safe.md
+++ b/docs/plugins/safe.md
@@ -148,7 +148,9 @@ Fetch pending multisig transactions that have not been executed yet. Optionally 
 
 Each transaction includes: `safeTxHash`, `to`, `value`, `data`, `operation` (0=CALL, 1=DELEGATECALL), `operationLabel`, `nonce`, `confirmations`, `confirmationsRequired`, `confirmationsCollected`, `dataDecoded`, `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`, `submissionDate`, `safe`
 
-**When to use:** Monitor your Safe for new transactions awaiting your signature, verify transaction calldata before signing, detect suspicious proposals (DELEGATECALL, proxy upgrades, unknown targets).
+A non-zero `gasPrice` together with a `gasToken` and a `refundReceiver` makes `execTransaction` pay a refund out of the Safe and call the token contract to do it, so a hostile pair drains the Safe when the transaction is executed. The benign case is a zero `gasPrice` with the zero address for both `gasToken` and `refundReceiver`; check all three before signing.
+
+**When to use:** Monitor your Safe for new transactions awaiting your signature, verify transaction calldata before signing, detect suspicious proposals (DELEGATECALL, proxy upgrades, unknown targets, refund parameters that pay an attacker).
 
 ---
 

--- a/plugins/safe/index.ts
+++ b/plugins/safe/index.ts
@@ -20,7 +20,7 @@ const getPendingTransactionsAction = {
     {
       field: "transactions",
       description:
-        "Array of pending transactions with safeTxHash, to, value, data, operation, nonce, confirmations, confirmationsRequired, dataDecoded, and submissionDate",
+        "Array of pending transactions with safeTxHash, to, value, data, operation, operationLabel, nonce, confirmations, confirmationsRequired, confirmationsCollected, dataDecoded, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, submissionDate, and safe",
     },
     {
       field: "count",

--- a/plugins/safe/steps/get-pending-transactions.ts
+++ b/plugins/safe/steps/get-pending-transactions.ts
@@ -64,6 +64,11 @@ type PendingTransaction = {
   confirmationsRequired: number;
   confirmationsCollected: number;
   dataDecoded: unknown;
+  safeTxGas: number;
+  baseGas: number;
+  gasPrice: string;
+  gasToken: string;
+  refundReceiver: string;
   submissionDate: string;
   safe: string;
 };
@@ -270,6 +275,11 @@ async function stepHandler(
       confirmationsRequired: tx.confirmationsRequired,
       confirmationsCollected: tx.confirmations.length,
       dataDecoded: tx.dataDecoded,
+      safeTxGas: tx.safeTxGas,
+      baseGas: tx.baseGas,
+      gasPrice: tx.gasPrice,
+      gasToken: tx.gasToken,
+      refundReceiver: tx.refundReceiver,
       submissionDate: tx.submissionDate,
       safe: tx.safe,
     }));

--- a/tests/unit/safe-pending-transactions-projection.test.ts
+++ b/tests/unit/safe-pending-transactions-projection.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/safe-fetch", () => ({ safeFetch }));
 import { getPendingTransactionsStep } from "@/plugins/safe/steps/get-pending-transactions";
 
 const SAFE_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 function jsonResponse(body: unknown): Response {
   return {
@@ -33,6 +34,34 @@ function jsonResponse(body: unknown): Response {
     status: 200,
     json: async () => body,
   } as unknown as Response;
+}
+
+function pendingTransaction(
+  refundFields: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    safe: SAFE_ADDRESS,
+    to: "0x0000000000000000000000000000000000000001",
+    value: "42",
+    data: "0x1234",
+    operation: 0,
+    nonce: 7,
+    safeTxHash: `0x${"ab".repeat(32)}`,
+    submissionDate: "2026-09-07T19:00:00Z",
+    executionDate: null,
+    isExecuted: false,
+    confirmationsRequired: 2,
+    confirmations: [],
+    dataDecoded: null,
+    origin: null,
+    ...refundFields,
+  };
+}
+
+function mockQueue(transaction: Record<string, unknown>): void {
+  safeFetch
+    .mockResolvedValueOnce(jsonResponse({ nonce: 7 }))
+    .mockResolvedValueOnce(jsonResponse({ count: 1, results: [transaction] }));
 }
 
 describe("Safe pending transaction projection", () => {
@@ -43,36 +72,15 @@ describe("Safe pending transaction projection", () => {
   });
 
   it("preserves every execTransaction gas and refund field", async () => {
-    safeFetch
-      .mockResolvedValueOnce(jsonResponse({ nonce: 7 }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          count: 1,
-          results: [
-            {
-              safe: SAFE_ADDRESS,
-              to: "0x0000000000000000000000000000000000000001",
-              value: "42",
-              data: "0x1234",
-              operation: 0,
-              nonce: 7,
-              safeTxHash: `0x${"ab".repeat(32)}`,
-              submissionDate: "2026-09-07T19:00:00Z",
-              executionDate: null,
-              isExecuted: false,
-              confirmationsRequired: 2,
-              confirmations: [],
-              dataDecoded: null,
-              safeTxGas: 123,
-              baseGas: 456,
-              gasPrice: "789",
-              gasToken: "0x0000000000000000000000000000000000000002",
-              refundReceiver: "0x0000000000000000000000000000000000000003",
-              origin: null,
-            },
-          ],
-        })
-      );
+    mockQueue(
+      pendingTransaction({
+        safeTxGas: 123,
+        baseGas: 456,
+        gasPrice: "789",
+        gasToken: "0x0000000000000000000000000000000000000002",
+        refundReceiver: "0x0000000000000000000000000000000000000003",
+      })
+    );
 
     const result = await getPendingTransactionsStep({
       integrationId: "int-safe",
@@ -91,6 +99,37 @@ describe("Safe pending transaction projection", () => {
       gasPrice: "789",
       gasToken: "0x0000000000000000000000000000000000000002",
       refundReceiver: "0x0000000000000000000000000000000000000003",
+    });
+  });
+
+  it("reports a benign transaction's zeroed refund parameters as they arrive", async () => {
+    mockQueue(
+      pendingTransaction({
+        safeTxGas: 0,
+        baseGas: 0,
+        gasPrice: "0",
+        gasToken: ZERO_ADDRESS,
+        refundReceiver: ZERO_ADDRESS,
+      })
+    );
+
+    const result = await getPendingTransactionsStep({
+      integrationId: "int-safe",
+      safeAddress: SAFE_ADDRESS,
+      network: "ethereum",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0]).toMatchObject({
+      safeTxGas: 0,
+      baseGas: 0,
+      gasPrice: "0",
+      gasToken: ZERO_ADDRESS,
+      refundReceiver: ZERO_ADDRESS,
     });
   });
 });

--- a/tests/unit/safe-pending-transactions-projection.test.ts
+++ b/tests/unit/safe-pending-transactions-projection.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+vi.mock("@/lib/logging", () => ({
+  ErrorCategory: {
+    CONFIGURATION: "configuration",
+    VALIDATION: "validation",
+    EXTERNAL_SERVICE: "external_service",
+  },
+  logUserError: vi.fn(),
+}));
+
+const mockFetchCredentials = vi.fn();
+vi.mock("@/lib/credential-fetcher", () => ({
+  fetchCredentials: (...args: unknown[]) => mockFetchCredentials(...args),
+}));
+
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+vi.mock("@/lib/safe-fetch", () => ({ safeFetch }));
+
+import { getPendingTransactionsStep } from "@/plugins/safe/steps/get-pending-transactions";
+
+const SAFE_ADDRESS = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("Safe pending transaction projection", () => {
+  beforeEach(() => {
+    mockFetchCredentials.mockReset();
+    mockFetchCredentials.mockResolvedValue({ apiKey: "test-api-key" });
+    safeFetch.mockReset();
+  });
+
+  it("preserves every execTransaction gas and refund field", async () => {
+    safeFetch
+      .mockResolvedValueOnce(jsonResponse({ nonce: 7 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          count: 1,
+          results: [
+            {
+              safe: SAFE_ADDRESS,
+              to: "0x0000000000000000000000000000000000000001",
+              value: "42",
+              data: "0x1234",
+              operation: 0,
+              nonce: 7,
+              safeTxHash: `0x${"ab".repeat(32)}`,
+              submissionDate: "2026-09-07T19:00:00Z",
+              executionDate: null,
+              isExecuted: false,
+              confirmationsRequired: 2,
+              confirmations: [],
+              dataDecoded: null,
+              safeTxGas: 123,
+              baseGas: 456,
+              gasPrice: "789",
+              gasToken: "0x0000000000000000000000000000000000000002",
+              refundReceiver: "0x0000000000000000000000000000000000000003",
+              origin: null,
+            },
+          ],
+        })
+      );
+
+    const result = await getPendingTransactionsStep({
+      integrationId: "int-safe",
+      safeAddress: SAFE_ADDRESS,
+      network: "ethereum",
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.transactions).toHaveLength(1);
+    expect(result.transactions[0]).toMatchObject({
+      safeTxGas: 123,
+      baseGas: 456,
+      gasPrice: "789",
+      gasToken: "0x0000000000000000000000000000000000000002",
+      refundReceiver: "0x0000000000000000000000000000000000000003",
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2278.

## Summary

- preserve `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, and
  `refundReceiver` when projecting pending Safe transactions
- update the action catalog to describe the complete current output shape
- align the Safe plugin documentation with the additive fields
- cover the execution-critical gas/refund projection with a focused mocked
  Transaction Service test

The upstream response already contains these values; this change adds no
request and does not alter existing fields or filtering behavior.

## Verification

- `corepack pnpm@9 exec vitest run tests/unit/safe-pending-transactions-projection.test.ts tests/unit/protocol-safe.test.ts tests/unit/validate-workflow-structural.test.ts tests/unit/credential-map-coverage.test.ts` — 66 tests passed
- `corepack pnpm@9 run discover-plugins`
- `corepack pnpm@9 run type-check`
- `corepack pnpm@9 exec biome check plugins/safe/steps/get-pending-transactions.ts plugins/safe/index.ts docs/plugins/safe.md tests/unit/safe-pending-transactions-projection.test.ts`
- `git diff --check`

AI assistance was used to prepare this contribution. I reviewed the resulting
changes and ran the checks above in a clean, lockfile-pinned checkout.
