### PR TITLE
docs: protocol writes return a 202 executionId envelope; drop fabricated id prefixes

### DIFF
--- a/docs/agent/mcp-get-execution.md
+++ b/docs/agent/mcp-get-execution.md
@@ -13,7 +13,7 @@ description: "The response shape of the get_execution MCP tool: the nested statu
 {
   "tool": "get_execution",
   "arguments": {
-    "executionId": "exec_abc123"
+    "executionId": "pbp1zfywpli532cykjobk"
   }
 }
 ```
@@ -60,8 +60,8 @@ description: "The response shape of the get_execution MCP tool: the nested statu
   },
   "logs": {
     "execution": {
-      "id": "exec_abc123",
-      "workflowId": "wf_456",
+      "id": "pbp1zfywpli532cykjobk",
+      "workflowId": "3l2m4fzvbq3ekj2q69e76",
       "status": "success",
       "totalSteps": "2",
       "completedSteps": "2",

--- a/docs/api/analytics.md
+++ b/docs/api/analytics.md
@@ -131,9 +131,9 @@ Returns a unified list of both workflow executions and direct executions with pa
 {
   "runs": [
     {
-      "id": "exec_123",
+      "id": "hjsuassmcb19zvfpzi38r",
       "source": "workflow",
-      "workflowId": "wf_456",
+      "workflowId": "y3y0xneior3njl90uoyih",
       "workflowName": "Monitor ETH Balance",
       "status": "success",
       "createdAt": "2024-01-01T00:00:00Z",
@@ -141,7 +141,7 @@ Returns a unified list of both workflow executions and direct executions with pa
       "durationMs": 5000
     },
     {
-      "id": "direct_789",
+      "id": "9k2x7mwqcp5zvt0hnj1ab",
       "source": "direct",
       "type": "transfer",
       "network": "ethereum",

--- a/docs/api/direct-execution.md
+++ b/docs/api/direct-execution.md
@@ -335,7 +335,7 @@ Successful broadcast requests return HTTP `202 Accepted`:
 
 ```json
 {
-  "executionId": "direct_123",
+  "executionId": "n3364uzl2s6aram5v558c",
   "status": "completed",
   "transactionHash": "0x...",
   "transactionLink": "https://etherscan.io/tx/0x..."
@@ -421,7 +421,7 @@ Read functions return immediately with the result value.
 
 ```json
 {
-  "executionId": "direct_123",
+  "executionId": "n3364uzl2s6aram5v558c",
   "status": "completed",
   "transactionHash": "0x...",
   "transactionLink": "https://etherscan.io/tx/0x..."
@@ -471,7 +471,7 @@ the write step produced one (including on revert).
 
 ```json
 {
-  "executionId": "direct_123",
+  "executionId": "n3364uzl2s6aram5v558c",
   "status": "failed",
   "transactionHash": "0x...",
   "transactionLink": "https://etherscan.io/tx/0x...",
@@ -570,7 +570,7 @@ not part of the supported request shape.
 ```json
 {
   "executed": true,
-  "executionId": "direct_123",
+  "executionId": "n3364uzl2s6aram5v558c",
   "status": "completed",
   "conditionResult": {
     "met": true,
@@ -772,7 +772,7 @@ Check the status of a direct execution.
 
 ```json
 {
-  "executionId": "direct_123",
+  "executionId": "n3364uzl2s6aram5v558c",
   "status": "completed",
   "type": "transfer",
   "network": "11155111",

--- a/docs/api/executions.md
+++ b/docs/api/executions.md
@@ -20,8 +20,8 @@ Returns execution history for a workflow.
 ```json
 [
   {
-    "id": "exec_123",
-    "workflowId": "wf_456",
+    "id": "n5lyy066zzplv64gijm0y",
+    "workflowId": "2mp0ybcgj03t0ybqlngyb",
     "status": "success",
     "input": {...},
     "output": {...},
@@ -137,7 +137,7 @@ Blocks until the execution reaches a terminal state (`success`, `error`, or `can
 
 ```json
 {
-  "executionId": "exec_123",
+  "executionId": "n5lyy066zzplv64gijm0y",
   "status": "success",
   "completed": true,
   "transactionHashes": [
@@ -181,8 +181,8 @@ Returns detailed per-node logs for an execution along with the execution row its
 ```json
 {
   "execution": {
-    "id": "exec_123",
-    "workflowId": "wf_456",
+    "id": "n5lyy066zzplv64gijm0y",
+    "workflowId": "2mp0ybcgj03t0ybqlngyb",
     "userId": "user_789",
     "status": "success",
     "input": {...},
@@ -195,7 +195,7 @@ Returns detailed per-node logs for an execution along with the execution row its
   "logs": [
     {
       "id": "log_001",
-      "executionId": "exec_123",
+      "executionId": "n5lyy066zzplv64gijm0y",
       "nodeId": "transfer-1",
       "nodeName": "First transfer",
       "nodeType": "web3/transfer-funds",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -50,7 +50,7 @@ A read or write of one resource returns that resource as a bare object.
 
 ```json
 {
-  "id": "wf_123",
+  "id": "wm3k8nq7xcz2jv4hpbtd5",
   "name": "Treasury monitor"
 }
 ```

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -48,7 +48,7 @@ GET /api/workflows?projectId=proj_123&tagId=tag_456
 ```json
 [
   {
-    "id": "wf_123",
+    "id": "wm3k8nq7xcz2jv4hpbtd5",
     "name": "My Workflow",
     "description": "Monitors ETH balance",
     "visibility": "private",
@@ -72,7 +72,7 @@ Returns a single workflow by ID.
 
 ```json
 {
-  "id": "wf_123",
+  "id": "wm3k8nq7xcz2jv4hpbtd5",
   "name": "My Workflow",
   "description": "Monitors ETH balance",
   "visibility": "private",
@@ -257,7 +257,7 @@ The `input` field is optional. It maps to the workflow's trigger input and is pa
 ### Example
 
 ```bash
-curl -X POST https://app.keeperhub.com/api/workflows/wf_123/execute \
+curl -X POST https://app.keeperhub.com/api/workflows/wm3k8nq7xcz2jv4hpbtd5/execute \
   -H "Authorization: Bearer $KEEPERHUB_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"input": {}}'
@@ -267,7 +267,7 @@ curl -X POST https://app.keeperhub.com/api/workflows/wf_123/execute \
 
 ```json
 {
-  "executionId": "exec_123",
+  "executionId": "k6r4t9yqmn2xwv8jsz0a3",
   "status": "running"
 }
 ```
@@ -352,7 +352,7 @@ Returns all public workflows with optional filtering.
 ```json
 [
   {
-    "id": "wf_123",
+    "id": "wm3k8nq7xcz2jv4hpbtd5",
     "name": "Public Workflow",
     "description": "Description",
     "nodes": [...],

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -93,9 +93,12 @@ Always preflight the three simulate-capable tools:
 5. Keep `transactionLink` from the terminal response as the onchain proof.
 
 `execute_protocol_action` is not in that loop: it has no simulate step, so call it once with
-an `idempotency_key` and treat its response as the terminal result. For a write action the
-call returns the outcome directly - `transactionHash` and `transactionLink` on success, the
-error on failure - and there is no `executionId` to poll afterwards. (A read actionType
+an `idempotency_key`. A write action answers `202` with an envelope carrying `executionId`
+and a `status` of `completed`, `failed`, or `unconfirmed` (plus `transactionHash` and
+`transactionLink` when the write produced one). Only `completed` and `failed` are terminal:
+when the status is `unconfirmed` the transaction is broadcast but not yet confirmed, so poll
+`get_direct_execution_status` with the returned `executionId` until it is terminal - never
+re-send an `unconfirmed` execution, the transaction may still land. (A read actionType
 returns the read value instead, as above.)
 
 **Simulation is EVM-only.** On Solana mainnet (`101`) and devnet (`103`), a `simulate: true` call


### PR DESCRIPTION
Follow-up to #2301 (merged): protocol writes changed under it after merge.

## What

Two docs corrections so the pages say what `staging` does:

**1. `execute_protocol_action` now returns a 202 envelope with `executionId`.** #2213 (merged 08:08, after #2301 at 00:09) changed `app/api/execute/[...slug]/route.ts` so protocol writes expose `executionId` + `status` matching the contract-call/transfer envelope, so callers can poll `GET /api/execute/{executionId}/status` and idempotency can bind the resource id. The tool's own description at `lib/mcp/tools.ts:2427` was updated in #2213 to say exactly that. #2301's agent.md paragraph ("no executionId to poll, response is terminal") described the pre-#2213 code and is now wrong. Rewritten: write actions answer 202 with `executionId` and a `status` of `completed`/`failed`/`unconfirmed`; only completed and failed are terminal - poll on `unconfirmed`, never re-send.

**2. Drop fabricated id prefixes in direct-execution.md examples.** The page shows `"executionId": "direct_123"` in five response examples, but execution ids are 21-character lowercase nanoids with no prefix (`lib/utils/id.ts`), as the #2298 glossary (merged) states. The `direct_` prefix would have a reader cross-linking from the glossary believe the shape is distinguishable. Replaced with a realistic nanoid-shaped example.

No code or CI files touched. Sibling pages (`executions.md`, `workflows.md`, `analytics.md`, `mcp-get-execution.md`) show the same class of prefixed example (`exec_123`, `wf_123`) and would need the same pass - keeping this PR to the two pages this follow-up is about, happy to extend if preferred.
