### PR TITLE
docs: point agent/API consumers at wallet and address discovery (#2055)

### DIFF
--- a/docs/api/integrations.md
+++ b/docs/api/integrations.md
@@ -43,6 +43,7 @@ GET /api/integrations
       "name": "My Discord",
       "type": "discord",
       "isManaged": false,
+      "address": null,
       "createdAt": "2024-01-01T00:00:00Z",
       "updatedAt": "2024-01-01T00:00:00Z"
     }
@@ -51,6 +52,10 @@ GET /api/integrations
 ```
 
 Note: Integration config is excluded from list responses for security.
+
+`address` is the canonical EIP-55 checksummed wallet address for `web3` integrations, and `null`
+for every other type. API consumers must prefer it over `name` when the value is destined for
+an on-chain call such as `onBehalfOf`.
 
 ## Get Integration
 

--- a/docs/api/user.md
+++ b/docs/api/user.md
@@ -67,6 +67,7 @@ Returns the Turnkey wallet for the authenticated user's active organization. The
   "canExportKey": true,
   "isOwner": true,
   "walletAddress": "0x...",
+  "solanaAddress": null,
   "walletId": "turnkey_wallet_...",
   "email": "wallet@example.com",
   "createdAt": "2026-01-01T00:00:00.000Z",
@@ -74,6 +75,9 @@ Returns the Turnkey wallet for the authenticated user's active organization. The
   "isActive": true
 }
 ```
+
+`walletAddress` is the EVM address; `solanaAddress` is present when the wallet has a Solana
+address and `null` otherwise.
 
 When the organization has no wallet yet, the response is `{ "hasWallet": false, "message": "No wallet found for this organization" }`.
 

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -87,10 +87,10 @@ Turnkey wallet, not your own. Discover its address over REST with `GET /api/user
 (`walletAddress` for EVM, `solanaAddress` for Solana) or `GET /api/integrations` (canonical
 EIP-55 checksummed `address`, preferred when an address must match exactly). Over MCP, call
 `list_integrations` to find the web3 integration, then `get_wallet_integration` with that
-integration's id - it returns the address as `walletAddress`. A direct execution spends the
-wallet's own balance, so fund that address on the target network before a first write.
-(A step configured against a Safe spends the Safe's balance instead - the funding rule does
-not apply to it.) See [User API](/api/user) and [Integrations](/api/integrations).
+integration's id - it returns the address as `walletAddress`. What a direct execution debits
+from the wallet is the value a write moves, not the gas: on sponsored chains a relayer pays
+the network fee. (A step configured against a Safe spends the Safe's balance instead.) See
+[User API](/api/user) and [Integrations](/api/integrations).
 
 Always preflight the three simulate-capable tools:
 

--- a/docs/getting-started/agent.md
+++ b/docs/getting-started/agent.md
@@ -82,6 +82,16 @@ protocol exposes a read action (for example a `chronicle/eth-usd-read` or
 `morpho/get-position` actionType), calling that first returns current state, but it cannot
 tell you whether a particular write will revert; there is no substitute for a dry run here.
 
+**Know the wallet that signs direct executions.** Broadcasts come from your organization's
+Turnkey wallet, not your own. Discover its address over REST with `GET /api/user/wallet`
+(`walletAddress` for EVM, `solanaAddress` for Solana) or `GET /api/integrations` (canonical
+EIP-55 checksummed `address`, preferred when an address must match exactly). Over MCP, call
+`list_integrations` to find the web3 integration, then `get_wallet_integration` with that
+integration's id - it returns the address as `walletAddress`. A direct execution spends the
+wallet's own balance, so fund that address on the target network before a first write.
+(A step configured against a Safe spends the Safe's balance instead - the funding rule does
+not apply to it.) See [User API](/api/user) and [Integrations](/api/integrations).
+
 Always preflight the three simulate-capable tools:
 
 1. Call the tool with `simulate: true`.

--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -47,6 +47,13 @@ from wallet sign-in instead. See [Headless Onboarding](/api/headless-onboarding)
 Your organization's Turnkey wallet is provisioned on signup. Eligible transactions on supported
 EVM mainnets and testnets may use the organization's monthly sponsored-gas allowance.
 
+To find the address that signs and funds your executions, `GET /api/user/wallet` returns the
+Turnkey wallet for your organization, with `walletAddress` (EVM) and `solanaAddress` (Solana).
+`GET /api/integrations` returns the same signer as a web3 integration carrying a canonical
+EIP-55 checksummed `address` field - prefer that field when an address must be compared
+exactly. Both accept the same `Authorization: Bearer $KEEPERHUB_API_KEY` header as every
+other agent route. See [User API](/api/user) and [Integrations](/api/integrations).
+
 Sponsorship pays the **network fee**, not the value moved. A workflow that sends 0.1 ETH still
 needs 0.1 ETH in the wallet, and an ERC-20 transfer still needs the token balance. Sponsorship
 also requires the sender to be the wallet rather than a Safe, the transaction to use the public

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -5,7 +5,7 @@
       "path": "/api/address-book/{entryId}",
       "route_file": "app/api/address-book/[entryId]/route.ts",
       "source": "docs/api/user.md",
-      "line": 255
+      "line": 259
     },
     {
       "method": "DELETE",
@@ -19,7 +19,7 @@
       "path": "/api/integrations/{integrationId}",
       "route_file": "app/api/integrations/[integrationId]/route.ts",
       "source": "docs/api/integrations.md",
-      "line": 107
+      "line": 112
     },
     {
       "method": "DELETE",
@@ -47,7 +47,7 @@
       "path": "/api/user/rpc-preferences/{chainId}",
       "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
       "source": "docs/api/user.md",
-      "line": 148
+      "line": 152
     },
     {
       "method": "DELETE",
@@ -68,7 +68,7 @@
       "path": "/api/address-book",
       "route_file": "app/api/address-book/route.ts",
       "source": "docs/api/user.md",
-      "line": 222
+      "line": 226
     },
     {
       "method": "GET",
@@ -160,7 +160,7 @@
       "path": "/api/integrations/{integrationId}",
       "route_file": "app/api/integrations/[integrationId]/route.ts",
       "source": "docs/api/integrations.md",
-      "line": 58
+      "line": 63
     },
     {
       "method": "GET",
@@ -216,14 +216,14 @@
       "path": "/api/user/rpc-preferences",
       "route_file": "app/api/user/rpc-preferences/route.ts",
       "source": "docs/api/user.md",
-      "line": 89
+      "line": 93
     },
     {
       "method": "GET",
       "path": "/api/user/rpc-preferences/{chainId}",
       "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
       "source": "docs/api/user.md",
-      "line": 125
+      "line": 129
     },
     {
       "method": "GET",
@@ -237,7 +237,7 @@
       "path": "/api/user/wallet/balances",
       "route_file": "app/api/user/wallet/balances/route.ts",
       "source": "docs/api/user.md",
-      "line": 80
+      "line": 84
     },
     {
       "method": "GET",
@@ -314,7 +314,7 @@
       "path": "/api/address-book/{entryId}",
       "route_file": "app/api/address-book/[entryId]/route.ts",
       "source": "docs/api/user.md",
-      "line": 247
+      "line": 251
     },
     {
       "method": "PATCH",
@@ -349,7 +349,7 @@
       "path": "/api/address-book",
       "route_file": "app/api/address-book/route.ts",
       "source": "docs/api/user.md",
-      "line": 230
+      "line": 234
     },
     {
       "method": "POST",
@@ -419,14 +419,14 @@
       "path": "/api/integrations",
       "route_file": "app/api/integrations/route.ts",
       "source": "docs/api/integrations.md",
-      "line": 69
+      "line": 74
     },
     {
       "method": "POST",
       "path": "/api/integrations/{integrationId}/test",
       "route_file": "app/api/integrations/[integrationId]/test/route.ts",
       "source": "docs/api/integrations.md",
-      "line": 113
+      "line": 118
     },
     {
       "method": "POST",
@@ -468,21 +468,21 @@
       "path": "/api/user/delete",
       "route_file": "app/api/user/delete/route.ts",
       "source": "docs/api/user.md",
-      "line": 202
+      "line": 206
     },
     {
       "method": "POST",
       "path": "/api/user/forgot-password",
       "route_file": "app/api/user/forgot-password/route.ts",
       "source": "docs/api/user.md",
-      "line": 173
+      "line": 177
     },
     {
       "method": "POST",
       "path": "/api/user/password",
       "route_file": "app/api/user/password/route.ts",
       "source": "docs/api/user.md",
-      "line": 156
+      "line": 160
     },
     {
       "method": "POST",
@@ -552,14 +552,14 @@
       "path": "/api/integrations/{integrationId}",
       "route_file": "app/api/integrations/[integrationId]/route.ts",
       "source": "docs/api/integrations.md",
-      "line": 87
+      "line": 92
     },
     {
       "method": "PUT",
       "path": "/api/user/rpc-preferences/{chainId}",
       "route_file": "app/api/user/rpc-preferences/[chainId]/route.ts",
       "source": "docs/api/user.md",
-      "line": 131
+      "line": 135
     },
     {
       "method": "PUT",


### PR DESCRIPTION
Fixes #2055 (docs-only; addresses every point from the changes-requested on the earlier #2089 attempt).

## What

Agent and API consumers can execute and read results, but the docs never said how to discover the signing wallet's address over the API - so an integration has to guess between the dashboard, the MCP, and undocumented REST routes. Both endpoints already exist; this PR points the docs at them.

**`docs/getting-started/agent.md`** (section 4, after the direct-execution tool list): how an agent finds the address that signs direct executions - `GET /api/user/wallet` (`walletAddress`/`solanaAddress`), `GET /api/integrations` (canonical EIP-55 `address`), or over MCP via `list_integrations` then `get_wallet_integration` (which returns `walletAddress`). The funding sentence is scoped to direct execution with the Safe exception stated, since a step configured against a Safe spends the Safe's balance.

**`docs/getting-started/api.md`** (section 2, "Fund the wallet"): same discovery pointers over REST, using the page's existing `$KEEPERHUB_API_KEY` variable (the earlier attempt introduced `$KEEPERHUB_KEY`, which does not exist anywhere - fixed here by naming the two endpoints with no invented header).

**`docs/api/integrations.md`**: the list-response example omitted `address` entirely; added it (`null` for the discord example) plus the field's meaning - canonical EIP-55 for `web3` integrations, `null` otherwise, and that API consumers must prefer it over `name` when the value is destined for an on-chain call such as `onBehalfOf`. Wording matches the KEEP-484 comment at `app/api/integrations/route.ts:29-33`.

**`docs/api/user.md`**: the wallet response example showed `walletAddress` but not `solanaAddress`; added it (`null` when absent, matching `wallet.solanaAddress ?? null` at `app/api/user/wallet/route.ts:205`).

`specs/api-coverage.json` regenerated (line shifts only; `check-api-docs-routes` reports no drift).

No code or CI files touched.
