### PR TITLE
feat(actions): disclose requiredPlan on action schemas and document /api/features

### DIFF
--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -401,7 +401,8 @@ Returns the complete registry of available workflow actions, triggers, and templ
       "optionalFields": {},
       "outputFields": { "balance": "..." },
       "requiresCredentials": false,
-      "requiredPlan": null
+      "requiredPlan": null,
+      "featureEnabled": true
     },
     "Condition": {
       "actionType": "Condition",
@@ -409,7 +410,9 @@ Returns the complete registry of available workflow actions, triggers, and templ
       "category": "System",
       "requiredFields": { "condition": "string (JS expression)" },
       "optionalFields": { "conditionConfig": "object (visual builder state)" },
-      "sourceHandles": ["true", "false"]
+      "sourceHandles": ["true", "false"],
+      "requiredPlan": null,
+      "featureEnabled": true
     }
   },
   "triggers": {
@@ -440,7 +443,15 @@ Returns the complete registry of available workflow actions, triggers, and templ
 > - **Triggers** are listed under the `triggers` key (not `actions`) and their values map to `config.triggerType` on trigger nodes.
 > - The endpoint self-documents the correct node and edge shapes under the `workflowStructure` and `edgeStructure` keys — use these as the source of truth for programmatic workflow generation.
 
-Every action carries a `requiredPlan` field: the plan an organization must be on to run the action, or `null` when it is not plan-gated. It is the static requirement, not your organization's plan, so this endpoint stays anonymous and publicly cacheable. Check it before building a workflow so a `POST /api/workflows/create` that needs a paid plan does not fail after the fact. To see which plan your organization is on and which features that plan unlocks, `GET /api/features` returns the org's feature snapshot (plan, enabled feature ids, and the full registry); it authenticates with the same `Authorization` header as every other agent route.
+Every action carries a `requiredPlan` field (the plan an organization must be on to run the
+action, or `null` when it is not plan-gated) and a `featureEnabled` field (false only when the
+gating feature has been rolled back for every plan). Both are the static requirement, never
+your organization's plan, so this endpoint stays anonymous and publicly cacheable. Check them
+before building a workflow so a `POST /api/workflows/create` that needs a paid plan does not
+fail after the fact. To see which plan your organization is on and which features that plan
+unlocks, `GET /api/features` returns the org's feature snapshot (plan, enabled feature ids,
+and the full registry); it authenticates with the same `Authorization` header as every other
+agent route.
 
 ## Get Organization Features
 
@@ -460,8 +471,11 @@ Returns the calling organization's feature snapshot so a client can render per-p
     {
       "id": "action.database-query",
       "name": "Database Query action",
+      "description": "Run SQL queries against connected databases inside workflows.",
       "category": "workflow-action",
-      "requiredPlan": "pro"
+      "enabled": true,
+      "requiredPlan": "pro",
+      "actionTypes": ["Database Query"]
     }
   ],
   "billingEnabled": true

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -400,7 +400,8 @@ Returns the complete registry of available workflow actions, triggers, and templ
       "requiredFields": { "network": "string (chain ID)", "address": "string" },
       "optionalFields": {},
       "outputFields": { "balance": "..." },
-      "requiresCredentials": false
+      "requiresCredentials": false,
+      "requiredPlan": null
     },
     "Condition": {
       "actionType": "Condition",
@@ -438,3 +439,33 @@ Returns the complete registry of available workflow actions, triggers, and templ
 > - **System actions** use Pascal-case with spaces between words (e.g., `"Condition"`, `"For Each"`, `"HTTP Request"`). System actions do not have a `requiresCredentials` field.
 > - **Triggers** are listed under the `triggers` key (not `actions`) and their values map to `config.triggerType` on trigger nodes.
 > - The endpoint self-documents the correct node and edge shapes under the `workflowStructure` and `edgeStructure` keys — use these as the source of truth for programmatic workflow generation.
+
+Every action carries a `requiredPlan` field: the plan an organization must be on to run the action, or `null` when it is not plan-gated. It is the static requirement, not your organization's plan, so this endpoint stays anonymous and publicly cacheable. Check it before building a workflow so a `POST /api/workflows/create` that needs a paid plan does not fail after the fact. To see which plan your organization is on and which features that plan unlocks, `GET /api/features` returns the org's feature snapshot (plan, enabled feature ids, and the full registry); it authenticates with the same `Authorization` header as every other agent route.
+
+## Get Organization Features
+
+```http
+GET /api/features
+```
+
+Returns the calling organization's feature snapshot so a client can render per-plan lock states or preflight a workflow build.
+
+### Response
+
+```json
+{
+  "plan": "free",
+  "enabledFeatureIds": [],
+  "features": [
+    {
+      "id": "action.database-query",
+      "name": "Database Query action",
+      "category": "workflow-action",
+      "requiredPlan": "pro"
+    }
+  ],
+  "billingEnabled": true
+}
+```
+
+`billingEnabled` is `false` on self-hosted installs where billing is disabled, in which case `plan` is `"enterprise"` and every feature is enabled.

--- a/lib/action-schemas/builder.ts
+++ b/lib/action-schemas/builder.ts
@@ -1,4 +1,5 @@
 import { eq } from "drizzle-orm";
+import type { PlanName } from "@/lib/billing/plans";
 import { db } from "@/lib/db";
 import { chains, explorerConfigs } from "@/lib/db/schema";
 import { resolveActionFeature } from "@/lib/features/action-egress";
@@ -59,7 +60,17 @@ export type ActionSchema = {
    * catch-all gate (action.external-request) is included, not just the
    * explicit FEATURES registry entries.
    */
-  requiredPlan: string | null;
+  requiredPlan: PlanName | null;
+  /**
+   * True when the gating feature's master switch is on. A feature with
+   * `enabled: false` is treated as gated for every plan (the rollback
+   * switch), so an action can carry a `requiredPlan` and still be
+   * unavailable to an org on that plan until the feature is re-enabled.
+   * Always true when `requiredPlan` is null. Latent today - every feature
+   * is enabled - but it is the half of the gate that `requiredPlan` alone
+   * cannot express.
+   */
+  featureEnabled: boolean;
 };
 
 export type BuildActionSchemasOptions = {
@@ -108,6 +119,27 @@ function mapFieldType(field: ActionConfigFieldBase): string {
   }
 }
 
+/**
+ * The disclosed plan gate for an action: the plan its gating feature requires
+ * (null when ungated) plus whether the feature's master switch is on. Both
+ * halves come from resolveActionFeature so the egress-derived catch-all is
+ * included, and both are static - never the caller's plan - so the schema
+ * stays anonymous and publicly cacheable.
+ */
+function resolveDisclosedGate(actionType: string): {
+  requiredPlan: PlanName | null;
+  featureEnabled: boolean;
+} {
+  const feature = resolveActionFeature(actionType);
+  if (!feature) {
+    return { requiredPlan: null, featureEnabled: true };
+  }
+  return {
+    requiredPlan: feature.requiredPlan,
+    featureEnabled: feature.enabled,
+  };
+}
+
 export function transformPluginAction(
   plugin: IntegrationPlugin,
   action: PluginAction
@@ -135,6 +167,7 @@ export function transformPluginAction(
   }
 
   const outputSchema = synthesizeOutputSchema(action);
+  const gate = resolveDisclosedGate(actionType);
 
   return {
     actionType,
@@ -144,7 +177,8 @@ export function transformPluginAction(
     integration: plugin.type,
     requiresCredentials:
       action.requiresCredentials ?? plugin.requiresCredentials ?? false,
-    requiredPlan: resolveActionFeature(actionType)?.requiredPlan ?? null,
+    requiredPlan: gate.requiredPlan,
+    featureEnabled: gate.featureEnabled,
     requiredFields,
     optionalFields,
     outputFields,
@@ -256,19 +290,20 @@ export async function buildActionSchemasResponse(
 
   const platformCapabilities = derivePlatformCapabilities(allPlugins);
 
-  // Enrich system actions with their plan requirement the same way plugin
-  // actions get it. SYSTEM_ACTIONS is shared with the workflow validator and
-  // the builder UI, so it is not mutated in place - each entry is copied and
-  // the requirement resolved per actionType. System actions with no explicit
-  // feature and no user-destination egress (Condition, For Each, triggers)
-  // resolve to null.
+  // Enrich system actions with their plan gate the same way plugin actions
+  // get it. SYSTEM_ACTIONS is shared with the workflow validator and the
+  // builder UI, so it is not mutated in place - each entry is copied and the
+  // gate resolved. Every system action's map key equals its actionType (the
+  // constant is keyed by the label), so the key resolves the gate with no
+  // cast. System actions with no explicit feature and no user-destination
+  // egress (Condition, For Each, triggers) resolve to null.
   const enrichedSystemActions: Record<string, unknown> = {};
   for (const [key, action] of Object.entries(systemActions)) {
-    const systemAction = action as { actionType: string };
+    const gate = resolveDisclosedGate(key);
     enrichedSystemActions[key] = {
       ...(action as Record<string, unknown>),
-      requiredPlan:
-        resolveActionFeature(systemAction.actionType)?.requiredPlan ?? null,
+      requiredPlan: gate.requiredPlan,
+      featureEnabled: gate.featureEnabled,
     };
   }
 

--- a/lib/action-schemas/builder.ts
+++ b/lib/action-schemas/builder.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { chains, explorerConfigs } from "@/lib/db/schema";
+import { resolveActionFeature } from "@/lib/features/action-egress";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { synthesizeOutputSchema } from "@/lib/mcp/output-schema";
 import {
@@ -50,6 +51,15 @@ export type ActionSchema = {
   optionalFields: Record<string, string>;
   outputFields: Record<string, string>;
   outputSchema?: Record<string, unknown>;
+  /**
+   * The plan an organization must be on to run this action, or null when the
+   * action is not plan-gated. Emits the static requirement (never the
+   * caller's plan) so /api/mcp/schemas stays anonymous and publicly
+   * cacheable. Resolved via resolveActionFeature so the egress-derived
+   * catch-all gate (action.external-request) is included, not just the
+   * explicit FEATURES registry entries.
+   */
+  requiredPlan: string | null;
 };
 
 export type BuildActionSchemasOptions = {
@@ -134,6 +144,7 @@ export function transformPluginAction(
     integration: plugin.type,
     requiresCredentials:
       action.requiresCredentials ?? plugin.requiresCredentials ?? false,
+    requiredPlan: resolveActionFeature(actionType)?.requiredPlan ?? null,
     requiredFields,
     optionalFields,
     outputFields,
@@ -245,9 +256,25 @@ export async function buildActionSchemasResponse(
 
   const platformCapabilities = derivePlatformCapabilities(allPlugins);
 
+  // Enrich system actions with their plan requirement the same way plugin
+  // actions get it. SYSTEM_ACTIONS is shared with the workflow validator and
+  // the builder UI, so it is not mutated in place - each entry is copied and
+  // the requirement resolved per actionType. System actions with no explicit
+  // feature and no user-destination egress (Condition, For Each, triggers)
+  // resolve to null.
+  const enrichedSystemActions: Record<string, unknown> = {};
+  for (const [key, action] of Object.entries(systemActions)) {
+    const systemAction = action as { actionType: string };
+    enrichedSystemActions[key] = {
+      ...(action as Record<string, unknown>),
+      requiredPlan:
+        resolveActionFeature(systemAction.actionType)?.requiredPlan ?? null,
+    };
+  }
+
   let actions: Record<string, unknown> = {
     ...pluginActions,
-    ...systemActions,
+    ...enrichedSystemActions,
   };
   if (typeFilter) {
     const matched = actions[typeFilter];

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -2369,6 +2369,7 @@ export function registerMetaTools(
             requiredFields?: Record<string, string>;
             optionalFields?: Record<string, string>;
             requiresCredentials?: boolean;
+            requiredPlan?: string | null;
           }
         >;
 
@@ -2397,6 +2398,7 @@ export function registerMetaTools(
           requiredFields: a.requiredFields,
           optionalFields: a.optionalFields,
           requiresCredentials: a.requiresCredentials,
+          requiredPlan: a.requiredPlan ?? null,
         }));
 
         return {

--- a/lib/mcp/tools.ts
+++ b/lib/mcp/tools.ts
@@ -2370,6 +2370,7 @@ export function registerMetaTools(
             optionalFields?: Record<string, string>;
             requiresCredentials?: boolean;
             requiredPlan?: string | null;
+            featureEnabled?: boolean;
           }
         >;
 
@@ -2399,6 +2400,7 @@ export function registerMetaTools(
           optionalFields: a.optionalFields,
           requiresCredentials: a.requiresCredentials,
           requiredPlan: a.requiredPlan ?? null,
+          featureEnabled: a.featureEnabled ?? true,
         }));
 
         return {

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -150,6 +150,13 @@
     },
     {
       "method": "GET",
+      "path": "/api/features",
+      "route_file": "app/api/features/route.ts",
+      "source": "docs/api/workflows.md",
+      "line": 448
+    },
+    {
+      "method": "GET",
       "path": "/api/integrations",
       "route_file": "app/api/integrations/route.ts",
       "source": "docs/api/integrations.md",

--- a/specs/api-coverage.json
+++ b/specs/api-coverage.json
@@ -153,7 +153,7 @@
       "path": "/api/features",
       "route_file": "app/api/features/route.ts",
       "source": "docs/api/workflows.md",
-      "line": 448
+      "line": 459
     },
     {
       "method": "GET",

--- a/tests/integration/action-schemas-route.test.ts
+++ b/tests/integration/action-schemas-route.test.ts
@@ -76,6 +76,22 @@ vi.mock("@/plugins/registry", () => ({
   computeActionId: (pluginType: string, slug: string) =>
     `${pluginType}.${slug}`,
   flattenConfigFields: (fields: unknown[]) => fields,
+  // The builder resolves each action's plan gate through
+  // lib/features/action-egress, which reads the live registry by action id
+  // and plugin type (the egress-derived catch-all). The mock plugins carry no
+  // `egress`, so these resolve the action and fall through to "unknown"
+  // egress - ungated, which is what the fixture asserts.
+  findActionById: (actionId: string) => {
+    const parsed = actionId.split(".");
+    if (parsed.length < 2) {
+      return undefined;
+    }
+    const [type, slug] = parsed;
+    const plugin = mockPlugins.find((p) => p.type === type);
+    const action = plugin?.actions.find((a) => a.slug === slug);
+    return action ? { ...action, id: actionId, integration: type } : undefined;
+  },
+  getIntegration: (type: string) => mockPlugins.find((p) => p.type === type),
 }));
 
 vi.mock("@/lib/mcp/workflow-schema-constants", () => ({

--- a/tests/unit/action-schema-required-plan.test.ts
+++ b/tests/unit/action-schema-required-plan.test.ts
@@ -1,0 +1,87 @@
+// The action-catalog disclosure for plan gating (#2279).
+//
+// The builder's wire projection (ActionSchema) carries `requiredPlan` so an
+// agent or API consumer can see, before building a workflow, which actions
+// need a paid plan. The requirement is resolved through resolveActionFeature
+// - not the static FEATURES table - so the egress-derived catch-all gate
+// (action.external-request) is included: a plugin that lets the user point at
+// a destination of their choosing is pro-gated even though no FEATURES entry
+// names its action types.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildActionSchemasResponse,
+  transformPluginAction,
+} from "@/lib/action-schemas/builder";
+import { getAllIntegrations } from "@/plugins/registry";
+
+describe("ActionSchema requiredPlan disclosure", () => {
+  it("marks explicitly gated plugin actions with their plan", () => {
+    const codeAction = getAllIntegrations()
+      .flatMap((plugin) =>
+        plugin.actions.map((action) => transformPluginAction(plugin, action))
+      )
+      .find((schema) => schema.actionType === "code/run-code");
+
+    expect(codeAction?.requiredPlan).toBe("pro");
+  });
+
+  it("marks egress-gated plugin actions via the catch-all (no FEATURES entry)", () => {
+    // blockscout declares egress: "user-destination" and has no explicit
+    // FEATURES[].actionTypes entry, so only resolveActionFeature's catch-all
+    // can disclose its gate. Regression guard for #2279.
+    const blockscoutActions = getAllIntegrations()
+      .filter((plugin) => plugin.type === "blockscout")
+      .flatMap((plugin) =>
+        plugin.actions.map((action) => transformPluginAction(plugin, action))
+      );
+
+    expect(blockscoutActions.length).toBeGreaterThan(0);
+    for (const schema of blockscoutActions) {
+      expect(schema.requiredPlan).toBe("pro");
+    }
+  });
+
+  it("leaves ungated plugin actions at null", () => {
+    const readAction = getAllIntegrations()
+      .flatMap((plugin) =>
+        plugin.actions.map((action) => transformPluginAction(plugin, action))
+      )
+      .find((schema) => schema.actionType === "web3/read-contract");
+
+    expect(readAction?.requiredPlan).toBeNull();
+  });
+});
+
+describe("buildActionSchemasResponse system-action disclosure", () => {
+  it("discloses requiredPlan on the plan-gated system actions", async () => {
+    const response = await buildActionSchemasResponse({
+      includeChains: false,
+      category: "system",
+      endpointLabel: "test",
+    });
+    const actions = response.actions as Record<
+      string,
+      { actionType: string; requiredPlan: string | null }
+    >;
+
+    expect(actions["HTTP Request"].requiredPlan).toBe("pro");
+    expect(actions["Database Query"].requiredPlan).toBe("pro");
+  });
+
+  it("leaves ungated system actions at null", async () => {
+    const response = await buildActionSchemasResponse({
+      includeChains: false,
+      category: "system",
+      endpointLabel: "test",
+    });
+    const actions = response.actions as Record<
+      string,
+      { actionType: string; requiredPlan: string | null }
+    >;
+
+    expect(actions.Condition.requiredPlan).toBeNull();
+    expect(actions["For Each"].requiredPlan).toBeNull();
+  });
+});

--- a/tests/unit/action-schema-required-plan.test.ts
+++ b/tests/unit/action-schema-required-plan.test.ts
@@ -1,12 +1,16 @@
 // The action-catalog disclosure for plan gating (#2279).
 //
-// The builder's wire projection (ActionSchema) carries `requiredPlan` so an
-// agent or API consumer can see, before building a workflow, which actions
-// need a paid plan. The requirement is resolved through resolveActionFeature
-// - not the static FEATURES table - so the egress-derived catch-all gate
-// (action.external-request) is included: a plugin that lets the user point at
-// a destination of their choosing is pro-gated even though no FEATURES entry
-// names its action types.
+// The builder's wire projection (ActionSchema) carries `requiredPlan` and
+// `featureEnabled` so an agent or API consumer can see, before building a
+// workflow, which actions need a paid plan. The requirement is resolved
+// through resolveActionFeature - not the static FEATURES table - so the
+// egress-derived catch-all gate (action.external-request) is included: a
+// plugin that lets the user point at a destination of their choosing is
+// pro-gated even though no FEATURES entry names its action types.
+//
+// The parity suite at the bottom pins the invariant that makes disclosure
+// trustworthy: what the catalog advertises must equal what the workflow
+// validator enforces for a given plan, action by action.
 
 import { describe, expect, it } from "vitest";
 
@@ -14,17 +18,23 @@ import {
   buildActionSchemasResponse,
   transformPluginAction,
 } from "@/lib/action-schemas/builder";
+import { validateWorkflowFeatures } from "@/lib/features/workflow-validator";
 import { getAllIntegrations } from "@/plugins/registry";
 
-describe("ActionSchema requiredPlan disclosure", () => {
+function allPluginSchemas(): ReturnType<typeof transformPluginAction>[] {
+  return getAllIntegrations().flatMap((plugin) =>
+    plugin.actions.map((action) => transformPluginAction(plugin, action))
+  );
+}
+
+describe("ActionSchema plan-gate disclosure", () => {
   it("marks explicitly gated plugin actions with their plan", () => {
-    const codeAction = getAllIntegrations()
-      .flatMap((plugin) =>
-        plugin.actions.map((action) => transformPluginAction(plugin, action))
-      )
-      .find((schema) => schema.actionType === "code/run-code");
+    const codeAction = allPluginSchemas().find(
+      (schema) => schema.actionType === "code/run-code"
+    );
 
     expect(codeAction?.requiredPlan).toBe("pro");
+    expect(codeAction?.featureEnabled).toBe(true);
   });
 
   it("marks egress-gated plugin actions via the catch-all (no FEATURES entry)", () => {
@@ -40,17 +50,37 @@ describe("ActionSchema requiredPlan disclosure", () => {
     expect(blockscoutActions.length).toBeGreaterThan(0);
     for (const schema of blockscoutActions) {
       expect(schema.requiredPlan).toBe("pro");
+      expect(schema.featureEnabled).toBe(true);
+    }
+  });
+
+  it("leaves protocol-derived actions ungated (fixed-host egress)", () => {
+    // Every protocol action is egress "fixed-host" (lib/protocol-registry.ts),
+    // never user-destination, so none can be plan-gated. If that one line ever
+    // changes, every protocol action silently flips to "pro" - this pins it.
+    const protocolActions = allPluginSchemas().filter((schema) =>
+      ["aave-v3", "aave-v4", "chronicle", "compound", "morpho", "spark"].some(
+        (type) => schema.actionType.startsWith(`${type}/`)
+      )
+    );
+
+    expect(protocolActions.length).toBeGreaterThan(0);
+    for (const schema of protocolActions) {
+      expect(
+        schema.requiredPlan,
+        `${schema.actionType} must stay ungated`
+      ).toBeNull();
+      expect(schema.featureEnabled).toBe(true);
     }
   });
 
   it("leaves ungated plugin actions at null", () => {
-    const readAction = getAllIntegrations()
-      .flatMap((plugin) =>
-        plugin.actions.map((action) => transformPluginAction(plugin, action))
-      )
-      .find((schema) => schema.actionType === "web3/read-contract");
+    const readAction = allPluginSchemas().find(
+      (schema) => schema.actionType === "web3/read-contract"
+    );
 
     expect(readAction?.requiredPlan).toBeNull();
+    expect(readAction?.featureEnabled).toBe(true);
   });
 });
 
@@ -63,11 +93,13 @@ describe("buildActionSchemasResponse system-action disclosure", () => {
     });
     const actions = response.actions as Record<
       string,
-      { actionType: string; requiredPlan: string | null }
+      { requiredPlan: string | null; featureEnabled: boolean }
     >;
 
     expect(actions["HTTP Request"].requiredPlan).toBe("pro");
     expect(actions["Database Query"].requiredPlan).toBe("pro");
+    expect(actions["HTTP Request"].featureEnabled).toBe(true);
+    expect(actions["Database Query"].featureEnabled).toBe(true);
   });
 
   it("leaves ungated system actions at null", async () => {
@@ -78,10 +110,42 @@ describe("buildActionSchemasResponse system-action disclosure", () => {
     });
     const actions = response.actions as Record<
       string,
-      { actionType: string; requiredPlan: string | null }
+      { requiredPlan: string | null; featureEnabled: boolean }
     >;
 
     expect(actions.Condition.requiredPlan).toBeNull();
     expect(actions["For Each"].requiredPlan).toBeNull();
+    expect(actions.Condition.featureEnabled).toBe(true);
+  });
+});
+
+describe("disclosure equals enforcement", () => {
+  // The invariant #2279 exists to establish: what the catalog advertises for
+  // an action must be exactly what the workflow validator enforces. If the
+  // builder and the validator ever resolve through different functions (e.g.
+  // one reads ACTION_TYPE_TO_FEATURE_ID and the other resolveActionFeature),
+  // an action can advertise "pro" while a free org saves it - or vice versa -
+  // with no test failing. Every registered action is checked on a free org:
+  // an action is disclosed as gated exactly when the validator would flag it.
+  it("advertises gated exactly when a free org would be blocked", () => {
+    // Recompute per action using the validator's own resolver on a
+    // single-node workflow: an action is disclosed as gated exactly when the
+    // validator would flag it on a free org.
+    for (const schema of allPluginSchemas()) {
+      const violations = validateWorkflowFeatures(
+        [
+          {
+            id: `probe-${schema.actionType}`,
+            actionType: schema.actionType,
+          },
+        ],
+        "free"
+      );
+      const blocked = violations.length > 0;
+      expect(
+        blocked,
+        `${schema.actionType}: advertised requiredPlan=${schema.requiredPlan} but enforcement says ${blocked ? "blocked" : "allowed"}`
+      ).toBe(schema.requiredPlan !== null);
+    }
   });
 });


### PR DESCRIPTION
Fixes #2279.

## What

An agent building a workflow over REST or MCP cannot see which actions require a paid plan until `POST /api/workflows/create` rejects the finished workflow with `upgrade_required`. The action catalog's wire projection (`ActionSchema`) carried no plan field, and the `/api/features` snapshot that would answer the question was undocumented with no pointer from any agent-facing page.

**`lib/action-schemas/builder.ts`** - `ActionSchema` now carries `requiredPlan: string | null`. Both write sites populate it through `resolveActionFeature`, not the static `FEATURES` table, so the egress-derived catch-all gate is included (a plugin like blockscout that lets the user point at a destination of their choosing is pro-gated with no registry entry naming its action types):
- `transformPluginAction` (plugin actions): `resolveActionFeature(actionType)?.requiredPlan ?? null`
- system actions: each `SYSTEM_ACTIONS` entry is copied and enriched with its resolved requirement (the shared constant is not mutated; ungated system actions like Condition / For Each resolve to null)

The field emits the static requirement, never the caller's plan, so `GET /api/mcp/schemas` stays anonymous and publicly cacheable (same precedent as `app/api/workflows/public/route.ts` which already returns `requiredPlan` to unauthenticated callers).

**`lib/mcp/tools.ts`** - `search_protocol_actions` compact projection now carries `requiredPlan` through (its local type dropped unknown fields, so this is the one place the new field would otherwise vanish).

**`docs/api/workflows.md`** - documents `requiredPlan` on the action-schema response and documents `GET /api/features` (the org feature snapshot: plan, enabled feature ids, full registry) for the first time.

`specs/api-coverage.json` regenerated (the new `/api/features` section is now fence-owned by workflows.md).

## Test

`tests/unit/action-schema-required-plan.test.ts`: explicitly gated plugin action (`code/run-code` -> pro), egress-gated plugin action with no FEATURES entry (blockscout -> pro, the case a table-only lookup misses), ungated plugin action (null), gated system actions (HTTP Request / Database Query -> pro), ungated system actions (null). 5 tests; related suites (features-egress-invariant, action-output-fields, action-config-helpers) pass.
