### PR TITLE
fix: surface plan-gate before action-config validation on workflow save

### DIFF
--- a/app/api/workflows/[workflowId]/route.ts
+++ b/app/api/workflows/[workflowId]/route.ts
@@ -555,6 +555,18 @@ export async function PATCH(
         );
       }
 
+      // Run the plan-gate before action-config validation so a plan-gated
+      // action (e.g. Run Code, Send Webhook) reports "upgrade required"
+      // instead of a generic INVALID_ACTION_CONFIG when its config is also
+      // incomplete.
+      const featureGuard = await enforceWorkflowFeatures(
+        extractActionTypeNodes(updateData.nodes),
+        existingWorkflow.organizationId
+      );
+      if (featureGuard.blocked) {
+        return featureGuard.response;
+      }
+
       const actionConfigValidation = validateWorkflowActionConfigs(
         updateData.nodes
       );
@@ -563,14 +575,6 @@ export async function PATCH(
           formatActionConfigValidationResponse(actionConfigValidation),
           { status: 422 }
         );
-      }
-
-      const featureGuard = await enforceWorkflowFeatures(
-        extractActionTypeNodes(updateData.nodes),
-        existingWorkflow.organizationId
-      );
-      if (featureGuard.blocked) {
-        return featureGuard.response;
       }
     }
 

--- a/app/api/workflows/create/route.ts
+++ b/app/api/workflows/create/route.ts
@@ -198,20 +198,23 @@ export async function POST(request: Request) {
       throw error;
     }
 
-    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
-    if (!actionConfigValidation.valid) {
-      return NextResponse.json(
-        formatActionConfigValidationResponse(actionConfigValidation),
-        { status: 422 }
-      );
-    }
-
+    // Run the plan-gate before action-config validation so a plan-gated
+    // action (e.g. Run Code, Send Webhook) reports "upgrade required" instead
+    // of a generic INVALID_ACTION_CONFIG when its config is also incomplete.
     const featureGuard = await enforceWorkflowFeatures(
       extractActionTypeNodes(nodes),
       organizationId
     );
     if (featureGuard.blocked) {
       return featureGuard.response;
+    }
+
+    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
+    if (!actionConfigValidation.valid) {
+      return NextResponse.json(
+        formatActionConfigValidationResponse(actionConfigValidation),
+        { status: 422 }
+      );
     }
 
     const workflowName = await generateWorkflowName(body.name, organizationId);

--- a/app/api/workflows/current/route.ts
+++ b/app/api/workflows/current/route.ts
@@ -125,20 +125,23 @@ export async function POST(request: Request) {
       );
     }
 
-    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
-    if (!actionConfigValidation.valid) {
-      return NextResponse.json(
-        formatActionConfigValidationResponse(actionConfigValidation),
-        { status: 422 }
-      );
-    }
-
+    // Run the plan-gate before action-config validation so a plan-gated
+    // action (e.g. Run Code, Send Webhook) reports "upgrade required" instead
+    // of a generic INVALID_ACTION_CONFIG when its config is also incomplete.
     const featureGuard = await enforceWorkflowFeatures(
       extractActionTypeNodes(nodes),
       organizationId
     );
     if (featureGuard.blocked) {
       return featureGuard.response;
+    }
+
+    const actionConfigValidation = validateWorkflowActionConfigs(nodes);
+    if (!actionConfigValidation.valid) {
+      return NextResponse.json(
+        formatActionConfigValidationResponse(actionConfigValidation),
+        { status: 422 }
+      );
     }
 
     // Check if current workflow exists for this user in this org.

--- a/app/api/workflows/import/route.ts
+++ b/app/api/workflows/import/route.ts
@@ -159,6 +159,17 @@ export async function POST(request: Request): Promise<NextResponse> {
       throw error;
     }
 
+    // Run the plan-gate before action-config validation so a plan-gated
+    // action (e.g. Run Code, Send Webhook) reports "upgrade required" instead
+    // of a generic INVALID_ACTION_CONFIG when its config is also incomplete.
+    const featureGuard = await enforceWorkflowFeatures(
+      extractActionTypeNodes(sanitized.nodes),
+      organizationId
+    );
+    if (featureGuard.blocked) {
+      return featureGuard.response;
+    }
+
     const actionConfigValidation = validateWorkflowActionConfigs(
       sanitized.nodes
     );
@@ -167,14 +178,6 @@ export async function POST(request: Request): Promise<NextResponse> {
         formatActionConfigValidationResponse(actionConfigValidation),
         { status: 422 }
       );
-    }
-
-    const featureGuard = await enforceWorkflowFeatures(
-      extractActionTypeNodes(sanitized.nodes),
-      organizationId
-    );
-    if (featureGuard.blocked) {
-      return featureGuard.response;
     }
 
     const workflowId = generateId();

--- a/tests/integration/workflow-create-route.test.ts
+++ b/tests/integration/workflow-create-route.test.ts
@@ -81,7 +81,9 @@ vi.mock("@/lib/security/audit-log", () => ({
   recordAuditEvent: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { NextResponse } from "next/server";
 import { POST } from "@/app/api/workflows/create/route";
+import { enforceWorkflowFeatures } from "@/lib/features/route-guard";
 
 function request(body: Record<string, unknown>): Request {
   return new Request("http://localhost:3000/api/workflows/create", {
@@ -273,6 +275,113 @@ describe("POST /api/workflows/create action config validation", () => {
     );
 
     expect(response.status).not.toBe(422);
+    expect(mockInsert).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/workflows/create plan-gating precedence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDualAuthContext.mockResolvedValue({
+      userId: "user-123",
+      organizationId: "org-123",
+      authMethod: "session",
+    });
+    mockValidateWorkflowIntegrations.mockResolvedValue({ valid: true });
+  });
+
+  it("returns the plan-gate 402 (not the generic 422) when a plan-gated action is also missing required config", async () => {
+    // The node is a plan-gated action whose config is ALSO invalid (required
+    // `code` missing; `timeout` present so it is not a skipped draft). Action-
+    // config validation would reject it with INVALID_ACTION_CONFIG/422, so a
+    // 402 here proves the plan-gate now runs first.
+    vi.mocked(enforceWorkflowFeatures).mockResolvedValueOnce({
+      blocked: true,
+      response: NextResponse.json(
+        {
+          error: "This workflow uses features that require a paid plan.",
+          code: "upgrade_required",
+          violations: [
+            {
+              featureId: "action.code",
+              featureName: "Code action",
+              requiredPlan: "pro",
+              actionType: "code/run-code",
+              nodeIds: ["node-1"],
+            },
+          ],
+        },
+        { status: 402 }
+      ),
+    });
+
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "code/run-code",
+            timeout: "30",
+          }),
+        ])
+      )
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(402);
+    expect(body.code).toBe("upgrade_required");
+    expect(body.violations[0].requiredPlan).toBe("pro");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("still returns INVALID_ACTION_CONFIG/422 for a permitted action with invalid config", async () => {
+    // Guard is not blocked (permitted action / paid plan); the generic config
+    // validation must still fire for a genuinely malformed non-gated action.
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "discord/send-message",
+            Message: "hello",
+          }),
+        ])
+      )
+    );
+
+    const body = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(body.error).toBe("INVALID_ACTION_CONFIG");
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("saves a permitted action with valid config", async () => {
+    const mockReturning = vi.fn().mockResolvedValue([
+      {
+        id: "wf-ok",
+        name: "Untitled Workflow",
+        enabled: false,
+        createdAt: new Date("2024-01-01"),
+        updatedAt: new Date("2024-01-01"),
+      },
+    ]);
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({ returning: mockReturning }),
+    });
+
+    const response = await POST(
+      request(
+        workflowBody([
+          baseActionNode({
+            actionType: "discord/send-message",
+            discordMessage: "hello",
+          }),
+        ])
+      )
+    );
+
+    expect(response.status).not.toBe(422);
+    expect(response.status).not.toBe(402);
     expect(mockInsert).toHaveBeenCalled();
   });
 });

--- a/tests/unit/features-route-guard.test.ts
+++ b/tests/unit/features-route-guard.test.ts
@@ -32,6 +32,20 @@ const blockscoutNode = {
   actionType: "blockscout/get-address-balance",
 };
 
+// Pro-gated plugin actions with explicit feature entries (action.code /
+// action.webhook). These are the plugin actions that used to collapse into a
+// generic INVALID_ACTION_CONFIG when their config was incomplete, because
+// action-config validation ran ahead of this gate.
+const runCodeNode = {
+  id: "node-code-1",
+  actionType: "code/run-code",
+};
+
+const sendWebhookNode = {
+  id: "node-wh-1",
+  actionType: "webhook/send-webhook",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -99,6 +113,46 @@ describe("enforceWorkflowFeatures", () => {
     expect(body.violations[0].featureId).toBe("action.external-request");
     expect(body.violations[0].requiredPlan).toBe("pro");
     expect(body.violations[0].nodeIds).toEqual(["node-bs-1"]);
+  });
+
+  it("blocks the Run Code action on the free plan with a plan-specific 402", async () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    vi.mocked(getOrgPlan).mockResolvedValue("free");
+
+    const result = await enforceWorkflowFeatures([runCodeNode], "org_1");
+
+    expect(result.blocked).toBe(true);
+    if (!result.blocked) {
+      return;
+    }
+    expect(result.response.status).toBe(402);
+    const body = await result.response.json();
+    expect(body.code).toBe("upgrade_required");
+    expect(body.error).toBe(
+      "This workflow uses features that require a paid plan."
+    );
+    expect(body.violations[0].featureId).toBe("action.code");
+    expect(body.violations[0].requiredPlan).toBe("pro");
+    expect(body.violations[0].actionType).toBe("code/run-code");
+    expect(body.violations[0].nodeIds).toEqual(["node-code-1"]);
+  });
+
+  it("blocks the Send Webhook action on the free plan with a plan-specific 402", async () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    vi.mocked(getOrgPlan).mockResolvedValue("free");
+
+    const result = await enforceWorkflowFeatures([sendWebhookNode], "org_1");
+
+    expect(result.blocked).toBe(true);
+    if (!result.blocked) {
+      return;
+    }
+    expect(result.response.status).toBe(402);
+    const body = await result.response.json();
+    expect(body.code).toBe("upgrade_required");
+    expect(body.violations[0].featureId).toBe("action.webhook");
+    expect(body.violations[0].requiredPlan).toBe("pro");
+    expect(body.violations[0].actionType).toBe("webhook/send-webhook");
   });
 
   it("allows the user-destination action on a paid plan", async () => {

--- a/tests/unit/workflow-save-plan-gate-ordering.test.ts
+++ b/tests/unit/workflow-save-plan-gate-ordering.test.ts
@@ -26,7 +26,10 @@ describe("workflow-save plan-gate ordering", () => {
       const gate = src.indexOf("enforceWorkflowFeatures(");
       const config = src.indexOf("validateWorkflowActionConfigs(");
 
-      expect(gate, `${route}: enforceWorkflowFeatures( call not found`).toBeGreaterThan(-1);
+      expect(
+        gate,
+        `${route}: enforceWorkflowFeatures( call not found`
+      ).toBeGreaterThan(-1);
       expect(
         config,
         `${route}: validateWorkflowActionConfigs( call not found`

--- a/tests/unit/workflow-save-plan-gate-ordering.test.ts
+++ b/tests/unit/workflow-save-plan-gate-ordering.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// The org plan-gate (enforceWorkflowFeatures -> 402 upgrade_required) must run
+// BEFORE action-config validation (validateWorkflowActionConfigs -> 422
+// INVALID_ACTION_CONFIG) in every workflow-save route, so a plan-gated action
+// whose config is also incomplete reports "upgrade required" instead of a
+// generic config error. workflow-create-route.test.ts proves the runtime
+// behavior for `create`; this guards the same ordering across all four routes,
+// catching a re-inversion in any single one that a per-route behavioral test
+// would miss.
+const SAVE_ROUTES = [
+  "app/api/workflows/create/route.ts",
+  "app/api/workflows/current/route.ts",
+  "app/api/workflows/import/route.ts",
+  "app/api/workflows/[workflowId]/route.ts",
+];
+
+describe("workflow-save plan-gate ordering", () => {
+  it.each(SAVE_ROUTES)(
+    "%s runs the plan-gate before action-config validation",
+    (route) => {
+      const src = readFileSync(path.resolve(process.cwd(), route), "utf8");
+      // Match the call sites (trailing "("), not the top-of-file imports.
+      const gate = src.indexOf("enforceWorkflowFeatures(");
+      const config = src.indexOf("validateWorkflowActionConfigs(");
+
+      expect(gate, `${route}: enforceWorkflowFeatures( call not found`).toBeGreaterThan(-1);
+      expect(
+        config,
+        `${route}: validateWorkflowActionConfigs( call not found`
+      ).toBeGreaterThan(-1);
+      expect(
+        gate,
+        `${route}: plan-gate must precede action-config validation`
+      ).toBeLessThan(config);
+    }
+  );
+});


### PR DESCRIPTION
## What

Free-plan orgs using a Pro-gated action (`code/run-code`, `webhook/send-webhook`) sometimes got a generic `422 INVALID_ACTION_CONFIG` on workflow save instead of the clear "upgrade required" error, so the user was sent to fix fields on an action they cannot use at all.

Root cause: a dedicated plan-gate already exists (`enforceWorkflowFeatures` -> `402` with `code: "upgrade_required"`, naming the feature and required plan), but in the four save routes it ran *after* `validateWorkflowActionConfigs` (`422`). A plan-gated plugin action whose config was also incomplete tripped the generic `422` first and never reached the clear `402`. (The two system actions in the ticket, HTTP Request and Database Query, are skipped by config validation and already reached the clean `402`.)

## Changes

- Reordered the two adjacent, independent checks so the plan-gate runs before action-config validation in all four save routes (`create`, `current`, `import`, `[workflowId]`). Both read the same `nodes` and neither mutates state, so this only changes which error wins when both would fire.
- No new error code: the plan-gated case now reports via the existing `upgrade_required` `402` even when config is incomplete. What is gated is unchanged.
- Tests: a plan-gated action with invalid config now returns `402` (not `422`) and does not insert; a permitted action with invalid config still returns `422 INVALID_ACTION_CONFIG`; a permitted valid action still saves.

## Verification

Ran in `node:22` (host has no node): `features-route-guard` and `workflow-create-route` suites pass (22 tests); related `features-egress-invariant` / `workflow-action-config-validation` suites unaffected.

## Out of scope (flagged for follow-up)

The ticket's "flag the gate upfront in the editor" half is not addressed; `hooks/use-features.ts` already resolves action features client-side, so an in-editor badge is a natural cheap follow-up.