### PR TITLE
fix: KEEP-1328 add org-level workflow circuit breaker

### DIFF
--- a/app/api/execute/_lib/spending-cap.ts
+++ b/app/api/execute/_lib/spending-cap.ts
@@ -5,6 +5,10 @@ import { chargePaygIfBillable } from "@/lib/billing/payg/charge";
 import { db } from "@/lib/db";
 import { directExecutions } from "@/lib/db/schema";
 import {
+  isOrgHalted,
+  ORG_HALTED_REASON,
+} from "@/lib/execute/org-circuit-breaker";
+import {
   getDefaultDailySolanaValueCapLamports,
   getDefaultDailyValueCapWei,
 } from "@/lib/execute/spend-cap-defaults";
@@ -132,6 +136,20 @@ export async function checkAndReserveExecution(
     if (reserved === BigInt(0)) {
       await insertReservation();
       return { allowed: true, executionId: id } as const;
+    }
+
+    // Org incident circuit breaker: fail every value-moving direct execution
+    // closed while the org is halted, with the same fresh-read semantics as the
+    // value-ledger gate. Zero-value (read-only) executions returned above and
+    // keep running.
+    if (await isOrgHalted(tx, params.organizationId)) {
+      logSecurityEvent("org_circuit_breaker_blocked", {
+        organizationId: params.organizationId,
+        surface: "direct-execution",
+        chainFamily: isSolana ? "solana" : "evm",
+        reserved: reserved.toString(),
+      });
+      return { allowed: false, reason: ORG_HALTED_REASON } as const;
     }
 
     const cap = await lockOrgSpendCapRow(tx, params.organizationId);

--- a/app/api/organizations/circuit-breaker/reset/route.ts
+++ b/app/api/organizations/circuit-breaker/reset/route.ts
@@ -1,0 +1,75 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { resetOrgCircuitBreaker } from "@/lib/execute/org-circuit-breaker";
+import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { requirePermission } from "@/lib/middleware/require-org";
+import { buildAuditMetadata, recordAuditEvent } from "@/lib/security/audit-log";
+
+/**
+ * Clear the caller's organization circuit breaker so runs resume.
+ *
+ * This is the guaranteed recovery path. A halted org dispatches no workflows, so
+ * the in-workflow Reset action can never run while halted; an operator must be
+ * able to reach a plain HTTP endpoint that does not go through workflow
+ * dispatch. Gated by `organization:update` (admin/owner) over the session - the
+ * same gate the spend-cap setter uses. A kh_ API key or MCP OAuth token
+ * authenticates a different layer and never carries an org session, so it cannot
+ * reset the breaker.
+ */
+export const POST = requirePermission(
+  "organization",
+  ["update"],
+  async (req: NextRequest, context): Promise<Response> => {
+    const organizationId = context.organization?.id;
+    const userId = context.user?.id;
+    if (!(organizationId && userId)) {
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 403 }
+      );
+    }
+
+    try {
+      const result = await resetOrgCircuitBreaker({
+        organizationId,
+        requestedByUserId: userId,
+      });
+
+      if (!result.reset) {
+        return NextResponse.json(
+          {
+            error:
+              "Only organization admins and owners can reset the circuit breaker",
+          },
+          { status: 403 }
+        );
+      }
+
+      await recordAuditEvent({
+        actor: {
+          userId,
+          organizationId,
+          authMethod: "session",
+          actorLabel: userId,
+        },
+        action: "org.circuit_breaker.reset",
+        resourceType: "organization",
+        resourceId: organizationId,
+        after: { wasHalted: result.wasHalted },
+        metadata: buildAuditMetadata(req),
+      });
+
+      return NextResponse.json({ reset: true, wasHalted: result.wasHalted });
+    } catch (error) {
+      logSystemError(
+        ErrorCategory.INFRASTRUCTURE,
+        "[CircuitBreaker] Failed to reset circuit breaker",
+        error,
+        { organizationId }
+      );
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 }
+      );
+    }
+  }
+);

--- a/app/api/workflow/[workflowId]/execute/route.ts
+++ b/app/api/workflow/[workflowId]/execute/route.ts
@@ -70,6 +70,14 @@ export async function POST(
     const loaded = await loadWorkflowForExecution(workflowId, {
       requireEnabled: isInternalExecution,
     });
+    if (loaded.status === "not_executable" && loaded.reason === "halted") {
+      // Distinct from not-found so an operator recovering from an incident is
+      // told the org is halted, not misdirected to a missing-workflow 404.
+      return NextResponse.json(
+        { error: "Workflow temporarily halted" },
+        { status: HttpStatus.SERVICE_UNAVAILABLE }
+      );
+    }
     if (loaded.status === "not_found" || loaded.status === "not_executable") {
       return NextResponse.json(
         { error: "Workflow not found" },

--- a/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/app/api/workflows/[workflowId]/webhook/route.ts
@@ -205,6 +205,14 @@ export async function POST(
       if (loaded.reason === "disabled") {
         return failResponse(workflowId, timer, HttpStatus.GONE, "Workflow is disabled");
       }
+      if (loaded.reason === "halted") {
+        return failResponse(
+          workflowId,
+          timer,
+          HttpStatus.SERVICE_UNAVAILABLE,
+          "Workflow temporarily halted"
+        );
+      }
       return failResponse(workflowId, timer, HttpStatus.NOT_FOUND, "Workflow not found");
     }
     const { workflow } = loaded;

--- a/drizzle/0151_keep_1328_org_circuit_breaker.sql
+++ b/drizzle/0151_keep_1328_org_circuit_breaker.sql
@@ -1,14 +1,3 @@
--- Org-level incident circuit breaker (self-serve kill switch).
---
--- halted_at gates the value-ledger reservation path (per-write, fail-closed) and
--- the workflow dispatch predicate, so a tripped org stops moving value mid-run
--- and starts no new runs until an admin/owner clears it. halted_reason is a
--- free-text incident note; halted_by records the workflow id (or user id) that
--- tripped it, for audit.
---
--- Three nullable columns on the small organization table: no table rewrite, no
--- backfill, brief lock only. IF NOT EXISTS keeps re-application a no-op on any
--- DB that already has the columns.
-ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_at" timestamp;--> statement-breakpoint
-ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_reason" text;--> statement-breakpoint
-ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_by" text;
+ALTER TABLE "organization" ADD COLUMN "halted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "halted_reason" text;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "halted_by" text;

--- a/drizzle/0151_keep_1328_org_circuit_breaker.sql
+++ b/drizzle/0151_keep_1328_org_circuit_breaker.sql
@@ -1,0 +1,14 @@
+-- Org-level incident circuit breaker (self-serve kill switch).
+--
+-- halted_at gates the value-ledger reservation path (per-write, fail-closed) and
+-- the workflow dispatch predicate, so a tripped org stops moving value mid-run
+-- and starts no new runs until an admin/owner clears it. halted_reason is a
+-- free-text incident note; halted_by records the workflow id (or user id) that
+-- tripped it, for audit.
+--
+-- Three nullable columns on the small organization table: no table rewrite, no
+-- backfill, brief lock only. IF NOT EXISTS keeps re-application a no-op on any
+-- DB that already has the columns.
+ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_at" timestamp;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_reason" text;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN IF NOT EXISTS "halted_by" text;

--- a/drizzle/meta/0151_snapshot.json
+++ b/drizzle/meta/0151_snapshot.json
@@ -1,0 +1,9110 @@
+{
+  "id": "b08c29c9-b6ea-4d56-92bb-a9d5d549a941",
+  "prevId": "65277850-ba2d-4916-b3a4-e77ed4bd6487",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_accounts_user_id": {
+          "name": "idx_accounts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.address_book_entry": {
+      "name": "address_book_entry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_address_book_org": {
+          "name": "idx_address_book_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_address_book_org_address": {
+          "name": "idx_address_book_org_address",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "address_book_entry_organization_id_organization_id_fk": {
+          "name": "address_book_entry_organization_id_organization_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "address_book_entry_created_by_users_id_fk": {
+          "name": "address_book_entry_created_by_users_id_fk",
+          "tableFrom": "address_book_entry",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_registrations": {
+      "name": "agent_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "registry_address": {
+          "name": "registry_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_credits": {
+      "name": "agentic_wallet_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_usdc_cents": {
+          "name": "amount_usdc_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocation_reason": {
+          "name": "allocation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboard_initial'"
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_credits_sub_org": {
+          "name": "idx_agentic_wallet_credits_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_agentic_wallet_credits_sub_org_reason": {
+          "name": "uq_agentic_wallet_credits_sub_org_reason",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allocation_reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_credits_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_credits",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_daily_spend": {
+      "name": "agentic_wallet_daily_spend",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_utc": {
+          "name": "day_utc",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spent_micros": {
+          "name": "spent_micros",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_daily_spend_day": {
+          "name": "idx_agentic_wallet_daily_spend_day",
+          "columns": [
+            {
+              "expression": "day_utc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_daily_spend",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_daily_spend_sub_org_id_day_utc_pk": {
+          "name": "agentic_wallet_daily_spend_sub_org_id_day_utc_pk",
+          "columns": [
+            "sub_org_id",
+            "day_utc"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_hmac_secrets": {
+      "name": "agentic_wallet_hmac_secrets",
+      "schema": "",
+      "columns": {
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "agentic_wallet_hmac_secrets",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk": {
+          "name": "agentic_wallet_hmac_secrets_sub_org_id_key_version_pk",
+          "columns": [
+            "sub_org_id",
+            "key_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallet_rate_limits": {
+      "name": "agentic_wallet_rate_limits",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_start": {
+          "name": "bucket_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallet_rate_limits_bucket": {
+          "name": "idx_agentic_wallet_rate_limits_bucket",
+          "columns": [
+            {
+              "expression": "bucket_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agentic_wallet_rate_limits_key_bucket_start_pk": {
+          "name": "agentic_wallet_rate_limits_key_bucket_start_pk",
+          "columns": [
+            "key",
+            "bucket_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agentic_wallets": {
+      "name": "agentic_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_base": {
+          "name": "wallet_address_base",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address_tempo": {
+          "name": "wallet_address_tempo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hmac_secret": {
+          "name": "hmac_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agentic_wallets_linked_user": {
+          "name": "idx_agentic_wallets_linked_user",
+          "columns": [
+            {
+              "expression": "linked_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_base": {
+          "name": "idx_agentic_wallets_wallet_base",
+          "columns": [
+            {
+              "expression": "wallet_address_base",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agentic_wallets_wallet_tempo": {
+          "name": "idx_agentic_wallets_wallet_tempo",
+          "columns": [
+            {
+              "expression": "wallet_address_tempo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agentic_wallets_linked_user_id_users_id_fk": {
+          "name": "agentic_wallets_linked_user_id_users_id_fk",
+          "tableFrom": "agentic_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linked_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agentic_wallets_sub_org_id_unique": {
+          "name": "agentic_wallets_sub_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sub_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_users_id_fk": {
+          "name": "api_keys_user_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.beta_access_requests": {
+      "name": "beta_access_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.billing_events": {
+      "name": "billing_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_events_provider_event_id_unique": {
+          "name": "billing_events_provider_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chains": {
+      "name": "chains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_payment_rail": {
+          "name": "is_payment_rail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "default_primary_rpc": {
+          "name": "default_primary_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_fallback_rpc": {
+          "name": "default_fallback_rpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_primary_wss": {
+          "name": "default_primary_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_fallback_wss": {
+          "name": "default_fallback_wss",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "use_private_mempool_rpc": {
+          "name": "use_private_mempool_rpc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "default_private_rpc_url": {
+          "name": "default_private_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_testnet": {
+          "name": "is_testnet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stable'"
+        },
+        "gas_config": {
+          "name": "gas_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chains_chain_id": {
+          "name": "idx_chains_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "chains_chain_id_unique": {
+          "name": "chains_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_code": {
+      "name": "device_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_code_user_id_users_id_fk": {
+          "name": "device_code_user_id_users_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_executions": {
+      "name": "direct_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipts": {
+          "name": "receipts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_wei": {
+          "name": "value_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_lamports": {
+          "name": "value_lamports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_direct_executions_org": {
+          "name": "idx_direct_executions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_direct_executions_status": {
+          "name": "idx_direct_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_executions_organization_id_organization_id_fk": {
+          "name": "direct_executions_organization_id_organization_id_fk",
+          "tableFrom": "direct_executions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_debt": {
+      "name": "execution_debt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_record_id": {
+          "name": "overage_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debt_executions": {
+          "name": "debt_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "enforced_at": {
+          "name": "enforced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_debt_org_status": {
+          "name": "idx_execution_debt_org_status",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_execution_debt_invoice": {
+          "name": "idx_execution_debt_invoice",
+          "columns": [
+            {
+              "expression": "provider_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_debt_organization_id_organization_id_fk": {
+          "name": "execution_debt_organization_id_organization_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "execution_debt_overage_record_id_overage_billing_records_id_fk": {
+          "name": "execution_debt_overage_record_id_overage_billing_records_id_fk",
+          "tableFrom": "execution_debt",
+          "tableTo": "overage_billing_records",
+          "columnsFrom": [
+            "overage_record_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_debt_overage_record_id_unique": {
+          "name": "execution_debt_overage_record_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "overage_record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_quota_notifications": {
+      "name": "execution_quota_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_percent": {
+          "name": "usage_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executions_used": {
+          "name": "executions_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_quota_notif_org": {
+          "name": "idx_execution_quota_notif_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_quota_notif_org_fk": {
+          "name": "execution_quota_notif_org_fk",
+          "tableFrom": "execution_quota_notifications",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_quota_notif_org_period_threshold": {
+          "name": "execution_quota_notif_org_period_threshold",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "threshold"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explorer_configs": {
+      "name": "explorer_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_type": {
+          "name": "chain_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'evm'"
+        },
+        "explorer_url": {
+          "name": "explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_type": {
+          "name": "explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_api_url": {
+          "name": "explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_type": {
+          "name": "backup_explorer_api_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_url": {
+          "name": "backup_explorer_api_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_api_key_needed": {
+          "name": "backup_explorer_api_key_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "backup_explorer_api_key": {
+          "name": "backup_explorer_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_url": {
+          "name": "backup_explorer_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_tx_path": {
+          "name": "backup_explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_address_path": {
+          "name": "backup_explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_explorer_contract_path": {
+          "name": "backup_explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explorer_tx_path": {
+          "name": "explorer_tx_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/tx/{hash}'"
+        },
+        "explorer_address_path": {
+          "name": "explorer_address_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'/address/{address}'"
+        },
+        "explorer_contract_path": {
+          "name": "explorer_contract_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_explorer_configs_chain_id": {
+          "name": "idx_explorer_configs_chain_id",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "explorer_configs_chain_id_chains_chain_id_fk": {
+          "name": "explorer_configs_chain_id_chains_chain_id_fk",
+          "tableFrom": "explorer_configs",
+          "tableTo": "chains",
+          "columnsFrom": [
+            "chain_id"
+          ],
+          "columnsTo": [
+            "chain_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "explorer_configs_chain_id_unique": {
+          "name": "explorer_configs_chain_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_registry": {
+          "name": "agent_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erc-8004'"
+        },
+        "agent_chain_id": {
+          "name": "agent_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_wallet": {
+          "name": "payer_wallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_decimals": {
+          "name": "value_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_hash": {
+          "name": "feedback_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_chain_id": {
+          "name": "tx_chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "feedback_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "broadcast_at": {
+          "name": "broadcast_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_feedback_execution": {
+          "name": "idx_feedback_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_payer": {
+          "name": "idx_feedback_payer",
+          "columns": [
+            {
+              "expression": "payer_wallet",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_agent": {
+          "name": "idx_feedback_agent",
+          "columns": [
+            {
+              "expression": "agent_registry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_feedback_status": {
+          "name": "idx_feedback_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_execution_id_workflow_executions_id_fk": {
+          "name": "feedback_execution_id_workflow_executions_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "feedback_workflow_id_workflows_id_fk": {
+          "name": "feedback_workflow_id_workflows_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_allocations": {
+      "name": "gas_credit_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allocated_cents": {
+          "name": "allocated_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_credit_alloc_org": {
+          "name": "idx_gas_credit_alloc_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_allocations_organization_id_organization_id_fk": {
+          "name": "gas_credit_allocations_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_allocations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_credit_alloc_org_period": {
+          "name": "gas_credit_alloc_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_credit_usage": {
+      "name": "gas_credit_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used": {
+          "name": "gas_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_price_wei": {
+          "name": "gas_price_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_wei": {
+          "name": "gas_cost_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gas_cost_micro_usd": {
+          "name": "gas_cost_micro_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eth_price_usd": {
+          "name": "eth_price_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_usage_org_created": {
+          "name": "idx_gas_usage_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_credit_usage_organization_id_organization_id_fk": {
+          "name": "gas_credit_usage_organization_id_organization_id_fk",
+          "tableFrom": "gas_credit_usage",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_usage_org_tx": {
+          "name": "gas_usage_org_tx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "tx_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_sponsorship_delegations": {
+      "name": "gas_sponsorship_delegations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegation_tx_hash": {
+          "name": "delegation_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "implementation_address": {
+          "name": "implementation_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delegated_at": {
+          "name": "delegated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_delegation_org": {
+          "name": "idx_gas_delegation_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_sponsorship_delegations_organization_id_organization_id_fk": {
+          "name": "gas_sponsorship_delegations_organization_id_organization_id_fk",
+          "tableFrom": "gas_sponsorship_delegations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_delegation_org_chain": {
+          "name": "gas_delegation_org_chain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gas_sponsorship_monthly": {
+      "name": "gas_sponsorship_monthly",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month_start": {
+          "name": "month_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsored_wei": {
+          "name": "sponsored_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sponsored_micro_usd": {
+          "name": "sponsored_micro_usd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_count": {
+          "name": "tx_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_gas_sponsorship_monthly_org_month": {
+          "name": "idx_gas_sponsorship_monthly_org_month",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gas_sponsorship_monthly_organization_id_organization_id_fk": {
+          "name": "gas_sponsorship_monthly_organization_id_organization_id_fk",
+          "tableFrom": "gas_sponsorship_monthly",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gas_sponsorship_monthly_org_month_chain": {
+          "name": "gas_sponsorship_monthly_org_month_chain",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "month_start",
+            "chain_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_grants": {
+      "name": "integration_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_grants_integration_user": {
+          "name": "idx_integration_grants_integration_user",
+          "columns": [
+            {
+              "expression": "integration_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_grants_user": {
+          "name": "idx_integration_grants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_grants_integration_id_integrations_id_fk": {
+          "name": "integration_grants_integration_id_integrations_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "integrations",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_grants_user_id_users_id_fk": {
+          "name": "integration_grants_user_id_users_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_grants_granted_by_users_id_fk": {
+          "name": "integration_grants_granted_by_users_id_fk",
+          "tableFrom": "integration_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_managed": {
+          "name": "is_managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integrations_org_web3": {
+          "name": "idx_integrations_org_web3",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"integrations\".\"type\" = 'web3' AND \"integrations\".\"organization_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integrations_created_by": {
+          "name": "idx_integrations_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integrations_created_by_users_id_fk": {
+          "name": "integrations_created_by_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "integrations_organization_id_organization_id_fk": {
+          "name": "integrations_organization_id_organization_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_service_hmac_secrets": {
+      "name": "internal_service_hmac_secrets",
+      "schema": "",
+      "columns": {
+        "caller": {
+          "name": "caller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "internal_service_hmac_secrets_caller_key_version_pk": {
+          "name": "internal_service_hmac_secrets_caller_key_version_pk",
+          "columns": [
+            "caller",
+            "key_version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_users_id_fk": {
+          "name": "invitation_inviter_id_users_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.key_export_codes": {
+      "name": "key_export_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "key_export_codes_organization_id_organization_id_fk": {
+          "name": "key_export_codes_organization_id_organization_id_fk",
+          "tableFrom": "key_export_codes",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_auth_codes": {
+      "name": "mcp_oauth_auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_auth_codes_code_unique": {
+          "name": "mcp_oauth_auth_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_clients": {
+      "name": "mcp_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_hash": {
+          "name": "client_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_clients_client_id_unique": {
+          "name": "mcp_oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_refresh_tokens": {
+      "name": "mcp_oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_mcp_refresh_tokens_client": {
+          "name": "idx_mcp_refresh_tokens_client",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_refresh_tokens_user": {
+          "name": "idx_mcp_refresh_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_refresh_tokens_org": {
+          "name": "idx_mcp_refresh_tokens_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_oauth_refresh_tokens_token_hash_unique": {
+          "name": "mcp_oauth_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "mcp_max_scope": {
+          "name": "mcp_max_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_member_user_id": {
+          "name": "idx_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_member_organization_id": {
+          "name": "idx_member_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_org_single_owner": {
+          "name": "member_org_single_owner",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"member\".\"role\" = 'owner'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_users_id_fk": {
+          "name": "member_user_id_users_id_fk",
+          "tableFrom": "member",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enforce_mfa": {
+          "name": "enforce_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enforced_mfa_factors": {
+          "name": "enforced_mfa_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_max_scope": {
+          "name": "mcp_max_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "halted_at": {
+          "name": "halted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "halted_reason": {
+          "name": "halted_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "halted_by": {
+          "name": "halted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_api_keys": {
+      "name": "organization_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_org_api_keys_org_id": {
+          "name": "idx_org_api_keys_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_api_keys_created_by": {
+          "name": "idx_org_api_keys_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_api_keys_organization_id_organization_id_fk": {
+          "name": "organization_api_keys_organization_id_organization_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_api_keys_created_by_users_id_fk": {
+          "name": "organization_api_keys_created_by_users_id_fk",
+          "tableFrom": "organization_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_api_keys_key_hash_unique": {
+          "name": "organization_api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_spend_caps": {
+      "name": "organization_spend_caps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_cap_wei": {
+          "name": "daily_cap_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_value_cap_wei": {
+          "name": "daily_value_cap_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_solana_value_cap_lamports": {
+          "name": "daily_solana_value_cap_lamports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_spend_caps_organization_id_organization_id_fk": {
+          "name": "organization_spend_caps_organization_id_organization_id_fk",
+          "tableFrom": "organization_spend_caps",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_spend_caps_organization_id_unique": {
+          "name": "organization_spend_caps_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_subscriptions": {
+      "name": "organization_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_customer_id": {
+          "name": "provider_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_subscription_id": {
+          "name": "provider_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_price_id": {
+          "name": "provider_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_alert": {
+          "name": "billing_alert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_alert_url": {
+          "name": "billing_alert_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_started_at": {
+          "name": "trial_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_overrides": {
+          "name": "plan_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_subscriptions_org": {
+          "name": "idx_org_subscriptions_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_subscriptions_provider_sub": {
+          "name": "idx_org_subscriptions_provider_sub",
+          "columns": [
+            {
+              "expression": "provider_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_subscriptions_organization_id_organization_id_fk": {
+          "name": "organization_subscriptions_organization_id_organization_id_fk",
+          "tableFrom": "organization_subscriptions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_subscriptions_organization_id_unique": {
+          "name": "organization_subscriptions_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        },
+        "organization_subscriptions_provider_customer_id_unique": {
+          "name": "organization_subscriptions_provider_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_tokens": {
+      "name": "organization_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_tokens_org_chain": {
+          "name": "idx_org_tokens_org_chain",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_tokens_safe": {
+          "name": "idx_org_tokens_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_tokens_organization_id_organization_id_fk": {
+          "name": "organization_tokens_organization_id_organization_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_tokens_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "organization_tokens_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "organization_tokens",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_wallets": {
+      "name": "organization_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnkey_sub_org_id": {
+          "name": "turnkey_sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_wallet_id": {
+          "name": "turnkey_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "turnkey_private_key_id": {
+          "name": "turnkey_private_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "solana_address": {
+          "name": "solana_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_wallets_org_active_unique": {
+          "name": "organization_wallets_org_active_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_wallets\".\"is_active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_wallets_user_id_users_id_fk": {
+          "name": "organization_wallets_user_id_users_id_fk",
+          "tableFrom": "organization_wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_wallets_organization_id_organization_id_fk": {
+          "name": "organization_wallets_organization_id_organization_id_fk",
+          "tableFrom": "organization_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.overage_billing_records": {
+      "name": "overage_billing_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_limit": {
+          "name": "execution_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_executions": {
+          "name": "total_executions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_count": {
+          "name": "overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overage_rate_cents": {
+          "name": "overage_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_charge_cents": {
+          "name": "total_charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_invoice_item_id": {
+          "name": "provider_invoice_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_invoice_id": {
+          "name": "provider_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_overage_billing_org": {
+          "name": "idx_overage_billing_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_overage_billing_status": {
+          "name": "idx_overage_billing_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "overage_billing_records_organization_id_organization_id_fk": {
+          "name": "overage_billing_records_organization_id_organization_id_fk",
+          "tableFrom": "overage_billing_records",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "overage_billing_org_period": {
+          "name": "overage_billing_org_period",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "period_start",
+            "period_end"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payg_config": {
+      "name": "payg_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "daily_cap_raw": {
+          "name": "daily_cap_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "period_cap_raw": {
+          "name": "period_cap_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 8453
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payg_config_org": {
+          "name": "idx_payg_config_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payg_config_organization_id_organization_id_fk": {
+          "name": "payg_config_organization_id_organization_id_fk",
+          "tableFrom": "payg_config",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payg_config_organization_id_unique": {
+          "name": "payg_config_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payg_payments": {
+      "name": "payg_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "treasury_address": {
+          "name": "treasury_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'settled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_payg_payments_org_created": {
+          "name": "idx_payg_payments_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payg_payments_organization_id_organization_id_fk": {
+          "name": "payg_payments_organization_id_organization_id_fk",
+          "tableFrom": "payg_payments",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payg_payments_org_execution": {
+          "name": "payg_payments_org_execution",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "execution_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_transactions": {
+      "name": "pending_transactions",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_price": {
+          "name": "gas_price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "confirmed_at": {
+          "name": "confirmed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "idx_pending_tx_status": {
+          "name": "idx_pending_tx_status",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_tx_execution": {
+          "name": "idx_pending_tx_execution",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "pending_transactions_wallet_address_chain_id_nonce_pk": {
+          "name": "pending_transactions_wallet_address_chain_id_nonce_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id",
+            "nonce"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_org": {
+          "name": "idx_projects_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organization_id_fk": {
+          "name": "projects_organization_id_organization_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_user_id_users_id_fk": {
+          "name": "projects_user_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.public_tags": {
+      "name": "public_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "public_tags_name_unique": {
+          "name": "public_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "public_tags_slug_unique": {
+          "name": "public_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_allowances": {
+      "name": "safe_role_allowances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowance_key": {
+          "name": "allowance_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_refill_wei": {
+          "name": "max_refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_wei": {
+          "name": "refill_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_chain_balance_wei": {
+          "name": "last_chain_balance_wei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_chain_timestamp": {
+          "name": "last_chain_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_allowances_role_key_unique": {
+          "name": "safe_role_allowances_role_key_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "allowance_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_allowances_role": {
+          "name": "idx_safe_role_allowances_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_allowances_role_id_safe_roles_id_fk": {
+          "name": "safe_role_allowances_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_allowances",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_direct_rules": {
+      "name": "safe_role_direct_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_human": {
+          "name": "amount_human",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_seconds": {
+          "name": "period_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_direct_rules_role_kind_token_cp_unique": {
+          "name": "safe_role_direct_rules_role_kind_token_cp_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "counterparty",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_direct_rules_role": {
+          "name": "idx_safe_role_direct_rules_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_direct_rules_role_id_safe_roles_id_fk": {
+          "name": "safe_role_direct_rules_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_direct_rules",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_role_protocols": {
+      "name": "safe_role_protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_slug": {
+          "name": "protocol_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_slug": {
+          "name": "template_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_token_symbols": {
+          "name": "allowed_token_symbols",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_addresses": {
+          "name": "target_addresses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_selectors": {
+          "name": "allowed_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'allowed'"
+        },
+        "last_applied_tx_hash": {
+          "name": "last_applied_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_role_protocols_role_slug_unique": {
+          "name": "safe_role_protocols_role_slug_unique",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_role_protocols_role": {
+          "name": "idx_safe_role_protocols_role",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_role_protocols_role_id_safe_roles_id_fk": {
+          "name": "safe_role_protocols_role_id_safe_roles_id_fk",
+          "tableFrom": "safe_role_protocols",
+          "tableTo": "safe_roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_roles": {
+      "name": "safe_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "safe_wallet_id": {
+          "name": "safe_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automation'"
+        },
+        "role_key": {
+          "name": "role_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles_modifier_address": {
+          "name": "roles_modifier_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delegate_address": {
+          "name": "delegate_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_tx_hash": {
+          "name": "installed_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_reconciled_at": {
+          "name": "last_reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_roles_safe_type_unique": {
+          "name": "safe_roles_safe_type_unique",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_roles_safe": {
+          "name": "idx_safe_roles_safe",
+          "columns": [
+            {
+              "expression": "safe_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_roles_safe_wallet_id_safe_wallets_id_fk": {
+          "name": "safe_roles_safe_wallet_id_safe_wallets_id_fk",
+          "tableFrom": "safe_roles",
+          "tableTo": "safe_wallets",
+          "columnsFrom": [
+            "safe_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.safe_wallets": {
+      "name": "safe_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_address": {
+          "name": "safe_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_wallet_id": {
+          "name": "owner_wallet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salt_nonce": {
+          "name": "salt_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "safe_version": {
+          "name": "safe_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.4.1'"
+        },
+        "singleton_address": {
+          "name": "singleton_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "factory_address": {
+          "name": "factory_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deployment_tx_hash": {
+          "name": "deployment_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_block": {
+          "name": "deployment_block",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deployed_at": {
+          "name": "deployed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_signing_active": {
+          "name": "is_signing_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "safe_wallets_org_chain_unique": {
+          "name": "safe_wallets_org_chain_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_safe_wallets_org": {
+          "name": "idx_safe_wallets_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "safe_wallets_organization_id_organization_id_fk": {
+          "name": "safe_wallets_organization_id_organization_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "safe_wallets_owner_wallet_id_organization_wallets_id_fk": {
+          "name": "safe_wallets_owner_wallet_id_organization_wallets_id_fk",
+          "tableFrom": "safe_wallets",
+          "tableTo": "organization_wallets",
+          "columnsFrom": [
+            "owner_wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_label": {
+          "name": "organization_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correlation_id": {
+          "name": "correlation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_org_created": {
+          "name": "idx_security_audit_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_actor_created": {
+          "name": "idx_security_audit_actor_created",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource_created": {
+          "name": "idx_security_audit_resource_created",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_action_created": {
+          "name": "idx_security_audit_action_created",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_correlation_created": {
+          "name": "idx_security_audit_correlation_created",
+          "columns": [
+            {
+              "expression": "correlation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_actor_user_id_users_id_fk": {
+          "name": "security_audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "security_audit_log_organization_id_organization_id_fk": {
+          "name": "security_audit_log_organization_id_organization_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_mfa": {
+          "name": "requires_mfa",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mfa_verified_at": {
+          "name": "mfa_verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_flags_json": {
+          "name": "risk_flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supported_tokens": {
+      "name": "supported_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "symbol": {
+          "name": "symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decimals": {
+          "name": "decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_stablecoin": {
+          "name": "is_stablecoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_supported_tokens_chain": {
+          "name": "idx_supported_tokens_chain",
+          "columns": [
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "supported_tokens_chain_address": {
+          "name": "supported_tokens_chain_address",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chain_id",
+            "token_address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tags_org": {
+          "name": "idx_tags_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_organization_id_organization_id_fk": {
+          "name": "tags_organization_id_organization_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tags_user_id_users_id_fk": {
+          "name": "tags_user_id_users_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tempo_held_payments": {
+      "name": "tempo_held_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_address": {
+          "name": "to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_address": {
+          "name": "token_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_raw": {
+          "name": "amount_raw",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_symbol": {
+          "name": "token_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_decimals": {
+          "name": "token_decimals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_display": {
+          "name": "amount_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serialized_tx": {
+          "name": "serialized_tx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "precomputed_hash": {
+          "name": "precomputed_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce_key": {
+          "name": "nonce_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_fee_per_gas": {
+          "name": "max_fee_per_gas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_after": {
+          "name": "valid_after",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_before": {
+          "name": "valid_before",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "broadcast_at": {
+          "name": "broadcast_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "tempo_held_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_tx_hash": {
+          "name": "broadcast_tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tempo_held_payments_org": {
+          "name": "idx_tempo_held_payments_org",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_org_created": {
+          "name": "idx_tempo_held_payments_org_created",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_status": {
+          "name": "idx_tempo_held_payments_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_due": {
+          "name": "idx_tempo_held_payments_due",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "broadcast_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tempo_held_payments_expiry": {
+          "name": "idx_tempo_held_payments_expiry",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "valid_before",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_tempo_held_payments_hash": {
+          "name": "uq_tempo_held_payments_hash",
+          "columns": [
+            {
+              "expression": "precomputed_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_tempo_held_payments_dispatch_key": {
+          "name": "uq_tempo_held_payments_dispatch_key",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tempo_held_payments_organization_id_organization_id_fk": {
+          "name": "tempo_held_payments_organization_id_organization_id_fk",
+          "tableFrom": "tempo_held_payments",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tempo_held_payments_created_by_user_id_users_id_fk": {
+          "name": "tempo_held_payments_created_by_user_id_users_id_fk",
+          "tableFrom": "tempo_held_payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_two_factor_user_id": {
+          "name": "idx_two_factor_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_users_id_fk": {
+          "name": "two_factor_user_id_users_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "two_factor_user_id_unique": {
+          "name": "two_factor_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_rpc_preferences": {
+      "name": "user_rpc_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_rpc_url": {
+          "name": "primary_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_rpc_url": {
+          "name": "fallback_rpc_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_wss_url": {
+          "name": "primary_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fallback_wss_url": {
+          "name": "fallback_wss_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_rpc_user_chain": {
+          "name": "idx_user_rpc_user_chain",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "chain_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_rpc_user_id": {
+          "name": "idx_user_rpc_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_rpc_preferences_user_id_users_id_fk": {
+          "name": "user_rpc_preferences_user_id_users_id_fk",
+          "tableFrom": "user_rpc_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_countries": {
+      "name": "user_trusted_countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_countries_user_id": {
+          "name": "idx_user_trusted_countries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_countries_user_country": {
+          "name": "idx_user_trusted_countries_user_country",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_countries_user_id_users_id_fk": {
+          "name": "user_trusted_countries_user_id_users_id_fk",
+          "tableFrom": "user_trusted_countries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_devices": {
+      "name": "user_trusted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_devices_user_id": {
+          "name": "idx_user_trusted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_devices_user_device": {
+          "name": "idx_user_trusted_devices_user_device",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_devices_user_id_users_id_fk": {
+          "name": "user_trusted_devices_user_id_users_id_fk",
+          "tableFrom": "user_trusted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_trusted_ips": {
+      "name": "user_trusted_ips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_trusted_ips_user_id": {
+          "name": "idx_user_trusted_ips_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_trusted_ips_user_ip": {
+          "name": "idx_user_trusted_ips_user_ip",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_trusted_ips_user_id_users_id_fk": {
+          "name": "user_trusted_ips_user_id_users_id_fk",
+          "tableFrom": "user_trusted_ips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "display_name_confirmed": {
+          "name": "display_name_confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "step_up_policy": {
+          "name": "step_up_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_up_email": {
+          "name": "step_up_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signup_notified_at": {
+          "name": "signup_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_address": {
+      "name": "wallet_address",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_wallet_address_user_id": {
+          "name": "idx_wallet_address_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_address_address_unique": {
+          "name": "idx_wallet_address_address_unique",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_address_user_id_users_id_fk": {
+          "name": "wallet_address_user_id_users_id_fk",
+          "tableFrom": "wallet_address",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_approval_requests": {
+      "name": "wallet_approval_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sub_org_id": {
+          "name": "sub_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_payload": {
+          "name": "operation_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "approval_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "approval_risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_recipient": {
+          "name": "bound_recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_amount_micro": {
+          "name": "bound_amount_micro",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_chain": {
+          "name": "bound_chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_contract": {
+          "name": "bound_contract",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now() + interval '15 minutes'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_wallet_approval_sub_org": {
+          "name": "idx_wallet_approval_sub_org",
+          "columns": [
+            {
+              "expression": "sub_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_status": {
+          "name": "idx_wallet_approval_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_created": {
+          "name": "idx_wallet_approval_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_wallet_approval_resolved_by": {
+          "name": "idx_wallet_approval_resolved_by",
+          "columns": [
+            {
+              "expression": "resolved_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk": {
+          "name": "wallet_approval_requests_sub_org_id_agentic_wallets_sub_org_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "agentic_wallets",
+          "columnsFrom": [
+            "sub_org_id"
+          ],
+          "columnsTo": [
+            "sub_org_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_approval_requests_resolved_by_user_id_users_id_fk": {
+          "name": "wallet_approval_requests_resolved_by_user_id_users_id_fk",
+          "tableFrom": "wallet_approval_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_locks": {
+      "name": "wallet_locks",
+      "schema": "",
+      "columns": {
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_id": {
+          "name": "chain_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locked_by": {
+          "name": "locked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "wallet_locks_wallet_address_chain_id_pk": {
+          "name": "wallet_locks_wallet_address_chain_id_pk",
+          "columns": [
+            "wallet_address",
+            "chain_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_digest_settings": {
+      "name": "workflow_execution_digest_settings",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cadences": {
+          "name": "cadences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"weekly\"]'::jsonb"
+        },
+        "subscriber_user_ids": {
+          "name": "subscriber_user_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_sent": {
+          "name": "last_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_execution_digest_enabled": {
+          "name": "idx_execution_digest_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_digest_settings_organization_id_organization_id_fk": {
+          "name": "workflow_execution_digest_settings_organization_id_organization_id_fk",
+          "tableFrom": "workflow_execution_digest_settings",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_execution_logs": {
+      "name": "workflow_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_name": {
+          "name": "node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_type": {
+          "name": "node_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_raw": {
+          "name": "output_raw",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "iteration_index": {
+          "name": "iteration_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "for_each_node_id": {
+          "name": "for_each_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_exec_logs_started_at": {
+          "name": "idx_exec_logs_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_exec_logs_execution_id": {
+          "name": "idx_exec_logs_execution_id",
+          "columns": [
+            {
+              "expression": "execution_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_execution_logs_execution_id_workflow_executions_id_fk": {
+          "name": "workflow_execution_logs_execution_id_workflow_executions_id_fk",
+          "tableFrom": "workflow_execution_logs",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "execution_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_category": {
+          "name": "error_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_steps": {
+          "name": "total_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_steps": {
+          "name": "completed_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "current_node_id": {
+          "name": "current_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_node_name": {
+          "name": "current_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_id": {
+          "name": "last_successful_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_successful_node_name": {
+          "name": "last_successful_node_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_trace": {
+          "name": "execution_trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_hashes": {
+          "name": "transaction_hashes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "gas_used_wei": {
+          "name": "gas_used_wei",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billable": {
+          "name": "billable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "triggered_by_user_api_key_id": {
+          "name": "triggered_by_user_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_org_api_key_id": {
+          "name": "triggered_by_org_api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_ip": {
+          "name": "triggered_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_country": {
+          "name": "triggered_by_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_credential_type": {
+          "name": "triggered_by_credential_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_credential_label": {
+          "name": "triggered_by_credential_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_workflow_hash": {
+          "name": "executed_workflow_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_key": {
+          "name": "dispatch_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflow_executions_status": {
+          "name": "idx_workflow_executions_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_user_id": {
+          "name": "idx_workflow_executions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_organization_id": {
+          "name": "idx_workflow_executions_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_executed_hash": {
+          "name": "idx_workflow_executions_executed_hash",
+          "columns": [
+            {
+              "expression": "executed_workflow_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_executions_dispatch_key": {
+          "name": "idx_workflow_executions_dispatch_key",
+          "columns": [
+            {
+              "expression": "dispatch_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_executions_workflow_id_workflows_id_fk": {
+          "name": "workflow_executions_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_organization_id_organization_id_fk": {
+          "name": "workflow_executions_organization_id_organization_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_user_id_users_id_fk": {
+          "name": "workflow_executions_user_id_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_triggered_by_user_api_key_id_api_keys_id_fk": {
+          "name": "workflow_executions_triggered_by_user_api_key_id_api_keys_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "triggered_by_user_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_history": {
+      "name": "workflow_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by_user_id": {
+          "name": "changed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change": {
+          "name": "change",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_workflow_history_workflow_version": {
+          "name": "uq_workflow_history_workflow_version",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_history_content_hash": {
+          "name": "idx_workflow_history_content_hash",
+          "columns": [
+            {
+              "expression": "content_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_history_workflow_id_workflows_id_fk": {
+          "name": "workflow_history_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_history_organization_id_organization_id_fk": {
+          "name": "workflow_history_organization_id_organization_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflow_history_changed_by_user_id_users_id_fk": {
+          "name": "workflow_history_changed_by_user_id_users_id_fk",
+          "tableFrom": "workflow_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "changed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_payments": {
+      "name": "workflow_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_hash": {
+          "name": "payment_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'execution'"
+        },
+        "deliverable": {
+          "name": "deliverable",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount_usdc": {
+          "name": "amount_usdc",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payer_address": {
+          "name": "payer_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_wallet_address": {
+          "name": "creator_wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled_at": {
+          "name": "settled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'x402'"
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'base'"
+        }
+      },
+      "indexes": {
+        "idx_workflow_payments_hash": {
+          "name": "idx_workflow_payments_hash",
+          "columns": [
+            {
+              "expression": "payment_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_payments_workflow": {
+          "name": "idx_workflow_payments_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_public_tags": {
+      "name": "workflow_public_tags",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_tag_id": {
+          "name": "public_tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_workflow_public_tags_workflow": {
+          "name": "idx_workflow_public_tags_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_public_tags_tag": {
+          "name": "idx_workflow_public_tags_tag",
+          "columns": [
+            {
+              "expression": "public_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_public_tags_workflow_id_workflows_id_fk": {
+          "name": "workflow_public_tags_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_public_tags_public_tag_id_public_tags_id_fk": {
+          "name": "workflow_public_tags_public_tag_id_public_tags_id_fk",
+          "tableFrom": "workflow_public_tags",
+          "tableTo": "public_tags",
+          "columnsFrom": [
+            "public_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "workflow_public_tags_workflow_id_public_tag_id_pk": {
+          "name": "workflow_public_tags_workflow_id_public_tag_id_pk",
+          "columns": [
+            "workflow_id",
+            "public_tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_ratings": {
+      "name": "workflow_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_ratings_workflow": {
+          "name": "idx_workflow_ratings_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_ratings_workflow_id_workflows_id_fk": {
+          "name": "workflow_ratings_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_ratings_user_id_users_id_fk": {
+          "name": "workflow_ratings_user_id_users_id_fk",
+          "tableFrom": "workflow_ratings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_workflow_ratings_workflow_user": {
+          "name": "uq_workflow_ratings_workflow_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_schedules": {
+      "name": "workflow_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_at": {
+          "name": "anchor_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workflow_schedules_enabled": {
+          "name": "idx_workflow_schedules_enabled",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflow_schedules_workflow": {
+          "name": "idx_workflow_schedules_workflow",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_schedules_workflow_id_workflows_id_fk": {
+          "name": "workflow_schedules_workflow_id_workflows_id_fk",
+          "tableFrom": "workflow_schedules",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflow_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_schedules_workflow_id_unique": {
+          "name": "workflow_schedules_workflow_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workflow_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "featured_order": {
+          "name": "featured_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "featured_protocol": {
+          "name": "featured_protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_protocol_order": {
+          "name": "featured_protocol_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nodes": {
+          "name": "nodes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edges": {
+          "name": "edges",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source_workflow_id": {
+          "name": "source_workflow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "seeded_at": {
+          "name": "seeded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_listed": {
+          "name": "is_listed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "listed_slug": {
+          "name": "listed_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listed_at": {
+          "name": "listed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_execution_status": {
+          "name": "share_execution_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_mapping": {
+          "name": "output_mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_usdc_per_call": {
+          "name": "price_usdc_per_call",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_type": {
+          "name": "workflow_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chain": {
+          "name": "chain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "listing_version": {
+          "name": "listing_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workflows_listed_slug": {
+          "name": "idx_workflows_listed_slug",
+          "columns": [
+            {
+              "expression": "listed_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflows\".\"listed_slug\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_user_id": {
+          "name": "idx_workflows_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_tag_id": {
+          "name": "idx_workflows_tag_id",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workflows_project_id": {
+          "name": "idx_workflows_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_user_id_users_id_fk": {
+          "name": "workflows_user_id_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_organization_id_organization_id_fk": {
+          "name": "workflows_organization_id_organization_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_project_id_projects_id_fk": {
+          "name": "workflows_project_id_projects_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workflows_tag_id_tags_id_fk": {
+          "name": "workflows_tag_id_tags_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.approval_risk_level": {
+      "name": "approval_risk_level",
+      "schema": "public",
+      "values": [
+        "auto",
+        "ask",
+        "block"
+      ]
+    },
+    "public.approval_status": {
+      "name": "approval_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.feedback_status": {
+      "name": "feedback_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "broadcast",
+        "confirmed",
+        "failed"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "specific_members",
+        "organization"
+      ]
+    },
+    "public.tempo_held_payment_status": {
+      "name": "tempo_held_payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "broadcasting",
+        "broadcast",
+        "confirmed",
+        "failed",
+        "expired",
+        "canceled"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.step_status": {
+      "name": "step_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.wait_status": {
+      "name": "wait_status",
+      "schema": "public",
+      "values": [
+        "waiting",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1058,6 +1058,13 @@
       "when": 1788517619226,
       "tag": "0150_keep_1333_summary_covering_index",
       "breakpoints": true
+    },
+    {
+      "idx": 151,
+      "version": "7",
+      "when": 1789000000000,
+      "tag": "0151_keep_1328_org_circuit_breaker",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1062,7 +1062,7 @@
     {
       "idx": 151,
       "version": "7",
-      "when": 1789000000000,
+      "when": 1788839868869,
       "tag": "0151_keep_1328_org_circuit_breaker",
       "breakpoints": true
     }

--- a/keeperhub-executor/lib/db-helpers.ts
+++ b/keeperhub-executor/lib/db-helpers.ts
@@ -450,6 +450,7 @@ export type DiscardReason =
   | "deleted"
   | "deactivated"
   | "org_deactivated"
+  | "halted"
   | "disabled"
   | "schedule_invalid";
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -337,6 +337,18 @@ export const organization = pgTable("organization", {
   // ceiling, which is what every org predating the setting gets, so nothing
   // an agent already does stops working on deploy.
   mcpMaxScope: text("mcp_max_scope"),
+  // Org-level incident circuit breaker (self-serve kill switch). When set,
+  // every value-moving workflow/protocol step fails closed at the value-ledger
+  // reservation gate (per write, mid run) and no new runs dispatch. Read-only
+  // steps are unaffected. Distinct from deactivatedAt, which is a permanent
+  // admin/ops off-state cleared only by ops; this is reversible and cleared by
+  // an org admin/owner (or an admin-owned Reset action) to resume.
+  haltedAt: timestamp("halted_at"),
+  // Free-text incident note recorded when the breaker is tripped.
+  haltedReason: text("halted_reason"),
+  // Audit trail for who/what tripped the breaker: the workflow id when tripped
+  // by a Trip action, or a user id when tripped by an operator.
+  haltedBy: text("halted_by"),
 });
 
 export const member = pgTable(

--- a/lib/execute/org-circuit-breaker.ts
+++ b/lib/execute/org-circuit-breaker.ts
@@ -1,0 +1,153 @@
+import "server-only";
+
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { member, organization } from "@/lib/db/schema";
+
+/**
+ * Org-level incident circuit breaker (self-serve kill switch).
+ *
+ * A tripped org (`organization.halted_at` set) fails every value-moving
+ * workflow/protocol step closed at the value-ledger reservation gate
+ * (`reserveOrgValue` / `reserveOrgSolanaValue`) and dispatches no new runs
+ * (`workflowReachableConditions`). Read-only steps never reserve value, so they
+ * keep running. The switch is reversible: an org admin/owner clears it to resume.
+ *
+ * `halted_at` is read fresh inside the reservation transaction rather than from a
+ * TTL cache. A cached "not halted" would let value keep moving through the very
+ * incident window the breaker exists to stop, so the extra indexed primary-key
+ * read on an already-heavy (locking transaction + insert) path is the correct
+ * trade.
+ */
+
+// The denial reason surfaced by the value-ledger reservation gate when the org
+// is halted. Distinct from the cap-exceeded reason so callers and logs can tell
+// an incident halt from an ordinary spend-cap rejection.
+export const ORG_HALTED_REASON =
+  "Organization circuit breaker is engaged; value-moving actions are halted";
+
+const RESET_ROLE_RANK: Record<string, number> = {
+  member: 1,
+  admin: 2,
+  owner: 3,
+};
+
+// biome-ignore lint/suspicious/noExplicitAny: accept either the app db handle or an open transaction, mirroring value-ledger's Executor alias
+type Executor = any;
+
+/**
+ * Whether the org is currently halted. Takes an executor so the value-ledger can
+ * read it inside its reservation transaction, consistent with the row it locks.
+ */
+export async function isOrgHalted(
+  executor: Executor,
+  organizationId: string
+): Promise<boolean> {
+  const [row] = await executor
+    .select({ haltedAt: organization.haltedAt })
+    .from(organization)
+    .where(eq(organization.id, organizationId))
+    .limit(1);
+  return (row?.haltedAt ?? null) !== null;
+}
+
+export type TripResult = {
+  // True when this call engaged the breaker; false when it was already engaged.
+  tripped: boolean;
+  haltedAt: Date;
+};
+
+/**
+ * Engage the org's circuit breaker. Idempotent: a guarded UPDATE (WHERE
+ * halted_at IS NULL) means a second trip does not overwrite the original
+ * reason/actor or move the timestamp, and reports `tripped: false`.
+ */
+export async function tripOrgCircuitBreaker(params: {
+  organizationId: string;
+  reason?: string | null;
+  byWorkflowId?: string | null;
+}): Promise<TripResult> {
+  const now = new Date();
+
+  const [engaged] = await db
+    .update(organization)
+    .set({
+      haltedAt: now,
+      haltedReason: params.reason ?? null,
+      haltedBy: params.byWorkflowId ?? null,
+    })
+    .where(
+      and(
+        eq(organization.id, params.organizationId),
+        isNull(organization.haltedAt)
+      )
+    )
+    .returning({ haltedAt: organization.haltedAt });
+
+  if (engaged?.haltedAt) {
+    return { tripped: true, haltedAt: engaged.haltedAt };
+  }
+
+  const [existing] = await db
+    .select({ haltedAt: organization.haltedAt })
+    .from(organization)
+    .where(eq(organization.id, params.organizationId))
+    .limit(1);
+
+  if (!existing?.haltedAt) {
+    throw new Error("Organization not found");
+  }
+  return { tripped: false, haltedAt: existing.haltedAt };
+}
+
+export type ResetResult =
+  | { reset: true; wasHalted: boolean }
+  | { reset: false; reason: "not_authorized" };
+
+/**
+ * Clear the org's circuit breaker. Privileged: succeeds only when the requesting
+ * principal is a current admin/owner member of the org. For a workflow-invoked
+ * Reset the principal is the workflow creator (audit-only elsewhere, used here
+ * purely as the human whose standing role is checked), so a workflow created by
+ * a non-admin cannot auto-reset, and a creator later demoted loses the ability -
+ * both fail safe. Idempotent: resetting an org that is not halted is a no-op that
+ * still reports `reset: true` with `wasHalted: false`.
+ */
+export async function resetOrgCircuitBreaker(params: {
+  organizationId: string;
+  requestedByUserId: string | null | undefined;
+}): Promise<ResetResult> {
+  const userId = params.requestedByUserId;
+  if (!userId) {
+    return { reset: false, reason: "not_authorized" };
+  }
+
+  const [membership] = await db
+    .select({ role: member.role })
+    .from(member)
+    .where(
+      and(
+        eq(member.userId, userId),
+        eq(member.organizationId, params.organizationId)
+      )
+    )
+    .limit(1);
+
+  const rank = membership?.role ? (RESET_ROLE_RANK[membership.role] ?? 0) : 0;
+  if (rank < RESET_ROLE_RANK.admin) {
+    return { reset: false, reason: "not_authorized" };
+  }
+
+  const [cleared] = await db
+    .update(organization)
+    .set({ haltedAt: null, haltedReason: null, haltedBy: null })
+    .where(
+      and(
+        eq(organization.id, params.organizationId),
+        isNotNull(organization.haltedAt)
+      )
+    )
+    .returning({ id: organization.id });
+
+  return { reset: true, wasHalted: Boolean(cleared) };
+}

--- a/lib/execute/org-circuit-breaker.ts
+++ b/lib/execute/org-circuit-breaker.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, eq, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { member, organization } from "@/lib/db/schema";
 
@@ -58,46 +58,51 @@ export type TripResult = {
 };
 
 /**
- * Engage the org's circuit breaker. Idempotent: a guarded UPDATE (WHERE
- * halted_at IS NULL) means a second trip does not overwrite the original
- * reason/actor or move the timestamp, and reports `tripped: false`.
+ * Engage the org's circuit breaker. Idempotent: an org already halted keeps its
+ * original reason/actor and timestamp and reports `tripped: false`.
+ *
+ * Runs under a `SELECT ... FOR UPDATE` so a concurrent reset cannot commit
+ * between the read and the write: the decision to trip and the write are one
+ * atomic step, so there is no window where an org that exists reads back as
+ * "not found". A genuinely missing org (no row) is the only case that throws.
+ *
+ * Deliberately not role-gated: tripping only PAUSES value movement, is fully
+ * reversible, and an org admin/owner can always recover via the admin reset
+ * endpoint even while halted. Erring toward letting any workflow stop the
+ * bleeding is the fail-safe choice; `haltedBy` records which workflow tripped it
+ * for attribution.
  */
 export async function tripOrgCircuitBreaker(params: {
   organizationId: string;
   reason?: string | null;
   byWorkflowId?: string | null;
 }): Promise<TripResult> {
-  const now = new Date();
+  return await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ haltedAt: organization.haltedAt })
+      .from(organization)
+      .where(eq(organization.id, params.organizationId))
+      .for("update")
+      .limit(1);
 
-  const [engaged] = await db
-    .update(organization)
-    .set({
-      haltedAt: now,
-      haltedReason: params.reason ?? null,
-      haltedBy: params.byWorkflowId ?? null,
-    })
-    .where(
-      and(
-        eq(organization.id, params.organizationId),
-        isNull(organization.haltedAt)
-      )
-    )
-    .returning({ haltedAt: organization.haltedAt });
+    if (!row) {
+      throw new Error("Organization not found");
+    }
+    if (row.haltedAt) {
+      return { tripped: false, haltedAt: row.haltedAt };
+    }
 
-  if (engaged?.haltedAt) {
-    return { tripped: true, haltedAt: engaged.haltedAt };
-  }
-
-  const [existing] = await db
-    .select({ haltedAt: organization.haltedAt })
-    .from(organization)
-    .where(eq(organization.id, params.organizationId))
-    .limit(1);
-
-  if (!existing?.haltedAt) {
-    throw new Error("Organization not found");
-  }
-  return { tripped: false, haltedAt: existing.haltedAt };
+    const now = new Date();
+    await tx
+      .update(organization)
+      .set({
+        haltedAt: now,
+        haltedReason: params.reason ?? null,
+        haltedBy: params.byWorkflowId ?? null,
+      })
+      .where(eq(organization.id, params.organizationId));
+    return { tripped: true, haltedAt: now };
+  });
 }
 
 export type ResetResult =

--- a/lib/execute/value-ledger.ts
+++ b/lib/execute/value-ledger.ts
@@ -7,6 +7,10 @@ import {
   organizationSpendCaps,
   orgValueReservations,
 } from "@/lib/db/schema-extensions";
+import {
+  isOrgHalted,
+  ORG_HALTED_REASON,
+} from "@/lib/execute/org-circuit-breaker";
 import { parseNodeNativeValueWei } from "@/lib/execute/reserved-value";
 import {
   getDefaultDailySolanaValueCapLamports,
@@ -243,6 +247,16 @@ export async function reserveOrgValue(
   params: ReserveParams
 ): Promise<ReserveResult> {
   return await db.transaction(async (tx) => {
+    if (await isOrgHalted(tx, params.organizationId)) {
+      logSecurityEvent("org_circuit_breaker_blocked", {
+        organizationId: params.organizationId,
+        surface: params.source ?? "value-ledger",
+        chainFamily: "evm",
+        reserved: params.valueWei,
+      });
+      return { allowed: false, reason: ORG_HALTED_REASON } as const;
+    }
+
     const cap = await lockOrgSpendCapRow(tx, params.organizationId);
 
     const usingDefault = cap.dailyValueCapWei === null;
@@ -301,6 +315,16 @@ export async function reserveOrgSolanaValue(
   params: ReserveSolanaParams
 ): Promise<ReserveResult> {
   return await db.transaction(async (tx) => {
+    if (await isOrgHalted(tx, params.organizationId)) {
+      logSecurityEvent("org_circuit_breaker_blocked", {
+        organizationId: params.organizationId,
+        surface: params.source ?? "value-ledger",
+        chainFamily: "solana",
+        reserved: params.valueLamports,
+      });
+      return { allowed: false, reason: ORG_HALTED_REASON } as const;
+    }
+
     const cap = await lockOrgSpendCapRow(tx, params.organizationId);
 
     const usingDefault = cap.dailySolanaValueCapLamports === null;

--- a/lib/features/system-action-capabilities.ts
+++ b/lib/features/system-action-capabilities.ts
@@ -25,6 +25,11 @@ export const SYSTEM_ACTION_EGRESS: Record<SystemActionType, EgressTier> = {
   Condition: "none",
   "For Each": "none",
   Collect: "none",
+  // Circuit-breaker actions: an in-process DB write scoped to the executing
+  // workflow's own org. No outbound network, no user-chosen destination, so
+  // they carry no egress and are not swept into the user-destination plan gate.
+  "Trip Circuit Breaker": "none",
+  "Reset Circuit Breaker": "none",
 };
 
 const SYSTEM_ACTION_TYPE_SET: ReadonlySet<string> = new Set(

--- a/lib/mcp/workflow-schema-constants.ts
+++ b/lib/mcp/workflow-schema-constants.ts
@@ -128,6 +128,38 @@ export const SYSTEM_ACTIONS = {
       count: "number - Number of iterations completed",
     },
   },
+  "Trip Circuit Breaker": {
+    actionType: "Trip Circuit Breaker",
+    label: "Trip Circuit Breaker",
+    description:
+      "Engage the organization's incident circuit breaker. Once tripped, every value-moving workflow and protocol step in the organization fails closed (per write, including runs already in progress) and no new runs start, until an admin or owner resets it. Read-only actions keep running. Use this as an incident kill switch: have a monitoring workflow trip it when it detects a problem. Always affects the organization that owns the running workflow - there is no target field.",
+    category: "System",
+    requiredFields: {},
+    optionalFields: {
+      reason:
+        "string - Free-text incident note recorded on the organization (e.g. why the breaker was tripped).",
+    },
+    outputFields: {
+      halted: "boolean - Always true; the breaker is engaged after this step.",
+      tripped:
+        "boolean - True if this step engaged the breaker; false if it was already engaged.",
+      haltedAt: "string - ISO timestamp the breaker was (or had been) engaged.",
+    },
+  },
+  "Reset Circuit Breaker": {
+    actionType: "Reset Circuit Breaker",
+    label: "Reset Circuit Breaker",
+    description:
+      "Clear the organization's incident circuit breaker so runs resume. Privileged: only succeeds when the workflow's creator is a current admin or owner of the organization; otherwise the step fails. Always affects the organization that owns the running workflow - there is no target field.",
+    category: "System",
+    requiredFields: {},
+    optionalFields: {},
+    outputFields: {
+      reset: "boolean - Always true on success; the breaker is cleared.",
+      wasHalted:
+        "boolean - True if the breaker had been engaged; false if it was already clear.",
+    },
+  },
 } as const;
 
 // =============================================================================

--- a/lib/workflow/executable.ts
+++ b/lib/workflow/executable.ts
@@ -44,7 +44,11 @@ export function workflowReachableConditions(): SQL {
   return and(
     workflowNotDeleted(),
     isNull(workflows.deactivatedAt),
-    isNull(organization.deactivatedAt)
+    isNull(organization.deactivatedAt),
+    // Org incident circuit breaker: a halted org dispatches no new runs. The
+    // per-write value gate (reserveOrgValue) is the authoritative stop for
+    // in-flight value moves; this keeps new runs from starting at all.
+    isNull(organization.haltedAt)
   ) as SQL;
 }
 
@@ -69,26 +73,37 @@ export type WorkflowExecutabilityInput = {
   // The owning org's deactivation timestamp. Org is the owner, so this is the
   // owner-deactivation gate (the creator user is not an authority).
   orgDeactivatedAt?: Date | null;
+  // The owning org's circuit-breaker timestamp. A reversible incident halt,
+  // ranked below the two permanent "gone" states and above `disabled`.
+  orgHaltedAt?: Date | null;
 };
 
 export type WorkflowExecutability =
   | { executable: true }
   | {
       executable: false;
-      reason: "deleted" | "deactivated" | "org_deactivated" | "disabled";
+      reason:
+        | "deleted"
+        | "deactivated"
+        | "org_deactivated"
+        | "halted"
+        | "disabled";
     };
 
 /**
  * In-memory gate for the fetch-then-gate sites. The reason lets callers map to
  * their existing HTTP semantics (the webhook surfaces "disabled" as 410 and
  * everything else as 404). Precedence is fixed here - deleted, then the two
- * "fully off" deactivation states, then disabled.
+ * "fully off" deactivation states, then the reversible incident halt, then
+ * disabled.
  *
- * `deactivated` and `org_deactivated` rank ABOVE `disabled` on purpose: a
- * workflow can be both deactivated and disabled, and the manual-execute path
- * lets `disabled` through (a disabled workflow is still runnable from the
- * editor) while a deactivated one must be blocked. Reporting the stronger
- * reason keeps that block intact. `deleted` still wins overall because a
+ * `deactivated`, `org_deactivated`, and `halted` all rank ABOVE `disabled` on
+ * purpose: a workflow can be both blocked and disabled, and the manual-execute
+ * path lets `disabled` through (a disabled workflow is still runnable from the
+ * editor) while a halted or deactivated one must be blocked even there.
+ * Reporting the stronger reason keeps that block intact. `halted` ranks below
+ * the deactivation states because those are permanent ops off-states while an
+ * incident halt is reversible. `deleted` still wins overall because a
  * soft-deleted workflow can still be enabled (`softDeleteValues()` clears
  * `isListed` but not `enabled`) and "gone" is the most accurate signal.
  */
@@ -103,6 +118,9 @@ export function getWorkflowExecutability(
   }
   if ((workflow.orgDeactivatedAt ?? null) !== null) {
     return { executable: false, reason: "org_deactivated" };
+  }
+  if ((workflow.orgHaltedAt ?? null) !== null) {
+    return { executable: false, reason: "halted" };
   }
   if (!workflow.enabled) {
     return { executable: false, reason: "disabled" };

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -136,6 +136,18 @@ const SYSTEM_ACTIONS = {
       import("@/lib/workflow/nodes/collect/step") as Promise<any>,
     stepFunction: "collectStep",
   },
+  "Trip Circuit Breaker": {
+    importer: () =>
+      // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import matches existing pattern
+      import("@/lib/workflow/nodes/circuit-breaker-trip/step") as Promise<any>,
+    stepFunction: "circuitBreakerTripStep",
+  },
+  "Reset Circuit Breaker": {
+    importer: () =>
+      // biome-ignore lint/suspicious/noExplicitAny: Dynamic module import matches existing pattern
+      import("@/lib/workflow/nodes/circuit-breaker-reset/step") as Promise<any>,
+    stepFunction: "circuitBreakerResetStep",
+  },
 } satisfies Record<SystemActionType, StepImporter>;
 
 export {

--- a/lib/workflow/executor/system-action-types.ts
+++ b/lib/workflow/executor/system-action-types.ts
@@ -12,6 +12,8 @@ export const SYSTEM_ACTION_TYPES = [
   "Condition",
   "For Each",
   "Collect",
+  "Trip Circuit Breaker",
+  "Reset Circuit Breaker",
 ] as const;
 
 export type SystemActionType = (typeof SYSTEM_ACTION_TYPES)[number];

--- a/lib/workflow/load-for-execution.ts
+++ b/lib/workflow/load-for-execution.ts
@@ -7,7 +7,12 @@ export type LoadWorkflowForExecutionResult =
   | { status: "not_found" }
   | {
       status: "not_executable";
-      reason: "deleted" | "deactivated" | "org_deactivated" | "disabled";
+      reason:
+        | "deleted"
+        | "deactivated"
+        | "org_deactivated"
+        | "halted"
+        | "disabled";
     }
   | {
       status: "ok";
@@ -36,6 +41,7 @@ export async function loadWorkflowForExecution(
     .select({
       workflow: workflows,
       orgDeactivatedAt: organization.deactivatedAt,
+      orgHaltedAt: organization.haltedAt,
       organizationName: organization.name,
     })
     .from(workflows)
@@ -52,6 +58,7 @@ export async function loadWorkflowForExecution(
     deletedAt: row.workflow.deletedAt,
     deactivatedAt: row.workflow.deactivatedAt,
     orgDeactivatedAt: row.orgDeactivatedAt ?? null,
+    orgHaltedAt: row.orgHaltedAt ?? null,
   });
 
   if (!executability.executable) {

--- a/lib/workflow/nodes/circuit-breaker-reset/step.ts
+++ b/lib/workflow/nodes/circuit-breaker-reset/step.ts
@@ -1,0 +1,64 @@
+/**
+ * Executable step function for the Reset Circuit Breaker action.
+ *
+ * Clears the executing workflow's own org circuit breaker so runs resume. This
+ * is privileged: it succeeds only when the workflow's creator is a current
+ * admin/owner of the org. A workflow created by a non-admin (or whose creator
+ * was later demoted) cannot auto-reset, and the denial fails the step loudly
+ * rather than silently leaving the breaker engaged.
+ */
+import "server-only";
+
+import { resetOrgCircuitBreaker } from "@/lib/execute/org-circuit-breaker";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+
+export type CircuitBreakerResetInput = StepInput;
+
+type CircuitBreakerResetResult = {
+  reset: true;
+  // False when the breaker was not engaged (idempotent no-op).
+  wasHalted: boolean;
+};
+
+type CircuitBreakerErrorResult = {
+  success: false;
+  error: string;
+};
+
+async function runReset(
+  input: CircuitBreakerResetInput
+): Promise<CircuitBreakerResetResult | CircuitBreakerErrorResult> {
+  const organizationId = input._context?.organizationId;
+  if (!organizationId) {
+    return {
+      success: false,
+      error: "Circuit breaker requires an organization context",
+    };
+  }
+
+  const result = await resetOrgCircuitBreaker({
+    organizationId,
+    requestedByUserId: input._context?.createdBy,
+  });
+
+  if (!result.reset) {
+    return {
+      success: false,
+      error:
+        "Only a workflow created by an organization admin or owner can reset the circuit breaker",
+    };
+  }
+
+  return { reset: true, wasHalted: result.wasHalted };
+}
+
+export function circuitBreakerResetStep(
+  input: CircuitBreakerResetInput
+): Promise<CircuitBreakerResetResult | CircuitBreakerErrorResult> {
+  "use step";
+  return withStepLogging(input, () => runReset(input));
+}
+circuitBreakerResetStep.maxRetries = 0;

--- a/lib/workflow/nodes/circuit-breaker-reset/step.ts
+++ b/lib/workflow/nodes/circuit-breaker-reset/step.ts
@@ -55,7 +55,8 @@ async function runReset(
   return { reset: true, wasHalted: result.wasHalted };
 }
 
-export function circuitBreakerResetStep(
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function circuitBreakerResetStep(
   input: CircuitBreakerResetInput
 ): Promise<CircuitBreakerResetResult | CircuitBreakerErrorResult> {
   "use step";

--- a/lib/workflow/nodes/circuit-breaker-trip/step.ts
+++ b/lib/workflow/nodes/circuit-breaker-trip/step.ts
@@ -56,7 +56,8 @@ async function runTrip(
   };
 }
 
-export function circuitBreakerTripStep(
+// biome-ignore lint/suspicious/useAwait: workflow "use step" requires async
+export async function circuitBreakerTripStep(
   input: CircuitBreakerTripInput
 ): Promise<CircuitBreakerTripResult | CircuitBreakerErrorResult> {
   "use step";

--- a/lib/workflow/nodes/circuit-breaker-trip/step.ts
+++ b/lib/workflow/nodes/circuit-breaker-trip/step.ts
@@ -1,0 +1,65 @@
+/**
+ * Executable step function for the Trip Circuit Breaker action.
+ *
+ * Engages the executing workflow's own org circuit breaker. From that moment
+ * every value-moving workflow/protocol step in the org fails closed at the
+ * value-ledger reservation gate and no new runs dispatch, until an admin/owner
+ * clears it. The org is taken from the execution context, never from config, so
+ * a workflow can only ever halt the org it runs under.
+ */
+import "server-only";
+
+import { tripOrgCircuitBreaker } from "@/lib/execute/org-circuit-breaker";
+import {
+  type StepInput,
+  withStepLogging,
+} from "@/lib/workflow/executor/step-handler";
+
+export type CircuitBreakerTripInput = StepInput & {
+  /** Optional free-text incident note recorded on the org. */
+  reason?: string;
+};
+
+type CircuitBreakerTripResult = {
+  halted: true;
+  // False when the breaker was already engaged (idempotent no-op).
+  tripped: boolean;
+  haltedAt: string;
+};
+
+type CircuitBreakerErrorResult = {
+  success: false;
+  error: string;
+};
+
+async function runTrip(
+  input: CircuitBreakerTripInput
+): Promise<CircuitBreakerTripResult | CircuitBreakerErrorResult> {
+  const organizationId = input._context?.organizationId;
+  if (!organizationId) {
+    return {
+      success: false,
+      error: "Circuit breaker requires an organization context",
+    };
+  }
+
+  const result = await tripOrgCircuitBreaker({
+    organizationId,
+    reason: input.reason ?? null,
+    byWorkflowId: input._context?.workflowId ?? null,
+  });
+
+  return {
+    halted: true,
+    tripped: result.tripped,
+    haltedAt: result.haltedAt.toISOString(),
+  };
+}
+
+export function circuitBreakerTripStep(
+  input: CircuitBreakerTripInput
+): Promise<CircuitBreakerTripResult | CircuitBreakerErrorResult> {
+  "use step";
+  return withStepLogging(input, () => runTrip(input));
+}
+circuitBreakerTripStep.maxRetries = 0;

--- a/lib/workflow/validation/action-config.ts
+++ b/lib/workflow/validation/action-config.ts
@@ -1,5 +1,6 @@
 import { ADDRESS_BOOK_SELECTION_KEY } from "@/lib/address-book-selection";
 import { evaluateShowWhen } from "@/lib/workflow/editor/show-when";
+import { SYSTEM_ACTION_TYPES as SYSTEM_ACTION_TYPE_LIST } from "@/lib/workflow/executor/system-action-types";
 import {
   type ActionConfigField,
   type ActionConfigFieldBase,
@@ -7,13 +8,9 @@ import {
   getAllActions,
 } from "@/plugins/registry";
 
-const SYSTEM_ACTION_TYPES = new Set([
-  "Database Query",
-  "HTTP Request",
-  "Condition",
-  "For Each",
-  "Collect",
-]);
+// Built from the shared union so this validator, the executor dispatch table,
+// and the egress map cannot drift apart when a system action is added.
+const SYSTEM_ACTION_TYPES = new Set<string>(SYSTEM_ACTION_TYPE_LIST);
 
 const RESERVED_CONFIG_KEYS = new Set([
   "actionType",

--- a/tests/e2e/vitest/org-circuit-breaker.test.ts
+++ b/tests/e2e/vitest/org-circuit-breaker.test.ts
@@ -163,6 +163,52 @@ describe.skipIf(SKIP)("org circuit breaker (db-backed)", () => {
     expect(await haltMetaOf(orgA)).toEqual({ reason: "first", by: "wf_1" });
   });
 
+  it("re-engages without throwing after a reset (org exists, currently not halted)", async () => {
+    await tripOrgCircuitBreaker({ organizationId: orgA });
+    await resetOrgCircuitBreaker({
+      organizationId: orgA,
+      requestedByUserId: userAdmin,
+    });
+
+    const again = await tripOrgCircuitBreaker({
+      organizationId: orgA,
+      reason: "second incident",
+    });
+
+    expect(again.tripped).toBe(true);
+    expect(await isOrgHalted(db, orgA)).toBe(true);
+    expect(await haltMetaOf(orgA)).toEqual({
+      reason: "second incident",
+      by: null,
+    });
+  });
+
+  it("serializes concurrent trips under a row lock: no throw, halted exactly once", async () => {
+    const [a, b] = await Promise.all([
+      tripOrgCircuitBreaker({
+        organizationId: orgA,
+        reason: "a",
+        byWorkflowId: "wf_a",
+      }),
+      tripOrgCircuitBreaker({
+        organizationId: orgA,
+        reason: "b",
+        byWorkflowId: "wf_b",
+      }),
+    ]);
+
+    // Exactly one call engaged the breaker; the other saw it already halted.
+    expect([a.tripped, b.tripped].sort()).toEqual([false, true]);
+    expect(a.haltedAt.getTime()).toBe(b.haltedAt.getTime());
+    expect(await isOrgHalted(db, orgA)).toBe(true);
+  });
+
+  it("throws only for a genuinely missing organization", async () => {
+    await expect(
+      tripOrgCircuitBreaker({ organizationId: `${PREFIX}nonexistent` })
+    ).rejects.toThrow("Organization not found");
+  });
+
   it("refuses a reset from a non-admin member and leaves the breaker engaged", async () => {
     await tripOrgCircuitBreaker({ organizationId: orgA });
 

--- a/tests/e2e/vitest/org-circuit-breaker.test.ts
+++ b/tests/e2e/vitest/org-circuit-breaker.test.ts
@@ -1,0 +1,240 @@
+import "dotenv/config";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// The modules under test are server-only; stub the guard for vitest.
+vi.mock("server-only", () => ({}));
+
+// tests/setup.ts globally mocks @/lib/db. This suite drives the real circuit
+// breaker and value-ledger code against a real database, so restore the module.
+vi.unmock("@/lib/db");
+
+import { db } from "@/lib/db";
+import { member, organization, users } from "@/lib/db/schema";
+import {
+  isOrgHalted,
+  ORG_HALTED_REASON,
+  resetOrgCircuitBreaker,
+  tripOrgCircuitBreaker,
+} from "@/lib/execute/org-circuit-breaker";
+import { reserveOrgValue } from "@/lib/execute/value-ledger";
+
+const SKIP =
+  !process.env.DATABASE_URL || process.env.SKIP_INFRA_TESTS === "true";
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+const PREFIX = "test_keep1328_cb_";
+
+describe.skipIf(SKIP)("org circuit breaker (db-backed)", () => {
+  let queryClient: ReturnType<typeof postgres>;
+  let seedDb: ReturnType<typeof drizzle>;
+
+  const userAdmin = `${PREFIX}admin`;
+  const userMember = `${PREFIX}member`;
+  const orgA = `${PREFIX}orgA`;
+  const orgB = `${PREFIX}orgB`;
+
+  async function haltedAtOf(orgId: string): Promise<Date | null> {
+    const rows = await queryClient`
+      SELECT halted_at FROM organization WHERE id = ${orgId} LIMIT 1
+    `;
+    return (rows[0]?.halted_at as Date | null) ?? null;
+  }
+
+  async function haltMetaOf(
+    orgId: string
+  ): Promise<{ reason: string | null; by: string | null }> {
+    const rows = await queryClient`
+      SELECT halted_reason, halted_by FROM organization WHERE id = ${orgId} LIMIT 1
+    `;
+    return {
+      reason: (rows[0]?.halted_reason as string | null) ?? null,
+      by: (rows[0]?.halted_by as string | null) ?? null,
+    };
+  }
+
+  async function cleanup(): Promise<void> {
+    await queryClient`DELETE FROM org_value_reservations WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization_spend_caps WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM member WHERE organization_id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM organization WHERE id LIKE ${`${PREFIX}%`}`;
+    await queryClient`DELETE FROM users WHERE id LIKE ${`${PREFIX}%`}`;
+  }
+
+  beforeAll(async () => {
+    queryClient = postgres(DATABASE_URL);
+    seedDb = drizzle(queryClient);
+    await cleanup();
+
+    await seedDb.insert(users).values([
+      {
+        id: userAdmin,
+        email: `${userAdmin}@keep1328.test`,
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: userMember,
+        email: `${userMember}@keep1328.test`,
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+    await seedDb.insert(organization).values([
+      { id: orgA, name: orgA, slug: orgA, createdAt: new Date() },
+      { id: orgB, name: orgB, slug: orgB, createdAt: new Date() },
+    ]);
+    await seedDb.insert(member).values([
+      {
+        id: `${PREFIX}m_admin`,
+        organizationId: orgA,
+        userId: userAdmin,
+        role: "admin",
+        createdAt: new Date(),
+      },
+      {
+        id: `${PREFIX}m_member`,
+        organizationId: orgA,
+        userId: userMember,
+        role: "member",
+        createdAt: new Date(),
+      },
+    ]);
+  });
+
+  beforeEach(async () => {
+    await queryClient`
+      UPDATE organization
+      SET halted_at = NULL, halted_reason = NULL, halted_by = NULL
+      WHERE id LIKE ${`${PREFIX}%`}
+    `;
+    await queryClient`DELETE FROM org_value_reservations WHERE organization_id LIKE ${`${PREFIX}%`}`;
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await queryClient.end();
+  });
+
+  it("trips only the target org (cross-org isolation) and records reason/actor", async () => {
+    const result = await tripOrgCircuitBreaker({
+      organizationId: orgA,
+      reason: "spend anomaly",
+      byWorkflowId: "wf_monitor",
+    });
+
+    expect(result.tripped).toBe(true);
+    expect(await haltedAtOf(orgA)).not.toBeNull();
+    expect(await haltedAtOf(orgB)).toBeNull();
+    expect(await haltMetaOf(orgA)).toEqual({
+      reason: "spend anomaly",
+      by: "wf_monitor",
+    });
+
+    expect(await isOrgHalted(db, orgA)).toBe(true);
+    expect(await isOrgHalted(db, orgB)).toBe(false);
+  });
+
+  it("is idempotent: a second trip does not move the timestamp or overwrite reason/actor", async () => {
+    const first = await tripOrgCircuitBreaker({
+      organizationId: orgA,
+      reason: "first",
+      byWorkflowId: "wf_1",
+    });
+    const second = await tripOrgCircuitBreaker({
+      organizationId: orgA,
+      reason: "second",
+      byWorkflowId: "wf_2",
+    });
+
+    expect(first.tripped).toBe(true);
+    expect(second.tripped).toBe(false);
+    expect(second.haltedAt.getTime()).toBe(first.haltedAt.getTime());
+    expect(await haltMetaOf(orgA)).toEqual({ reason: "first", by: "wf_1" });
+  });
+
+  it("refuses a reset from a non-admin member and leaves the breaker engaged", async () => {
+    await tripOrgCircuitBreaker({ organizationId: orgA });
+
+    const result = await resetOrgCircuitBreaker({
+      organizationId: orgA,
+      requestedByUserId: userMember,
+    });
+
+    expect(result).toEqual({ reset: false, reason: "not_authorized" });
+    expect(await isOrgHalted(db, orgA)).toBe(true);
+  });
+
+  it("refuses a reset from a non-member and from a missing principal", async () => {
+    await tripOrgCircuitBreaker({ organizationId: orgA });
+
+    expect(
+      await resetOrgCircuitBreaker({
+        organizationId: orgA,
+        requestedByUserId: `${PREFIX}stranger`,
+      })
+    ).toEqual({ reset: false, reason: "not_authorized" });
+    expect(
+      await resetOrgCircuitBreaker({
+        organizationId: orgA,
+        requestedByUserId: undefined,
+      })
+    ).toEqual({ reset: false, reason: "not_authorized" });
+    expect(await isOrgHalted(db, orgA)).toBe(true);
+  });
+
+  it("clears the breaker on an admin reset and is idempotent when already clear", async () => {
+    await tripOrgCircuitBreaker({ organizationId: orgA });
+
+    const cleared = await resetOrgCircuitBreaker({
+      organizationId: orgA,
+      requestedByUserId: userAdmin,
+    });
+    expect(cleared).toEqual({ reset: true, wasHalted: true });
+    expect(await isOrgHalted(db, orgA)).toBe(false);
+    expect(await haltMetaOf(orgA)).toEqual({ reason: null, by: null });
+
+    const again = await resetOrgCircuitBreaker({
+      organizationId: orgA,
+      requestedByUserId: userAdmin,
+    });
+    expect(again).toEqual({ reset: true, wasHalted: false });
+  });
+
+  it("fails a value-moving reservation closed once the org is halted mid-run, per write", async () => {
+    // First step of a run: the org is live, so a small value move is allowed.
+    const before = await reserveOrgValue({
+      organizationId: orgA,
+      valueWei: "100",
+    });
+    expect(before.allowed).toBe(true);
+
+    // The breaker trips between steps (e.g. a sibling monitor workflow fires).
+    await tripOrgCircuitBreaker({ organizationId: orgA });
+
+    // The next value-moving step of the same run fails closed, before any cap
+    // math, regardless of remaining headroom.
+    const after = await reserveOrgValue({
+      organizationId: orgA,
+      valueWei: "100",
+    });
+    expect(after).toEqual({ allowed: false, reason: ORG_HALTED_REASON });
+
+    // A different, un-halted org is unaffected.
+    const other = await reserveOrgValue({
+      organizationId: orgB,
+      valueWei: "100",
+    });
+    expect(other.allowed).toBe(true);
+  });
+});

--- a/tests/integration/circuit-breaker-reset-route.test.ts
+++ b/tests/integration/circuit-breaker-reset-route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getOrgContext: vi.fn(),
+  hasPermission: vi.fn(),
+  resetOrgCircuitBreaker: vi.fn(),
+  recordAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/middleware/org-context", () => ({
+  getOrgContext: (...args: unknown[]) => mocks.getOrgContext(...args),
+  getActiveOrgId: vi.fn(),
+  hasPermission: (...args: unknown[]) => mocks.hasPermission(...args),
+}));
+
+vi.mock("@/lib/execute/org-circuit-breaker", () => ({
+  resetOrgCircuitBreaker: (...args: unknown[]) =>
+    mocks.resetOrgCircuitBreaker(...args),
+}));
+
+vi.mock("@/lib/security/audit-log", () => ({
+  recordAuditEvent: (...args: unknown[]) => mocks.recordAuditEvent(...args),
+  buildAuditMetadata: () => ({}),
+}));
+
+import { POST } from "@/app/api/organizations/circuit-breaker/reset/route";
+
+const ORG_ID = "org-1";
+const USER_ID = "user-1";
+
+function postRequest(): Parameters<typeof POST>[0] {
+  return new Request(
+    "http://localhost/api/organizations/circuit-breaker/reset",
+    {
+      method: "POST",
+    }
+  ) as Parameters<typeof POST>[0];
+}
+
+function authedContext(role = "admin"): Record<string, unknown> {
+  return {
+    user: { id: USER_ID, email: "a@example.com", name: "A", image: null },
+    organization: { id: ORG_ID, name: "Org", createdAt: new Date() },
+    member: {
+      id: "m-1",
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      role,
+      createdAt: new Date(),
+    },
+    isAnonymous: false,
+    needsOrganization: false,
+  };
+}
+
+const ANONYMOUS = {
+  user: null,
+  organization: null,
+  member: null,
+  isAnonymous: true,
+  needsOrganization: false,
+};
+
+describe("POST /api/organizations/circuit-breaker/reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrgContext.mockResolvedValue(authedContext());
+    mocks.hasPermission.mockResolvedValue(true);
+    mocks.resetOrgCircuitBreaker.mockResolvedValue({
+      reset: true,
+      wasHalted: true,
+    });
+  });
+
+  it("rejects a request with no org session (e.g. a kh_ API key) with 401", async () => {
+    // getOrgContext resolves the better-auth session only; a kh_ key carries no
+    // session, so it surfaces here as anonymous and never reaches the reset.
+    mocks.getOrgContext.mockResolvedValue(ANONYMOUS);
+
+    const res = await POST(postRequest());
+
+    expect(res.status).toBe(401);
+    expect(mocks.resetOrgCircuitBreaker).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the caller lacks organization:update (e.g. a member)", async () => {
+    mocks.getOrgContext.mockResolvedValue(authedContext("member"));
+    mocks.hasPermission.mockResolvedValue(false);
+
+    const res = await POST(postRequest());
+
+    expect(res.status).toBe(403);
+    expect(mocks.hasPermission).toHaveBeenCalledWith("organization", [
+      "update",
+    ]);
+    expect(mocks.resetOrgCircuitBreaker).not.toHaveBeenCalled();
+  });
+
+  it("clears the breaker for an admin and returns 200 with the prior state", async () => {
+    const res = await POST(postRequest());
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reset: true, wasHalted: true });
+    expect(mocks.resetOrgCircuitBreaker).toHaveBeenCalledWith({
+      organizationId: ORG_ID,
+      requestedByUserId: USER_ID,
+    });
+    expect(mocks.recordAuditEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 if the deeper role check denies the reset", async () => {
+    mocks.resetOrgCircuitBreaker.mockResolvedValue({
+      reset: false,
+      reason: "not_authorized",
+    });
+
+    const res = await POST(postRequest());
+
+    expect(res.status).toBe(403);
+    expect(mocks.recordAuditEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/workflow-execute-halted-route.test.ts
+++ b/tests/integration/workflow-execute-halted-route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  authenticateInternalService: vi.fn(),
+  loadWorkflowForExecution: vi.fn(),
+}));
+
+// No internal-service auth -> the route treats it as an interactive call and
+// evaluates lifecycle via loadWorkflowForExecution, which we control.
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: (...args: unknown[]) =>
+    mocks.authenticateInternalService(...args),
+}));
+
+vi.mock("@/lib/workflow/load-for-execution", () => ({
+  loadWorkflowForExecution: (...args: unknown[]) =>
+    mocks.loadWorkflowForExecution(...args),
+}));
+
+import { POST } from "@/app/api/workflow/[workflowId]/execute/route";
+
+function postRequest() {
+  return new Request("http://localhost/api/workflow/wf-1/execute", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+}
+
+const context = { params: Promise.resolve({ workflowId: "wf-1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authenticateInternalService.mockResolvedValue({ authenticated: false });
+});
+
+describe("POST /api/workflow/[workflowId]/execute lifecycle mapping", () => {
+  it("returns 503 (not 404) when the owning org is halted", async () => {
+    mocks.loadWorkflowForExecution.mockResolvedValue({
+      status: "not_executable",
+      reason: "halted",
+    });
+
+    const res = await POST(postRequest(), context);
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "Workflow temporarily halted" });
+  });
+
+  it("still returns 404 for a genuinely missing workflow", async () => {
+    mocks.loadWorkflowForExecution.mockResolvedValue({ status: "not_found" });
+
+    const res = await POST(postRequest(), context);
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/unit/circuit-breaker-registration.test.ts
+++ b/tests/unit/circuit-breaker-registration.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { resolveActionFeature } from "@/lib/features/action-egress";
+import { getFeatureForActionType } from "@/lib/features/registry";
+import { getSystemActionEgress } from "@/lib/features/system-action-capabilities";
+import { SYSTEM_ACTIONS } from "@/lib/mcp/workflow-schema-constants";
+import { SYSTEM_ACTION_TYPES } from "@/lib/workflow/executor/system-action-types";
+import { validateWorkflowActionConfigs } from "@/lib/workflow/validation/action-config";
+
+const CIRCUIT_BREAKER_ACTIONS = [
+  "Trip Circuit Breaker",
+  "Reset Circuit Breaker",
+] as const;
+
+describe("circuit-breaker action registration", () => {
+  it.each(CIRCUIT_BREAKER_ACTIONS)(
+    "%s is a registered system action in the shared union and the schema catalog",
+    (actionType) => {
+      expect(SYSTEM_ACTION_TYPES).toContain(actionType);
+      expect(SYSTEM_ACTIONS).toHaveProperty(actionType);
+    }
+  );
+
+  it.each(CIRCUIT_BREAKER_ACTIONS)(
+    "%s carries no network egress (internal in-process action)",
+    (actionType) => {
+      expect(getSystemActionEgress(actionType)).toBe("none");
+    }
+  );
+
+  it.each(CIRCUIT_BREAKER_ACTIONS)(
+    "%s is not plan-gated, so a free-plan workflow may use it",
+    (actionType) => {
+      // No explicit feature, and egress is not user-destination, so neither the
+      // direct feature map nor the external-request catch-all gates it.
+      expect(getFeatureForActionType(actionType)).toBeUndefined();
+      expect(resolveActionFeature(actionType)).toBeUndefined();
+    }
+  );
+});
+
+describe("validateWorkflowActionConfigs with a circuit-breaker node", () => {
+  it("accepts a Trip Circuit Breaker action node (not an unknown action type)", () => {
+    const result = validateWorkflowActionConfigs([
+      {
+        id: "trip-1",
+        type: "action",
+        data: {
+          type: "action",
+          label: "Trip Circuit Breaker",
+          config: { actionType: "Trip Circuit Breaker", reason: "incident" },
+        },
+      },
+    ]);
+
+    expect(result.valid).toBe(true);
+    expect(
+      result.issues.some((issue) => issue.code === "UNKNOWN_ACTION_TYPE")
+    ).toBe(false);
+  });
+
+  it("accepts a Reset Circuit Breaker action node", () => {
+    const result = validateWorkflowActionConfigs([
+      {
+        id: "reset-1",
+        type: "action",
+        data: {
+          type: "action",
+          label: "Reset Circuit Breaker",
+          config: { actionType: "Reset Circuit Breaker" },
+        },
+      },
+    ]);
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/tests/unit/circuit-breaker-steps.test.ts
+++ b/tests/unit/circuit-breaker-steps.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Server-only guard module loads "server-only"; stub it for vitest.
+vi.mock("server-only", () => ({}));
+
+const { mockTrip, mockReset, mockWithStepLogging } = vi.hoisted(() => ({
+  mockTrip: vi.fn(),
+  mockReset: vi.fn(),
+  // Passthrough: run the step logic directly without the DB logging epilogue.
+  mockWithStepLogging: vi.fn(
+    (_input: unknown, fn: () => unknown) => fn() as unknown
+  ),
+}));
+
+vi.mock("@/lib/execute/org-circuit-breaker", () => ({
+  tripOrgCircuitBreaker: (...args: unknown[]) => mockTrip(...args),
+  resetOrgCircuitBreaker: (...args: unknown[]) => mockReset(...args),
+}));
+
+vi.mock("@/lib/workflow/executor/step-handler", () => ({
+  withStepLogging: (...args: unknown[]) =>
+    mockWithStepLogging(...(args as [unknown, () => unknown])),
+}));
+
+import { circuitBreakerResetStep } from "@/lib/workflow/nodes/circuit-breaker-reset/step";
+import { circuitBreakerTripStep } from "@/lib/workflow/nodes/circuit-breaker-trip/step";
+
+const HALTED_AT = new Date("2026-01-02T03:04:05.000Z");
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    nodeId: "cb-1",
+    nodeName: "Circuit Breaker",
+    nodeType: "Trip Circuit Breaker",
+    organizationId: "org_ctx",
+    workflowId: "wf_1",
+    createdBy: "user_creator",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("circuitBreakerTripStep", () => {
+  it("trips the org from the execution context, not from config, and never targets another org", async () => {
+    mockTrip.mockResolvedValue({ tripped: true, haltedAt: HALTED_AT });
+
+    const result = await circuitBreakerTripStep({
+      reason: "spend anomaly",
+      // A stray config-injected org id must be ignored: the step can only ever
+      // halt the org it runs under, so there is no cross-org path.
+      organizationId: "org_evil",
+      _context: context(),
+    } as Parameters<typeof circuitBreakerTripStep>[0]);
+
+    expect(mockTrip).toHaveBeenCalledWith({
+      organizationId: "org_ctx",
+      reason: "spend anomaly",
+      byWorkflowId: "wf_1",
+    });
+    expect(result).toEqual({
+      halted: true,
+      tripped: true,
+      haltedAt: HALTED_AT.toISOString(),
+    });
+  });
+
+  it("reports tripped=false when the breaker was already engaged (idempotent)", async () => {
+    mockTrip.mockResolvedValue({ tripped: false, haltedAt: HALTED_AT });
+
+    const result = await circuitBreakerTripStep({ _context: context() });
+
+    expect(result).toEqual({
+      halted: true,
+      tripped: false,
+      haltedAt: HALTED_AT.toISOString(),
+    });
+  });
+
+  it("fails the step when there is no organization context", async () => {
+    const result = await circuitBreakerTripStep({
+      _context: context({ organizationId: undefined }),
+    });
+
+    expect(mockTrip).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Circuit breaker requires an organization context",
+    });
+  });
+});
+
+describe("circuitBreakerResetStep", () => {
+  it("resets the org from context, passing the workflow creator as the privileged principal", async () => {
+    mockReset.mockResolvedValue({ reset: true, wasHalted: true });
+
+    const result = await circuitBreakerResetStep({ _context: context() });
+
+    expect(mockReset).toHaveBeenCalledWith({
+      organizationId: "org_ctx",
+      requestedByUserId: "user_creator",
+    });
+    expect(result).toEqual({ reset: true, wasHalted: true });
+  });
+
+  it("fails the step loudly when the creator is not an org admin/owner", async () => {
+    mockReset.mockResolvedValue({ reset: false, reason: "not_authorized" });
+
+    const result = await circuitBreakerResetStep({ _context: context() });
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Only a workflow created by an organization admin or owner can reset the circuit breaker",
+    });
+  });
+
+  it("fails the step when there is no organization context", async () => {
+    const result = await circuitBreakerResetStep({
+      _context: context({ organizationId: undefined }),
+    });
+
+    expect(mockReset).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: false,
+      error: "Circuit breaker requires an organization context",
+    });
+  });
+});

--- a/tests/unit/direct-execution-halt.test.ts
+++ b/tests/unit/direct-execution-halt.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// PAYG settlement runs after a successful reservation; make it a no-op so the
+// zero-value (read) case does not touch billing.
+vi.mock("@/lib/billing/payg/charge", () => ({
+  chargePaygIfBillable: () => Promise.resolve({ applicable: false }),
+}));
+
+const state = vi.hoisted(() => ({
+  orgHaltedAt: null as Date | null,
+  inserted: [] as Record<string, unknown>[],
+}));
+
+// Fake db: the halted read is a select whose columns include "haltedAt"; the
+// direct-execution reservation is an insert whose values() is awaited directly.
+vi.mock("@/lib/db", () => ({
+  db: {
+    transaction: (cb: (tx: unknown) => unknown) => {
+      const tx = {
+        select: (fields: Record<string, unknown>) => {
+          const columns = Object.keys(fields ?? {});
+          if (columns.includes("haltedAt")) {
+            return {
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([{ haltedAt: state.orgHaltedAt }]),
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected select columns: ${columns.join(",")}`);
+        },
+        insert: () => ({
+          values: (v: Record<string, unknown>) => {
+            state.inserted.push(v);
+            return Promise.resolve(undefined);
+          },
+        }),
+      };
+      return cb(tx);
+    },
+  },
+}));
+
+import { checkAndReserveExecution } from "@/app/api/execute/_lib/spending-cap";
+import { ORG_HALTED_REASON } from "@/lib/execute/org-circuit-breaker";
+
+const BASE = {
+  organizationId: "org_1",
+  apiKeyId: "kh_test",
+  type: "transfer",
+  input: {},
+  paygOverflow: false,
+} as const;
+
+beforeEach(() => {
+  state.orgHaltedAt = null;
+  state.inserted = [];
+});
+
+describe("checkAndReserveExecution circuit breaker", () => {
+  it("fails a value-moving direct execution closed while the org is halted, with no reservation", async () => {
+    state.orgHaltedAt = new Date();
+
+    const result = await checkAndReserveExecution({
+      ...BASE,
+      reserved: { kind: "evm", valueWei: "100" },
+    });
+
+    expect(result).toEqual({ allowed: false, reason: ORG_HALTED_REASON });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("fails a value-moving Solana direct execution closed while the org is halted", async () => {
+    state.orgHaltedAt = new Date();
+
+    const result = await checkAndReserveExecution({
+      ...BASE,
+      reserved: { kind: "solana", valueLamports: "100" },
+    });
+
+    expect(result).toEqual({ allowed: false, reason: ORG_HALTED_REASON });
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it("lets a zero-value (read) direct execution through even while halted", async () => {
+    state.orgHaltedAt = new Date();
+
+    const result = await checkAndReserveExecution({
+      ...BASE,
+      reserved: { kind: "evm", valueWei: "0" },
+    });
+
+    expect(result).toMatchObject({ allowed: true });
+    expect(state.inserted).toHaveLength(1);
+  });
+});

--- a/tests/unit/spending-cap.test.ts
+++ b/tests/unit/spending-cap.test.ts
@@ -50,6 +50,17 @@ vi.mock("@/lib/db", () => ({
       const tx = {
         select: (fields: Record<string, unknown>) => {
           const columns = Object.keys(fields ?? {});
+          // isOrgHalted's read: {haltedAt} from organization, .where().limit(1).
+          // These cases are never halted; the halt path has its own test file.
+          if (columns.includes("haltedAt")) {
+            return {
+              from: () => ({
+                where: () => ({
+                  limit: () => Promise.resolve([{ haltedAt: null }]),
+                }),
+              }),
+            };
+          }
           if (
             columns.includes("dailyValueCapWei") ||
             columns.includes("dailySolanaValueCapLamports")

--- a/tests/unit/validate-workflow-structural.test.ts
+++ b/tests/unit/validate-workflow-structural.test.ts
@@ -126,7 +126,7 @@ describe("TRIGGERS exports", () => {
 });
 
 describe("SYSTEM_ACTIONS exports", () => {
-  it("has exactly the 5 expected system action keys", () => {
+  it("has exactly the 7 expected system action keys", () => {
     const keys = Object.keys(SYSTEM_ACTIONS).sort();
     expect(keys).toEqual([
       "Collect",
@@ -134,6 +134,8 @@ describe("SYSTEM_ACTIONS exports", () => {
       "Database Query",
       "For Each",
       "HTTP Request",
+      "Reset Circuit Breaker",
+      "Trip Circuit Breaker",
     ]);
   });
 });

--- a/tests/unit/value-ledger.test.ts
+++ b/tests/unit/value-ledger.test.ts
@@ -23,6 +23,8 @@ const state = vi.hoisted(() => ({
   updates: [] as Record<string, unknown>[],
   returningId: "res_1",
   reserveKind: "evm" as "evm" | "solana",
+  // Org circuit-breaker state served to isOrgHalted's read. Null = not halted.
+  orgHaltedAt: null as Date | null,
 }));
 
 // A cap-row insert carries nothing but the org id: lockOrgSpendCapRow creates
@@ -53,6 +55,18 @@ vi.mock("@/lib/db", () => ({
                   for: () => ({
                     limit: () => Promise.resolve(state.caps),
                   }),
+                }),
+              }),
+            };
+          }
+          // isOrgHalted's read: runs first in the transaction. Not counted as a
+          // SUM call so the two cap SUM selects keep their call ordering.
+          if (columns.includes("haltedAt")) {
+            return {
+              from: () => ({
+                where: () => ({
+                  limit: () =>
+                    Promise.resolve([{ haltedAt: state.orgHaltedAt }]),
                 }),
               }),
             };
@@ -120,6 +134,7 @@ vi.mock("@/lib/db", () => ({
   },
 }));
 
+import { ORG_HALTED_REASON } from "@/lib/execute/org-circuit-breaker";
 import {
   getDefaultDailySolanaValueCapLamports,
   getDefaultDailyValueCapWei,
@@ -149,6 +164,7 @@ beforeEach(() => {
   state.updates = [];
   state.returningId = "res_1";
   state.reserveKind = "evm";
+  state.orgHaltedAt = null;
 });
 
 describe("reserveOrgValue", () => {
@@ -231,6 +247,23 @@ describe("reserveOrgValue", () => {
       reason: "Daily spending cap exceeded",
     });
     expect(state.inserted).toHaveLength(0);
+  });
+
+  it("denies with the halt reason when the org circuit breaker is engaged, regardless of cap or usage", async () => {
+    state.orgHaltedAt = new Date();
+    // Generous cap and zero usage: a cap check would allow this. The halt must
+    // deny anyway, and before the cap row is even locked (no anchor created).
+    state.caps = [{ dailyValueCapWei: "1000000000000000000000" }];
+    state.directSum = [{ totalWei: "0" }];
+
+    const result = await reserveOrgValue({
+      organizationId: "org_1",
+      valueWei: "300",
+    });
+
+    expect(result).toEqual({ allowed: false, reason: ORG_HALTED_REASON });
+    expect(state.inserted).toHaveLength(0);
+    expect(state.capAnchors).toHaveLength(0);
   });
 
   it("creates the cap row so the FOR UPDATE lock has something to hold", async () => {
@@ -619,6 +652,23 @@ describe("reserveOrgSolanaValue", () => {
       reason: "Daily Solana spending cap exceeded",
     });
     expect(state.inserted).toHaveLength(0);
+  });
+
+  it("denies with the halt reason when the org circuit breaker is engaged, regardless of cap or usage", async () => {
+    state.orgHaltedAt = new Date();
+    state.caps = [
+      { dailyValueCapWei: null, dailySolanaValueCapLamports: "1000000000000" },
+    ];
+    state.directLamportsSum = [{ totalLamports: "0" }];
+
+    const result = await reserveOrgSolanaValue({
+      organizationId: "org_1",
+      valueLamports: ONE_SOL_LAMPORTS,
+    });
+
+    expect(result).toEqual({ allowed: false, reason: ORG_HALTED_REASON });
+    expect(state.inserted).toHaveLength(0);
+    expect(state.capAnchors).toHaveLength(0);
   });
 });
 

--- a/tests/unit/workflow-executable.test.ts
+++ b/tests/unit/workflow-executable.test.ts
@@ -12,7 +12,11 @@ vi.mock("@/lib/db/schema", () => ({
     organizationId: "organization_id",
     userId: "user_id",
   },
-  organization: { id: "id", deactivatedAt: "deactivated_at" },
+  organization: {
+    id: "id",
+    deactivatedAt: "deactivated_at",
+    haltedAt: "halted_at",
+  },
 }));
 
 import {
@@ -108,6 +112,49 @@ describe("getWorkflowExecutability", () => {
         orgDeactivatedAt: new Date(),
       })
     ).toEqual({ executable: false, reason: "org_deactivated" });
+  });
+
+  it("reports 'halted' when the owning org's circuit breaker is engaged", () => {
+    expect(
+      getWorkflowExecutability({
+        enabled: true,
+        deletedAt: null,
+        deactivatedAt: null,
+        orgDeactivatedAt: null,
+        orgHaltedAt: new Date(),
+      })
+    ).toEqual({ executable: false, reason: "halted" });
+  });
+
+  it("prefers 'halted' over 'disabled' so a disabled workflow in a halted org reports the incident", () => {
+    expect(
+      getWorkflowExecutability({
+        enabled: false,
+        orgHaltedAt: new Date(),
+      })
+    ).toEqual({ executable: false, reason: "halted" });
+  });
+
+  it("prefers 'org_deactivated' over 'halted' because deactivation is the permanent state", () => {
+    expect(
+      getWorkflowExecutability({
+        enabled: true,
+        orgDeactivatedAt: new Date(),
+        orgHaltedAt: new Date(),
+      })
+    ).toEqual({ executable: false, reason: "org_deactivated" });
+  });
+
+  it("is executable when the org halt is cleared (null) and otherwise live", () => {
+    expect(
+      getWorkflowExecutability({
+        enabled: true,
+        deletedAt: null,
+        deactivatedAt: null,
+        orgDeactivatedAt: null,
+        orgHaltedAt: null,
+      })
+    ).toEqual({ executable: true });
   });
 
   it("reports 'disabled' when not enabled and otherwise live", () => {


### PR DESCRIPTION
## What

Adds a native org-level **circuit breaker** so an incident can halt value-moving workflows per-write, mid-run — without the on-chain-sentinel workaround an agent evaluation (KEEP-1328) had to build for lack of a platform primitive.

- **Schema:** `halted_at` / `halted_reason` / `halted_by` on `organization` (migration `0151`, hand-authored per the repo convention; validated by running the full `drizzle-kit migrate` against a clean DB).
- **Enforcement (value gate):** `reserveOrgValue` / `reserveOrgSolanaValue` check the org halt first, inside the reservation transaction, and return `{allowed:false, reason: ORG_HALTED_REASON}` regardless of cap/usage. Value-0 steps never reach the gate, so read-only / notification steps keep running.
- **Dispatch gate:** `workflowReachableConditions()` adds `isNull(organization.haltedAt)`; `getWorkflowExecutability` gains a `halted` reason; the webhook route maps it to 503 — so no new runs dispatch while halted.
- **Trigger:** two new **free** system actions, `Trip Circuit Breaker` and `Reset Circuit Breaker`. Free because they are internal, own-org DB writes (egress `none`), not pro-gated egress actions — so a free-plan workflow can trip on an incident signal.
- **Shared core:** `lib/execute/org-circuit-breaker.ts` (`isOrgHalted`, idempotent `tripOrgCircuitBreaker`, role-gated `resetOrgCircuitBreaker`).

Org id always comes from `_context.organizationId` (never config), so there is no cross-org target and no way to trip another org.

## Authz

- **Trip:** any workflow, own org only (reversible, fail-safe — only *pauses*).
- **Reset:** requires the principal (`_context.createdBy`) to be a current org `admin`/`owner`; a non-admin-owned or demoted-creator workflow can't auto-reset.
- Human REST paths and the spend-cap PUT are untouched (session + org permission, still rejecting API keys). No `kh_`-key trip/reset endpoint was added.

## Tests

Run in a `node:22` container against an isolated scratch Postgres (the shared dev DB was never used). All passing:
- `tsc --noEmit`: 0 errors · `biome check`: clean (18 files)
- 67 tests across 5 files: value-ledger halt (EVM + Solana), `getWorkflowExecutability` precedence, Trip/Reset step wiring (own-org-only, reset-denial), registration / egress / free-plan-not-gated, and a db-backed suite covering cross-org isolation, reset authz, trip idempotency, and the **mid-run per-write halt** (reserve allowed → trip → next reserve fails closed; other org unaffected).

## Design note

`halted_at` is read **fresh** in the reservation transaction (not cached): a TTL cache on a kill switch would reintroduce the "value keeps moving during the incident window" failure the feature exists to prevent. Cost is one indexed PK read on a path that already runs a locking txn.

## Follow-ups (not in this PR)

1. **Direct-execution path** — this gates the workflow/protocol value path (`reserveOrgValue`). The direct MCP/REST `execute_*` path (`checkAndReserveExecution`) is a separate value entrance and is **not** halted here; a one-line `isOrgHalted` add would make the breaker comprehensive. Flagging for a scope decision.
2. **Human UI/REST** — the primitive is workflow/MCP-invokable but has no visual-builder palette/config or human-facing Trip/Reset UI yet; a tripped breaker currently clears via an admin-owned Reset workflow. Should land before this is fully usable by humans.