### PR TITLE
fix: #2004 enforce the simulate invariant across /api/execute/*

### DIFF
--- a/app/api/execute/[...slug]/route.ts
+++ b/app/api/execute/[...slug]/route.ts
@@ -41,6 +41,7 @@ import {
 import { buildProtocolFunctionArgs } from "../_lib/protocol-function-args";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseNativeValueWei } from "../_lib/reserved-value";
+import { refuseSimulateBody, rejectSimulateQuery } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import type { ExecuteResponse } from "../_lib/types";
 import { requireWallet } from "../_lib/wallet-check";
@@ -377,6 +378,13 @@ export async function POST(
     );
   }
 
+  // #2004: ?simulate= is refused on every /api/execute/* route rather than
+  // silently ignored.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
+  }
+
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
@@ -409,6 +417,16 @@ export async function POST(
       { error: "Invalid JSON body" },
       { status: HttpStatus.BAD_REQUEST }
     );
+  }
+
+  // #2004 (the severe half): this route has no dry-run support, and a body
+  // `simulate` used to fall through as an unknown field while the protocol
+  // action broadcast for real (issue #1929). Refuse it loudly, before the
+  // idempotency key is reserved so a refused request consumes no execution
+  // and leaves no lock to release.
+  const simulateBody = refuseSimulateBody(body);
+  if (simulateBody) {
+    return simulateBody;
   }
 
   const idem = await beginIdempotentFromRequest({

--- a/app/api/execute/[executionId]/status/route.ts
+++ b/app/api/execute/[executionId]/status/route.ts
@@ -10,6 +10,7 @@ import { requireScope } from "@/lib/middleware/require-scope";
 import { applyRateLimitHeaders } from "@/lib/rate-limit-headers";
 import { validateApiKey } from "../../_lib/auth";
 import { checkRateLimit } from "../../_lib/rate-limit";
+import { rejectSimulateQuery } from "../../_lib/simulate-flag";
 import type { ExecutionStatusResponse } from "../../_lib/types";
 
 // Seconds a client should wait before polling status again while the execution
@@ -37,6 +38,14 @@ export async function GET(
   });
   if (scopeError) {
     return scopeError;
+  }
+
+  // #2004: ?simulate= is refused rather than ignored on every /api/execute/*
+  // route. This endpoint is read-only, so a dry run has nothing to mean here
+  // -- there is exactly one shape of status request.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
   }
 
   const rateLimit = checkRateLimit(apiKeyCtx.apiKeyId);

--- a/app/api/execute/_lib/simulate-flag.ts
+++ b/app/api/execute/_lib/simulate-flag.ts
@@ -11,7 +11,20 @@
  * supported: an execute endpoint must have exactly one shape per
  * input, and silently falling through to "spend real funds" because
  * a caller mistyped `"true"` instead of `true` is unsafe.
+ *
+ * #2004: the same principle extended to the flag's *place*. Every
+ * /api/execute/* route rejects a `simulate` query parameter with 400
+ * (rejectSimulateQuery), and a route with no dry-run support at all
+ * rejects a body `simulate` with 400 (refuseSimulateBody) instead of
+ * dropping the field and broadcasting for real. A route either honours
+ * a dry run or refuses one -- it never accepts the flag and
+ * broadcasts. tests/integration/execute-simulate-invariant.test.ts
+ * enumerates the routes from the filesystem and fails when a route
+ * has not declared (and wired) its side.
  */
+
+import { NextResponse } from "next/server";
+import { HttpStatus } from "@/lib/http-status";
 
 type ParsedSimulateFlag =
   | { ok: true; simulate: boolean }
@@ -32,4 +45,62 @@ export function parseSimulateFlag(
     };
   }
   return { ok: true, simulate: value };
+}
+
+// The only routes that honour a body dry run. Refusal messages name them so a
+// caller holding the flag in the wrong place knows where it belongs. Keep in
+// sync with the routes that call parseSimulateFlag.
+const DRY_RUN_ROUTES =
+  "/api/execute/transfer, /api/execute/contract-call, and /api/execute/check-and-execute";
+
+function simulateUnsupportedResponse(error: string): NextResponse {
+  return NextResponse.json(
+    { error, field: "simulate", code: "unsupported_param" },
+    { status: HttpStatus.BAD_REQUEST }
+  );
+}
+
+/**
+ * Reject a `simulate` query parameter on any /api/execute/* route (#2004).
+ *
+ * The query string was never honoured, but silently ignoring it made "I asked
+ * for a dry run" and "spend real funds" indistinguishable on the wire -- the
+ * same hazard as a flag of the wrong type, just in the wrong place. Any
+ * `simulate` key is now a 400: `true`, `false`, an empty value, or a
+ * mistyped string. Other query parameters are untouched.
+ *
+ * Returns the 400 response, or null when no `simulate` query parameter is
+ * present -- the proceed signal, matching the `NextResponse | null` guard
+ * convention used by requireScope and requireWallet.
+ */
+export function rejectSimulateQuery(request: Request): NextResponse | null {
+  if (!new URL(request.url).searchParams.has("simulate")) {
+    return null;
+  }
+  return simulateUnsupportedResponse(
+    `\`simulate\` is not accepted as a query parameter. Pass it in the JSON body instead; a body dry run is honoured by ${DRY_RUN_ROUTES} and refused by every other /api/execute/* route.`
+  );
+}
+
+/**
+ * Refuse a `simulate` field in the body of a route with no dry-run support
+ * (#2004, the refusal branch of item 1).
+ *
+ * On these routes the flag used to fall through as an unknown body field and
+ * the route broadcast for real -- the exact "accepted the flag and
+ * broadcast" shape the simulate invariant forbids. Any value is refused
+ * (including the string "true"): a route with no dry-run support has no
+ * correct flag shape to accept.
+ *
+ * Same `NextResponse | null` convention as rejectSimulateQuery. Call it
+ * before the idempotency key is reserved so a refused request consumes no
+ * execution and leaves no lock to release.
+ */
+export function refuseSimulateBody(body: unknown): NextResponse | null {
+  if (typeof body !== "object" || body === null || !("simulate" in body)) {
+    return null;
+  }
+  return simulateUnsupportedResponse(
+    `\`simulate\` is not supported on this route: it executes for real and cannot dry-run. Dry runs are honoured by ${DRY_RUN_ROUTES}.`
+  );
 }

--- a/app/api/execute/check-and-execute/route.ts
+++ b/app/api/execute/check-and-execute/route.ts
@@ -34,7 +34,7 @@ import {
   withRejectedSignerOverride,
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
-import { parseSimulateFlag } from "../_lib/simulate-flag";
+import { parseSimulateFlag, rejectSimulateQuery } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import { validateCheckAndExecuteInput } from "../_lib/validate";
 import { requireWallet } from "../_lib/wallet-check";
@@ -340,6 +340,13 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: apiKeyCtx.error },
       { status: apiKeyCtx.status }
     );
+  }
+
+  // #2004: ?simulate= is refused on every /api/execute/* route rather than
+  // silently ignored. This route honours the flag only in the body.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
   }
 
   // Parsed before the scope gate because the required scope depends on

--- a/app/api/execute/contract-call/route.ts
+++ b/app/api/execute/contract-call/route.ts
@@ -33,7 +33,7 @@ import {
 } from "../_lib/execution-service";
 import { checkRateLimit } from "../_lib/rate-limit";
 import { parseNativeValueWei } from "../_lib/reserved-value";
-import { parseSimulateFlag } from "../_lib/simulate-flag";
+import { parseSimulateFlag, rejectSimulateQuery } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import type { ExecuteResponse } from "../_lib/types";
 import { validateContractCallInput } from "../_lib/validate";
@@ -266,6 +266,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: apiKeyCtx.error },
       { status: apiKeyCtx.status }
     );
+  }
+
+  // #2004: ?simulate= is refused on every /api/execute/* route rather than
+  // silently ignored. This route honours the flag only in the body; the
+  // old "query string must NOT be honoured" position is retired deliberately
+  // -- a family where transfer rejects and this route ignores is the worst
+  // of the three uniform answers.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
   }
 
   // Parsed before the scope gate because the required scope depends on

--- a/app/api/execute/node/route.ts
+++ b/app/api/execute/node/route.ts
@@ -42,6 +42,7 @@ import {
   type TransactionResult,
   transactionRetryOptions,
 } from "../_lib/retry";
+import { refuseSimulateBody, rejectSimulateQuery } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import type { NodeExecuteRequest, RetryConfig } from "../_lib/types";
 import { requireWallet } from "../_lib/wallet-check";
@@ -504,6 +505,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     );
   }
 
+  // #2004: ?simulate= is refused on every /api/execute/* route rather than
+  // silently ignored.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
+  }
+
   const scopeError = requireScope(apiKeyCtx.scope, SCOPE_MCP_WRITE, {
     organizationId: apiKeyCtx.organizationId,
     credentialId: apiKeyCtx.apiKeyId,
@@ -541,6 +549,16 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: "Invalid JSON body" },
       { status: HttpStatus.BAD_REQUEST }
     );
+  }
+
+  // #2004: this route has no dry-run support. A top-level `simulate` used to
+  // be dropped by validateRequest's fixed whitelist and the step broadcast
+  // for real -- the same accept-and-broadcast defect as the protocol route,
+  // reached through a different mechanism. Refuse it loudly, before the
+  // whitelist and before the idempotency key is reserved.
+  const simulateBody = refuseSimulateBody(body);
+  if (simulateBody) {
+    return simulateBody;
   }
 
   const validation = validateRequest(body);

--- a/app/api/execute/swap/route.ts
+++ b/app/api/execute/swap/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { SCOPE_MCP_WRITE } from "@/lib/mcp/oauth-scopes";
 import { requireScope } from "@/lib/middleware/require-scope";
 import { validateApiKey } from "../_lib/auth";
+import { rejectSimulateQuery } from "../_lib/simulate-flag";
 
 export async function POST(request: Request): Promise<NextResponse> {
   const apiKeyCtx = await validateApiKey(request);
@@ -22,6 +23,14 @@ export async function POST(request: Request): Promise<NextResponse> {
   });
   if (scopeError) {
     return scopeError;
+  }
+
+  // #2004: ?simulate= is refused rather than ignored on every /api/execute/*
+  // route, including this stub. The body is never read here, so there is no
+  // body flag to refuse -- the 501 already refuses everything.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
   }
 
   return NextResponse.json({ message: "Coming soon" }, { status: 501 });

--- a/app/api/execute/transfer/route.ts
+++ b/app/api/execute/transfer/route.ts
@@ -36,7 +36,7 @@ import {
   parseNativeValueLamports,
   parseNativeValueWei,
 } from "../_lib/reserved-value";
-import { parseSimulateFlag } from "../_lib/simulate-flag";
+import { parseSimulateFlag, rejectSimulateQuery } from "../_lib/simulate-flag";
 import { checkAndReserveExecution } from "../_lib/spending-cap";
 import type { ExecuteResponse } from "../_lib/types";
 import { validateTokenFields, validateTransferInput } from "../_lib/validate";
@@ -50,6 +50,15 @@ export async function POST(request: Request): Promise<NextResponse> {
       { error: apiKeyCtx.error },
       { status: apiKeyCtx.status }
     );
+  }
+
+  // 1.5 #2004: ?simulate= is refused on every /api/execute/* route rather
+  // than silently ignored. This route honours the flag only in the body;
+  // a query flag used to fall through to a real broadcast with no
+  // acknowledgement that a dry run had been asked for.
+  const simulateQuery = rejectSimulateQuery(request);
+  if (simulateQuery) {
+    return simulateQuery;
   }
 
   // Parsed before the scope gate because the required scope depends on

--- a/tests/integration/execute-simulate-invariant.test.ts
+++ b/tests/integration/execute-simulate-invariant.test.ts
@@ -1,0 +1,647 @@
+/**
+ * #2004 -- the simulate invariant across /api/execute/*, enforced the way
+ * the issue asks for it: "a route either honours a dry run or refuses one,
+ * and never accepts the flag and broadcasts."
+ *
+ * The route list is NOT maintained by hand here. The first test walks
+ * app/api/execute on the filesystem for every route.ts, and each discovered
+ * route must appear in ROUTE_STANCES below -- a new route file cannot merge
+ * without declaring (and wiring) exactly one of:
+ *
+ *   - honors-body:  body simulate:true dry-runs; a query flag and a
+ *     mistyped flag are 400s; the broadcast cores are unreachable whenever
+ *     a flag is present
+ *   - refuses:      body AND query `simulate` are both 400s before any
+ *     reservation, execution row, or broadcast
+ *   - stub-501:     the route never reads a body and answers 501, so it
+ *     cannot broadcast by construction; the query flag is still a 400
+ *   - read-only-get: no POST handler exists; the query flag is still a 400
+ *
+ * The per-stance assertions iterate over the manifest, so a route declared
+ * here automatically gets its behavioural checks -- declaring a stance
+ * without wiring the guard fails this suite.
+ *
+ * The honouring routes' simulate-path details (response shapes, revert
+ * surfaces, token transfers) live in
+ * tests/integration/execute-simulate-route.test.ts; this file holds only
+ * the family-wide invariant.
+ *
+ * Run with: pnpm vitest tests/integration/execute-simulate-invariant.test.ts
+ */
+
+import { readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Filesystem enumeration -- the route list comes from disk (the 9/7 comment
+// on #2004), not from a list someone maintains by hand.
+// ---------------------------------------------------------------------------
+
+const EXECUTE_DIR = fileURLToPath(
+  new URL("../../app/api/execute", import.meta.url)
+);
+
+// Returns sorted route keys: app/api/execute/<key>/route.ts, relative to the
+// execute dir, with the route.ts segment stripped. Underscore-prefixed dirs
+// (_lib and friends) are not route segments.
+function discoverExecuteRoutes(): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith("_") || entry.name.startsWith(".")) {
+        continue;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.name === "route.ts") {
+        const segments = path.relative(EXECUTE_DIR, full).split(path.sep);
+        found.push(segments.slice(0, -1).join("/"));
+      }
+    }
+  };
+  walk(EXECUTE_DIR);
+  return found.sort();
+}
+
+type SimulateStance = "honors-body" | "refuses" | "stub-501" | "read-only-get";
+
+type RouteStance = { stance: SimulateStance; why: string };
+
+// The manifest. Every route discovered on disk must appear here exactly once
+// (and vice versa); the behavioural suites below are generated from it.
+const ROUTE_STANCES: Record<string, RouteStance> = {
+  transfer: {
+    stance: "honors-body",
+    why: "native/token transfer dry-runs via estimateGas; flag in body only",
+  },
+  "contract-call": {
+    stance: "honors-body",
+    why: "write dry-runs via provider.call + estimateGas; flag in body only",
+  },
+  "check-and-execute": {
+    stance: "honors-body",
+    why: "condition is read-only, the action write dry-runs; flag in body only",
+  },
+  "[...slug]": {
+    stance: "refuses",
+    why: "protocol actions broadcast for real (#1929); no per-action dry-run semantics, so the flag is refused (#2004 item 1, refusal branch)",
+  },
+  node: {
+    stance: "refuses",
+    why: "arbitrary node steps execute for real; simulate was silently dropped by the validator whitelist (#1929's twin) and is now refused",
+  },
+  swap: {
+    stance: "stub-501",
+    why: "501 Coming soon; body never parsed, nothing to broadcast; query flag still refused",
+  },
+  "[executionId]/status": {
+    stance: "read-only-get",
+    why: "GET-only status poll; no POST handler exists so no flag can change an outcome; query flag still refused",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Hoisted spies -- shared by every route harness below.
+// ---------------------------------------------------------------------------
+
+const FROM_ADDRESS = "0xaa0000000000000000000000000000000000aa00";
+
+const spies = vi.hoisted(() => ({
+  checkAndReserveExecution: vi.fn(),
+  markRunning: vi.fn(),
+  completeExecution: vi.fn(),
+  failExecution: vi.fn(),
+  setRetryCount: vi.fn(),
+  createExecution: vi.fn(),
+  writeContractCore: vi.fn(),
+  transferFundsCore: vi.fn(),
+  transferTokenCore: vi.fn(),
+  readContractCore: vi.fn(),
+  stepFn: vi.fn(),
+  simulateContractCallMock: vi.fn(),
+  simulateNativeTransferMock: vi.fn(),
+  simulateTokenTransferMock: vi.fn(),
+  resolveAction: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/protocols", () => ({}));
+
+vi.mock("../../app/api/execute/_lib/auth", () => ({
+  validateApiKey: vi.fn(() =>
+    Promise.resolve({ organizationId: "org_test", apiKeyId: "key_test" })
+  ),
+}));
+
+vi.mock("@/lib/billing/execution-guard", () => ({
+  enforceExecutionLimit: vi.fn(() => Promise.resolve({ blocked: false })),
+}));
+
+vi.mock("@/lib/db/org-helpers", () => ({
+  enterApiExecuteErrorContext: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../app/api/execute/_lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(() => ({ allowed: true })),
+}));
+
+vi.mock("../../app/api/execute/_lib/wallet-check", () => ({
+  requireWallet: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("../../app/api/execute/_lib/spending-cap", () => ({
+  checkAndReserveExecution: spies.checkAndReserveExecution,
+}));
+
+vi.mock("../../app/api/execute/_lib/concurrency-limit", () => ({
+  enforceDirectExecutionConcurrency: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock(
+  "../../app/api/execute/_lib/execution-service",
+  async (importActual) => {
+    const actual =
+      await importActual<
+        typeof import("../../app/api/execute/_lib/execution-service")
+      >();
+    return {
+      ...actual,
+      createExecution: spies.createExecution,
+      markRunning: spies.markRunning,
+      completeExecution: spies.completeExecution,
+      failExecution: spies.failExecution,
+      setRetryCount: spies.setRetryCount,
+      redactInput: (x: unknown) => x,
+    };
+  }
+);
+
+vi.mock("@/plugins/web3/steps/write-contract-core", () => ({
+  writeContractCore: spies.writeContractCore,
+}));
+vi.mock("@/plugins/web3/steps/transfer-funds-core", () => ({
+  transferFundsCore: spies.transferFundsCore,
+}));
+vi.mock("@/plugins/web3/steps/transfer-token-core", () => ({
+  transferTokenCore: spies.transferTokenCore,
+}));
+vi.mock("@/plugins/web3/steps/read-contract-core", () => ({
+  readContractCore: spies.readContractCore,
+}));
+
+vi.mock("@/lib/execute/simulate", () => ({
+  simulateContractCall: spies.simulateContractCallMock,
+  simulateNativeTransfer: spies.simulateNativeTransferMock,
+  simulateTokenTransfer: spies.simulateTokenTransferMock,
+}));
+
+// Validation passes through so the honouring-route happy bodies reach the
+// simulate branch.
+vi.mock("../../app/api/execute/_lib/validate", () => ({
+  validateContractCallInput: () => ({ valid: true }),
+  validateTransferInput: () => ({ valid: true }),
+  validateTokenFields: () => ({ valid: true }),
+  validateCheckAndExecuteInput: () => ({ valid: true }),
+}));
+
+vi.mock("@/lib/abi/cache", () => ({
+  resolveAbi: vi.fn(() => Promise.resolve({ abi: "[]" })),
+}));
+
+vi.mock("@/lib/abi/utils", () => ({
+  findAbiFunction: (_abi: unknown, name: string) => {
+    if (name === "setValue") {
+      return { name, type: "function", stateMutability: "nonpayable" };
+    }
+    if (name === "balanceOf") {
+      return {
+        name,
+        type: "function",
+        stateMutability: "view",
+        outputs: [{ name: "", type: "uint256" }],
+      };
+    }
+    return;
+  },
+}));
+
+vi.mock("../../app/api/execute/_lib/condition", () => ({
+  evaluateCondition: () => ({ met: true }),
+}));
+
+// [...slug] harness needs a resolvable action so a removed guard would reach
+// the broadcast path rather than dying earlier on an unknown action.
+vi.mock("@/plugins/protocol/steps/resolve-protocol-meta", () => ({
+  resolveProtocolMeta: vi.fn(() => ({
+    protocolSlug: "test-protocol",
+    contractKey: "router",
+    functionName: "swap",
+    actionType: "write",
+  })),
+}));
+
+vi.mock("@/lib/protocol-registry", () => ({
+  getProtocol: vi.fn(() => ({
+    contracts: { router: { addresses: { "8453": "0xBaseRouter" } } },
+    actions: [],
+  })),
+  resolveContractAddress: (
+    contract: { addresses: Record<string, string> },
+    network: string
+  ) => contract.addresses[network],
+}));
+
+vi.mock("@/lib/step-registry", () => ({
+  PLUGIN_STEP_IMPORTERS: {
+    "test-protocol/swap": () => Promise.resolve({}),
+  },
+}));
+
+// node harness: the resolved action would execute a step if the guard were
+// removed, so the refusal is observable as "stepFn never ran".
+vi.mock("@/app/api/execute/_lib/action-resolver", () => ({
+  resolveAction: spies.resolveAction,
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  integrations: { id: "id", organizationId: "organizationId" },
+  directExecutions: {},
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => Promise.resolve([])),
+        })),
+      })),
+    })),
+  },
+}));
+
+// Routes imported after mocks.
+import { POST as slugPOST } from "@/app/api/execute/[...slug]/route";
+import { GET as statusGET } from "@/app/api/execute/[executionId]/status/route";
+import { POST as checkAndExecutePOST } from "@/app/api/execute/check-and-execute/route";
+import { POST as contractCallPOST } from "@/app/api/execute/contract-call/route";
+import { POST as nodePOST } from "@/app/api/execute/node/route";
+import { POST as swapPOST } from "@/app/api/execute/swap/route";
+import { POST as transferPOST } from "@/app/api/execute/transfer/route";
+
+// ---------------------------------------------------------------------------
+// Fixtures + harnesses.
+// ---------------------------------------------------------------------------
+
+const WRITE_ABI = JSON.stringify([
+  {
+    type: "function",
+    name: "setValue",
+    inputs: [{ name: "v", type: "uint256" }],
+    outputs: [],
+    stateMutability: "nonpayable",
+  },
+]);
+
+const HAPPY_SIMULATE = {
+  success: true,
+  status: "simulated" as const,
+  from: FROM_ADDRESS,
+  to: "0xbb0000000000000000000000000000000000bb00",
+  value: "0",
+  gasEstimate: "42000",
+  simulatedReturnValue: null,
+  wouldRevert: false as const,
+};
+
+function jsonRequest(url: string, body: Record<string, unknown>): Request {
+  return new Request(`http://localhost${url}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+type HonoringHarness = {
+  post: (url: string, body: Record<string, unknown>) => Promise<Response>;
+  // Arrange the simulator so a dry-run body reaches a 200 "simulated".
+  arrange: () => void;
+  // The simulator spy that must be the ONLY side effect on the dry-run path.
+  simulator: ReturnType<typeof vi.fn>;
+  // A body the route accepts up to the simulate branch.
+  happyBody: Record<string, unknown>;
+};
+
+const HONORING_HARNESSES: Record<string, HonoringHarness> = {
+  transfer: {
+    post: (url, body) => transferPOST(jsonRequest(url, body)),
+    arrange: () =>
+      spies.simulateNativeTransferMock.mockResolvedValueOnce(HAPPY_SIMULATE),
+    simulator: spies.simulateNativeTransferMock,
+    happyBody: {
+      recipientAddress: "0xcc0000000000000000000000000000000000cc00",
+      amount: "0.1",
+      chainId: 1,
+    },
+  },
+  "contract-call": {
+    post: (url, body) => contractCallPOST(jsonRequest(url, body)),
+    arrange: () =>
+      spies.simulateContractCallMock.mockResolvedValueOnce(HAPPY_SIMULATE),
+    simulator: spies.simulateContractCallMock,
+    happyBody: {
+      contractAddress: "0xbb0000000000000000000000000000000000bb00",
+      network: "1",
+      functionName: "setValue",
+      abi: WRITE_ABI,
+      functionArgs: JSON.stringify(["1"]),
+    },
+  },
+  "check-and-execute": {
+    post: (url, body) => checkAndExecutePOST(jsonRequest(url, body)),
+    arrange: () => {
+      spies.readContractCore.mockResolvedValueOnce({
+        success: true,
+        result: 100,
+      });
+      spies.simulateContractCallMock.mockResolvedValueOnce(HAPPY_SIMULATE);
+    },
+    simulator: spies.simulateContractCallMock,
+    happyBody: {
+      contractAddress: "0xbb0000000000000000000000000000000000bb00",
+      functionName: "balanceOf",
+      functionArgs: JSON.stringify([FROM_ADDRESS]),
+      abi: JSON.stringify([
+        {
+          type: "function",
+          name: "balanceOf",
+          inputs: [{ name: "", type: "address" }],
+          outputs: [{ name: "", type: "uint256" }],
+          stateMutability: "view",
+        },
+      ]),
+      chainId: 1,
+      condition: {},
+      action: {
+        contractAddress: "0xbb0000000000000000000000000000000000bb00",
+        functionName: "setValue",
+        functionArgs: JSON.stringify(["1"]),
+        abi: WRITE_ABI,
+      },
+    },
+  },
+};
+
+type RefusingHarness = {
+  post: (url: string, body: Record<string, unknown>) => Promise<Response>;
+  // A body that would execute for real if the simulate guard were removed.
+  executableBody: Record<string, unknown>;
+};
+
+const REFUSING_HARNESSES: Record<string, RefusingHarness> = {
+  "[...slug]": {
+    post: (url, body) =>
+      slugPOST(jsonRequest(url, body), {
+        params: Promise.resolve({ slug: ["test-protocol", "swap"] }),
+      }),
+    executableBody: { chainId: 8453 },
+  },
+  node: {
+    post: (url, body) => nodePOST(jsonRequest(url, body)),
+    executableBody: {
+      actionType: "web3/write-contract",
+      config: { network: "1", contractAddress: "0xabc" },
+    },
+  },
+};
+
+const {
+  checkAndReserveExecution,
+  markRunning,
+  completeExecution,
+  failExecution,
+  setRetryCount,
+  createExecution,
+  writeContractCore,
+  transferFundsCore,
+  transferTokenCore,
+  stepFn,
+  resolveAction,
+} = spies;
+
+// The invariant's core claim: a flag-shaped request never reaches anything
+// that reserves, records, or broadcasts.
+function expectNoBroadcastSideEffects(): void {
+  expect(checkAndReserveExecution).not.toHaveBeenCalled();
+  expect(markRunning).not.toHaveBeenCalled();
+  expect(completeExecution).not.toHaveBeenCalled();
+  expect(failExecution).not.toHaveBeenCalled();
+  expect(createExecution).not.toHaveBeenCalled();
+  expect(setRetryCount).not.toHaveBeenCalled();
+  expect(writeContractCore).not.toHaveBeenCalled();
+  expect(transferFundsCore).not.toHaveBeenCalled();
+  expect(transferTokenCore).not.toHaveBeenCalled();
+  expect(stepFn).not.toHaveBeenCalled();
+}
+
+async function expectUnsupportedParam(res: Response): Promise<void> {
+  expect(res.status).toBe(400);
+  const body = (await res.json()) as Record<string, unknown>;
+  expect(body.code).toBe("unsupported_param");
+  expect(body.field).toBe("simulate");
+  // The refusal names the routes that do honour a dry run, so a caller
+  // holding the flag in the wrong place knows where it belongs.
+  expect(String(body.error)).toContain("/api/execute/transfer");
+  expect(String(body.error)).toContain("/api/execute/contract-call");
+  expect(String(body.error)).toContain("/api/execute/check-and-execute");
+}
+
+beforeEach(() => {
+  for (const spy of Object.values(spies)) {
+    spy.mockReset();
+  }
+  completeExecution.mockResolvedValue({ status: "completed" });
+  failExecution.mockResolvedValue({ status: "failed" });
+  checkAndReserveExecution.mockResolvedValue({
+    allowed: true,
+    executionId: "exec_1",
+  });
+  createExecution.mockResolvedValue({ executionId: "exec_1" });
+  resolveAction.mockImplementation((actionType: string) => ({
+    actionType,
+    label: "Test Action",
+    importer: {
+      importer: () => Promise.resolve({ step: stepFn }),
+      stepFunction: "step",
+    },
+    isPluginAction: true,
+  }));
+  stepFn.mockResolvedValue({ success: true });
+});
+
+// ---------------------------------------------------------------------------
+// Part 1: the route list comes from the filesystem.
+// ---------------------------------------------------------------------------
+
+describe("#2004 route discovery", () => {
+  it("every route file under app/api/execute has declared a simulate stance", () => {
+    const discovered = discoverExecuteRoutes();
+    const declared = Object.keys(ROUTE_STANCES).sort();
+
+    // Both directions: a new route file cannot appear without a stance, and
+    // a deleted route cannot leave a stale one behind.
+    expect(discovered).toEqual(declared);
+  });
+
+  it("the refusal messages name exactly the routes that honour a dry run", () => {
+    const honoring = Object.entries(ROUTE_STANCES)
+      .filter(([, s]) => s.stance === "honors-body")
+      .map(([key]) => `/api/execute/${key}`)
+      .sort();
+    // Guarded structurally by expectUnsupportedParam; here we pin that the
+    // honouring set is exactly the three routes the issue names, so the
+    // message cannot silently drift.
+    expect(honoring).toEqual([
+      "/api/execute/check-and-execute",
+      "/api/execute/contract-call",
+      "/api/execute/transfer",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part 2: honouring routes -- dry-run in the body, refusal everywhere else.
+// ---------------------------------------------------------------------------
+
+describe("#2004 honouring routes", () => {
+  for (const [routeKey, harness] of Object.entries(HONORING_HARNESSES)) {
+    describe(routeKey, () => {
+      it("body simulate:true dry-runs: the simulator is the only side effect", async () => {
+        harness.arrange();
+
+        const res = await harness.post(`/api/execute/${routeKey}`, {
+          ...harness.happyBody,
+          simulate: true,
+        });
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.status).toBe("simulated");
+        expect(harness.simulator).toHaveBeenCalledTimes(1);
+        expectNoBroadcastSideEffects();
+      });
+
+      it("query ?simulate=true is a 400 and never reserves or broadcasts", async () => {
+        const res = await harness.post(
+          `/api/execute/${routeKey}?simulate=true`,
+          harness.happyBody
+        );
+
+        await expectUnsupportedParam(res);
+        expect(harness.simulator).not.toHaveBeenCalled();
+        expectNoBroadcastSideEffects();
+      });
+
+      it("body simulate:'true' is still a 400 (strict boolean, nothing falls through)", async () => {
+        const res = await harness.post(`/api/execute/${routeKey}`, {
+          ...harness.happyBody,
+          simulate: "true" as unknown as boolean,
+        });
+
+        expect(res.status).toBe(400);
+        expect(harness.simulator).not.toHaveBeenCalled();
+        expectNoBroadcastSideEffects();
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Part 3: refusing routes -- any flag shape is a 400 before any side effect.
+// ---------------------------------------------------------------------------
+
+describe("#2004 refusing routes", () => {
+  for (const [routeKey, harness] of Object.entries(REFUSING_HARNESSES)) {
+    describe(routeKey, () => {
+      it("body simulate:true is a 400 before any reservation or broadcast", async () => {
+        const res = await harness.post(`/api/execute/${routeKey}`, {
+          ...harness.executableBody,
+          simulate: true,
+        });
+
+        await expectUnsupportedParam(res);
+        expectNoBroadcastSideEffects();
+      });
+
+      it("body simulate:'true' is refused too -- a refusing route has no correct flag shape", async () => {
+        const res = await harness.post(`/api/execute/${routeKey}`, {
+          ...harness.executableBody,
+          simulate: "true" as unknown as boolean,
+        });
+
+        expect(res.status).toBe(400);
+        expectNoBroadcastSideEffects();
+      });
+
+      it("query ?simulate=true is a 400 before anything else", async () => {
+        const res = await harness.post(
+          `/api/execute/${routeKey}?simulate=true`,
+          harness.executableBody
+        );
+
+        await expectUnsupportedParam(res);
+        expectNoBroadcastSideEffects();
+      });
+    });
+  }
+
+  it("the [...slug] refusal fires even when the action would resolve", async () => {
+    // resolveProtocolMeta is mocked to a resolvable write action; the flag
+    // must still be refused before any protocol resolution, idempotency
+    // reservation, or execution row.
+    const res = await slugPOST(
+      jsonRequest("/api/execute/test-protocol/swap", {
+        chainId: 8453,
+        simulate: true,
+      }),
+      { params: Promise.resolve({ slug: ["test-protocol", "swap"] }) }
+    );
+
+    await expectUnsupportedParam(res);
+    expectNoBroadcastSideEffects();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Part 4: the two routes that cannot broadcast, for completeness of the
+// family-wide query refusal (#2004 item 2: every /api/execute/* route).
+// ---------------------------------------------------------------------------
+
+describe("#2004 non-broadcast routes still refuse the query flag", () => {
+  it("swap: ?simulate=true is a 400, not the 501", async () => {
+    const res = await swapPOST(
+      jsonRequest("/api/execute/swap?simulate=true", {})
+    );
+    await expectUnsupportedParam(res);
+  });
+
+  it("swap: without the flag the stub still answers 501", async () => {
+    const res = await swapPOST(jsonRequest("/api/execute/swap", {}));
+    expect(res.status).toBe(501);
+  });
+
+  it("[executionId]/status: GET ?simulate=true is a 400", async () => {
+    const res = await statusGET(
+      new Request("http://localhost/api/execute/exec_1/status?simulate=true", {
+        method: "GET",
+      }),
+      { params: Promise.resolve({ executionId: "exec_1" }) }
+    );
+    await expectUnsupportedParam(res);
+  });
+});

--- a/tests/integration/execute-simulate-route.test.ts
+++ b/tests/integration/execute-simulate-route.test.ts
@@ -8,11 +8,19 @@
  *   - body.simulate === true (strict boolean) routes to the simulator
  *   - any non-boolean simulate value is rejected with 400 before any
  *     reserve / broadcast happens
+ *   - a `simulate` query parameter is rejected with 400 on every route
+ *     (#2004: a flag in the wrong place is the same hazard as a flag of
+ *     the wrong type -- the old "the query string must NOT be honoured"
+ *     position is retired deliberately)
  *   - checkAndReserveExecution is NOT called on the simulate path
  *   - markRunning is NOT called on the simulate path
  *   - the broadcast cores (writeContractCore, transferFundsCore,
  *     transferTokenCore) are NOT called
  *   - the route returns the simulate response shape
+ *
+ * The route-family-wide invariant (every route declares honours-or-
+ * refuses, enforced by filesystem enumeration) lives in
+ * tests/integration/execute-simulate-invariant.test.ts.
  *
  * Run with: pnpm vitest tests/integration/execute-simulate-route.test.ts
  */
@@ -269,22 +277,15 @@ describe("/api/execute/contract-call simulate", () => {
     expect(writeContractCore).not.toHaveBeenCalled();
   });
 
-  it("query-string simulate is ignored (one shape per input)", async () => {
+  it("rejects a ?simulate=true query parameter with 400 (#2004), never broadcasting", async () => {
     resetSpies();
-    // Without body.simulate, the query string must NOT be honoured —
-    // there is exactly one way to ask for a dry-run.
-    writeContractCore.mockResolvedValueOnce({
-      success: true,
-      transactionHash: "0xabc",
-      transactionLink: null,
-      gasUsed: "21000",
-      effectiveGasPrice: "1",
-    });
-    checkAndReserveExecution.mockResolvedValueOnce({
-      allowed: true,
-      executionId: "exec_1",
-    });
-
+    // The old contract here asserted 202 + a real broadcast, on the position
+    // that the query string must NOT be honoured ("there is exactly one way
+    // to ask for a dry-run"). #2004 retires that position deliberately: a
+    // family where transfer rejects the query flag and contract-call ignores
+    // it is the worst of the three uniform answers, and a caller that asked
+    // for a dry run and got a broadcast cannot tell the difference on the
+    // wire. The query flag is now a 400 before anything is reserved.
     const res = await contractCallPOST(
       jsonRequest("/api/execute/contract-call?simulate=true", {
         contractAddress: "0xbb0000000000000000000000000000000000bb00",
@@ -295,10 +296,35 @@ describe("/api/execute/contract-call simulate", () => {
       })
     );
 
-    expect(res.status).toBe(202);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("unsupported_param");
+    expect(body.field).toBe("simulate");
     expect(simulateContractCallMock).not.toHaveBeenCalled();
-    expect(checkAndReserveExecution).toHaveBeenCalledTimes(1);
-    expect(writeContractCore).toHaveBeenCalledTimes(1);
+    expect(checkAndReserveExecution).not.toHaveBeenCalled();
+    expect(markRunning).not.toHaveBeenCalled();
+    expect(writeContractCore).not.toHaveBeenCalled();
+  });
+
+  it("rejects ?simulate=false and ?simulate= the same as ?simulate=true", async () => {
+    resetSpies();
+    // Any `simulate` query key is refused -- a "false" or empty value must
+    // not read as "no dry run requested" when the caller is plainly holding
+    // the flag in the wrong place.
+    for (const query of ["?simulate=false", "?simulate="]) {
+      const res = await contractCallPOST(
+        jsonRequest(`/api/execute/contract-call${query}`, {
+          contractAddress: "0xbb0000000000000000000000000000000000bb00",
+          network: "1",
+          functionName: "setValue",
+          abi: WRITE_ABI,
+          functionArgs: JSON.stringify(["1"]),
+        })
+      );
+      expect(res.status).toBe(400);
+    }
+    expect(checkAndReserveExecution).not.toHaveBeenCalled();
+    expect(writeContractCore).not.toHaveBeenCalled();
   });
 
   it("returns HTTP 400 when the simulator reports a revert", async () => {


### PR DESCRIPTION
fix: #2004 enforce the simulate invariant across /api/execute/*

Closes #2004 (members #1929, #1959, #1933).

`simulate` now behaves uniformly across `/api/execute/*`: a route either honours a dry run or refuses one, and no route accepts the flag and broadcasts. One guard module, two guards, every route wired — and a filesystem-enumerated invariant test so a seventh route cannot merge without declaring a side.

## The five-route audit matrix

| Route | Body `simulate` before | Body `simulate` after | Query `?simulate=` before | Query `?simulate=` after | Test coverage |
|---|---|---|---|---|---|
| `/api/execute/transfer` | honoured (dry-run) | **unchanged** — still honoured | silently ignored → broadcast | **400 `unsupported_param`** | `execute-simulate-invariant.test.ts` (3 assertions) + `execute-simulate-route.test.ts` |
| `/api/execute/contract-call` | honoured (dry-run) | **unchanged** — still honoured | silently ignored → broadcast (test pinned 202 + broadcast) | **400 `unsupported_param`** (test deliberately rewritten) | same |
| `/api/execute/check-and-execute` | honoured (dry-run) | **unchanged** — still honoured | silently ignored → broadcast | **400 `unsupported_param`** | same |
| `/api/execute/{protocol}/{action}` (`[...slug]`) | **accepted, ignored → real broadcast** (#1929) | **400, before the idempotency key is reserved** — no execution row consumed | silently ignored → broadcast | **400** | `execute-simulate-invariant.test.ts` refusing-route block + resolution-precedence test |
| `/api/execute/node` | **accepted, dropped by the validator whitelist → real broadcast** (the 9/7 addition) | **400, before the whitelist runs** | silently ignored → broadcast | **400** | `execute-simulate-invariant.test.ts` refusing-route block |

Two non-write routes are wired for item 2's "every `/api/execute/*` route" and pinned in the manifest: `swap` (501 stub, body never read — `?simulate=` now 400, plain POST still 501) and `[executionId]/status` (GET-only — `?simulate=` now 400).

## The single decision point

Both guards live in `app/api/execute/_lib/simulate-flag.ts` next to `parseSimulateFlag`, and follow the same `NextResponse | null` guard convention as `requireScope`/`requireWallet`:

- `rejectSimulateQuery(request)` — any `simulate` key in the query string (`true`, `false`, empty, mistyped) is a 400 naming the three routes that honour a body dry run. Other query parameters are untouched.
- `refuseSimulateBody(body)` — any body `simulate` on a no-dry-run route is a 400. There is no correct flag shape on a refusing route, so every shape is refused, including `"true"`.

The 400 body carries `code: "unsupported_param"`, `field: "simulate"`, and a message naming `/api/execute/transfer`, `/api/execute/contract-call`, and `/api/execute/check-and-execute`.

Placement, per route:

- Honouring routes: after auth, before body parse — the rest of the route is untouched, so their existing semantics (strict-boolean body flag, `mcp:read` scope downgrade on dry runs, simulation cores) are unchanged.
- `[...slug]`: query guard after auth; body guard after `request.json()`, **before `beginIdempotentFromRequest`** — a refused request consumes no idempotency key and no `executionId`, which #1929's version burned silently.
- `node`: query guard after auth; body guard after `request.json()`, before `validateRequest` — the fixed whitelist (`route.ts:155-164` on `staging`) used to drop the field without a trace.

## Item 2 is an explicit call, made here

`tests/integration/execute-simulate-route.test.ts:272` used to assert `POST /api/execute/contract-call?simulate=true` → 202 + `writeContractCore` called, under the comment "the query string must NOT be honoured — there is exactly one way to ask for a dry-run." That position is retired **deliberately and in this PR, not in review**: as the 8/19 comment put it, a family where `transfer` rejects the query flag and `contract-call` ignores it is the worst of the three uniform answers — and a caller that asked for a dry run and received a broadcast cannot tell the difference on the wire. The rewritten test asserts the 400 and that nothing was reserved or broadcast. PR #2090 (transfer-only query guard, since closed) was exactly the split this avoids.

## The invariant test enumerates routes from the filesystem

`tests/integration/execute-simulate-invariant.test.ts` (per the 9/7 comment — "not from a list someone maintains by hand"):

1. Walks `app/api/execute` for every `route.ts` (`_lib` excluded) and requires each discovered route to appear exactly once in a stance manifest — and the manifest to contain no stale entries. A seventh route file cannot merge without declaring one of: `honors-body`, `refuses`, `stub-501` (swap), `read-only-get` (status).
2. Generates the behavioural assertions from that manifest, so declaring a stance without wiring the guard fails the suite. Per stance:
   - **honours**: body `simulate:true` → simulator is the *only* side effect (`checkAndReserveExecution`, `markRunning`, `completeExecution`, `failExecution`, `createExecution`, `setRetryCount`, `writeContractCore`, `transferFundsCore`, `transferTokenCore`, and the node step fn all asserted not called); query `?simulate=true` → 400 + zero side effects; body `"true"` → 400.
   - **refuses**: body `simulate:true` → 400 + zero side effects; body `"true"` → 400; query `?simulate=true` → 400 + zero side effects — including a test that the `[...slug]` refusal fires even when the protocol action would resolve.
   - **stub-501 / read-only-get**: `?simulate=` → 400; `swap` without the flag still 501.

## What is intentionally not here

- Real dry-run support for protocol actions / node steps (item 1's other branch — the refusal branch is the one the issue blessed as "the smaller change that removes the hazard today"; a future dry-run flips one route's answer, not the contract).
- Documentation: #2097's territory. One note for that issue: `docs/api/direct-execution.md`'s Dry-Run Simulation section now has a fifth sentence to consider, since the invariant itself is enforced in code and test.
- Case-insensitive query matching: the guard matches the exact `simulate` key, same as `parseSimulateFlag` matches the exact body field — an execute endpoint has exactly one shape per input.

## Verification (all run locally on Windows)

- `pnpm type-check` (tsgo, app) — 0 errors; `pnpm type-check:executor` — 0 errors
- `pnpm fix` (biome) — clean; remaining warning is the pre-existing file-size advisory present on an untouched tree
- `pnpm vitest run` on the touched surface — `execute-simulate-invariant` (21 new tests) + `execute-simulate-route` + `execute-node-reserved-fields` + `execute-protocol-*` (4 files) + `execute-scope-enforcement` + `execute-route-integration-authz` + `api-not-found` + `oauth-scope-route-gate` + `direct-execution-api` + `execute-api` — **all green (247 tests)**
- Full `tests/unit` suite — same failure set as the pre-existing Windows baseline established on the unmodified tree during #2368's verification (docker-sandbox and path-separator environment failures; unrelated to these routes), with the same method: compare against the unchanged base worktree before attributing anything to this PR.
