### PR TITLE
fix(metrics): restrict the Prometheus scrape endpoints to in-cluster callers

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ See [API Documentation](docs/api/index.md) for full reference.
 
 ## Observability
 
-Prometheus metrics exposed at `/api/metrics`:
+Prometheus metrics exposed at `/api/metrics`, readable from inside the cluster only:
 
 - Workflow execution performance
 - API latency

--- a/app/api/metrics/api/route.ts
+++ b/app/api/metrics/api/route.ts
@@ -3,14 +3,22 @@
  *
  * Exposes only in-memory API-process metrics (histograms, counters).
  * These are per-pod and should be scraped from all pods.
+ *
+ * Security: answers in-cluster callers only; see lib/metrics/scrape-guard.ts.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { authorizeMetricsScrape } from "@/lib/metrics/scrape-guard";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
+  }
+
+  const guard = await authorizeMetricsScrape(request);
+  if (!guard.allowed) {
+    return new NextResponse(guard.message, { status: guard.status });
   }
 
   try {

--- a/app/api/metrics/db/route.ts
+++ b/app/api/metrics/db/route.ts
@@ -9,18 +9,26 @@
  * route returns 404 so the heavy aggregate scan never runs on the
  * request-serving pods (the app's db-metrics ServiceMonitor is removed too).
  * The flag keeps the cutover reversible via config without a code revert.
+ *
+ * Security: answers in-cluster callers only; see lib/metrics/scrape-guard.ts.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { authorizeMetricsScrape } from "@/lib/metrics/scrape-guard";
 
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
   if (process.env.METRICS_DB_OFFLOADED === "true") {
     return new NextResponse("Not Found", { status: 404 });
   }
 
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
+  }
+
+  const guard = await authorizeMetricsScrape(request);
+  if (!guard.allowed) {
+    return new NextResponse(guard.message, { status: guard.status });
   }
 
   try {

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -4,13 +4,15 @@
  * Exposes application metrics in Prometheus format for scraping.
  * Only available when METRICS_COLLECTOR=prometheus is set.
  *
- * Security: This endpoint is only enabled when explicitly configured.
- * In production, it should only be accessible from within the cluster
- * (Prometheus scraper). The ingress should NOT expose /api/metrics publicly.
+ * Security: this endpoint is only enabled when explicitly configured, and it
+ * answers only in-cluster callers. The ingress routes every path on
+ * app.keeperhub.com to these pods, so the handler itself refuses requests that
+ * arrived through the edge; see lib/metrics/scrape-guard.ts.
  */
 
 import { NextResponse } from "next/server";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
+import { authorizeMetricsScrape } from "@/lib/metrics/scrape-guard";
 
 /**
  * GET /api/metrics
@@ -18,10 +20,15 @@ import { ErrorCategory, logSystemError } from "@/lib/logging";
  * Returns metrics in Prometheus text format.
  * Returns 404 if Prometheus metrics are not enabled.
  */
-export async function GET(): Promise<NextResponse> {
+export async function GET(request: Request): Promise<NextResponse> {
   // Only expose metrics when Prometheus collector is explicitly enabled
   if (process.env.METRICS_COLLECTOR !== "prometheus") {
     return new NextResponse("Not Found", { status: 404 });
+  }
+
+  const guard = await authorizeMetricsScrape(request);
+  if (!guard.allowed) {
+    return new NextResponse(guard.message, { status: guard.status });
   }
 
   try {

--- a/deploy/keeperhub-stack/prod/values.yaml
+++ b/deploy/keeperhub-stack/prod/values.yaml
@@ -248,6 +248,12 @@ app:
   podAnnotations:
     reloader.stakater.com/auto: "true"
 
+  # The app is the only component with an ingress, and it routes every path on
+  # its host to these pods, so /api/metrics* is reachable from the internet at
+  # the network layer. What keeps the per-org series private is that these
+  # scrapes arrive on the pod port directly, without the headers the edge adds,
+  # which is the signal the handlers authorize on (lib/metrics/scrape-guard.ts).
+  # Putting a proxy in front of this scrape would break it.
   serviceMonitors:
     enabled: true
     monitors:

--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -197,6 +197,12 @@ app:
   podAnnotations:
     reloader.stakater.com/auto: "true"
 
+  # The app is the only component with an ingress, and it routes every path on
+  # its host to these pods, so /api/metrics* is reachable from the internet at
+  # the network layer. What keeps the per-org series private is that these
+  # scrapes arrive on the pod port directly, without the headers the edge adds,
+  # which is the signal the handlers authorize on (lib/metrics/scrape-guard.ts).
+  # Putting a proxy in front of this scrape would break it.
   serviceMonitors:
     enabled: true
     monitors:

--- a/lib/metrics/scrape-guard.ts
+++ b/lib/metrics/scrape-guard.ts
@@ -15,9 +15,10 @@
  * Presence of any of them therefore means the request came through
  * app.keeperhub.com and is refused.
  *
- * A caller that must read metrics from outside the cluster signs the request
- * with the internal service HMAC (lib/internal-service-auth.ts), the same
- * scheme the /api/internal routes use.
+ * The edge check runs first and is unconditional. An in-cluster caller may
+ * additionally sign with the internal service HMAC (lib/internal-service-auth.ts),
+ * the same scheme the /api/internal routes use, but a signature does not buy a
+ * way in from the public host: the answer there is 404 either way.
  */
 
 import "server-only";
@@ -59,18 +60,19 @@ function hasAnyHeader(request: Request, names: readonly string[]): boolean {
 export async function authorizeMetricsScrape(
   request: Request
 ): Promise<MetricsScrapeGuardResult> {
+  // Edge check first. Answering a signed request differently from an unsigned
+  // one would let a prober confirm the route exists by sending a caller header
+  // and reading 401 instead of 404, so nothing from the edge gets that far.
+  if (hasAnyHeader(request, EDGE_FORWARDED_HEADERS)) {
+    return { allowed: false, status: 404, message: "Not Found" };
+  }
+
   if (hasAnyHeader(request, HMAC_HEADERS)) {
     const auth = await authenticateInternalService(request);
     if (auth.authenticated) {
       return { allowed: true };
     }
     return { allowed: false, status: auth.status, message: auth.error };
-  }
-
-  if (hasAnyHeader(request, EDGE_FORWARDED_HEADERS)) {
-    // Indistinguishable from a route that does not exist, so the endpoint does
-    // not confirm itself to an unauthenticated prober.
-    return { allowed: false, status: 404, message: "Not Found" };
   }
 
   return { allowed: true };

--- a/lib/metrics/scrape-guard.ts
+++ b/lib/metrics/scrape-guard.ts
@@ -1,0 +1,77 @@
+/**
+ * @security Access control for the Prometheus scrape endpoints under
+ * /api/metrics.
+ *
+ * The exposed series carry per-customer labels (org_slug, plan, workflow_id,
+ * plugin/action names, error breakdowns), so these routes must never answer a
+ * request that arrived from the public internet.
+ *
+ * Prometheus does not need the public edge. The ServiceMonitors in
+ * deploy/keeperhub-stack/<env>/values.yaml select the app Service and scrape
+ * the pod's http port directly over the cluster network, so a scrape reaches
+ * the handler with none of the headers the edge adds. Cloudflare sets
+ * cf-connecting-ip / cf-ray at its own edge and strips any client-supplied
+ * copy, and Traefik adds the x-forwarded-* set to every request it routes.
+ * Presence of any of them therefore means the request came through
+ * app.keeperhub.com and is refused.
+ *
+ * A caller that must read metrics from outside the cluster signs the request
+ * with the internal service HMAC (lib/internal-service-auth.ts), the same
+ * scheme the /api/internal routes use.
+ */
+
+import "server-only";
+
+import { authenticateInternalService } from "@/lib/internal-service-auth";
+
+/**
+ * Headers only a proxied request carries. Absence of all of them is what
+ * identifies a direct in-cluster scrape.
+ */
+const EDGE_FORWARDED_HEADERS: readonly string[] = [
+  "cf-connecting-ip",
+  "cf-ray",
+  "forwarded",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+];
+
+const HMAC_HEADERS: readonly string[] = [
+  "x-kh-caller",
+  "x-kh-signature",
+  "x-kh-timestamp",
+];
+
+export type MetricsScrapeGuardResult =
+  | { allowed: true }
+  | { allowed: false; status: number; message: string };
+
+function hasAnyHeader(request: Request, names: readonly string[]): boolean {
+  return names.some((name) => request.headers.get(name) !== null);
+}
+
+/**
+ * Decide whether a request may read metrics. Callers that claim the internal
+ * HMAC scheme are verified; everything else must be a direct in-cluster
+ * request.
+ */
+export async function authorizeMetricsScrape(
+  request: Request
+): Promise<MetricsScrapeGuardResult> {
+  if (hasAnyHeader(request, HMAC_HEADERS)) {
+    const auth = await authenticateInternalService(request);
+    if (auth.authenticated) {
+      return { allowed: true };
+    }
+    return { allowed: false, status: auth.status, message: auth.error };
+  }
+
+  if (hasAnyHeader(request, EDGE_FORWARDED_HEADERS)) {
+    // Indistinguishable from a route that does not exist, so the endpoint does
+    // not confirm itself to an unauthenticated prober.
+    return { allowed: false, status: 404, message: "Not Found" };
+  }
+
+  return { allowed: true };
+}

--- a/tests/unit/metrics-scrape-guard.test.ts
+++ b/tests/unit/metrics-scrape-guard.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Access control on the /api/metrics scrape endpoints.
+ *
+ * The series carry org_slug, plan and workflow_id labels, and the ingress
+ * routes every path on app.keeperhub.com to the app pods, so the handlers
+ * have to reject edge-originated requests themselves. Prometheus scrapes the
+ * pod port directly and so arrives without any forwarding header.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const authenticateInternalService = vi.fn();
+vi.mock("@/lib/internal-service-auth", () => ({
+  authenticateInternalService: (request: Request, rawBody?: string) =>
+    authenticateInternalService(request, rawBody),
+}));
+
+const { authorizeMetricsScrape } = await import("@/lib/metrics/scrape-guard");
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request("https://app.keeperhub.com/api/metrics", { headers });
+}
+
+beforeEach(() => {
+  authenticateInternalService.mockReset();
+});
+
+describe("authorizeMetricsScrape", () => {
+  it("allows a direct in-cluster scrape carrying no forwarding headers", async () => {
+    await expect(authorizeMetricsScrape(request())).resolves.toEqual({
+      allowed: true,
+    });
+  });
+
+  it.each([
+    "cf-connecting-ip",
+    "cf-ray",
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+  ])("refuses a request forwarded by the edge (%s)", async (header) => {
+    const result = await authorizeMetricsScrape(
+      request({ [header]: "1.2.3.4" })
+    );
+
+    expect(result).toEqual({
+      allowed: false,
+      status: 404,
+      message: "Not Found",
+    });
+  });
+
+  it("does not reach the HMAC verifier for an unsigned edge request", async () => {
+    await authorizeMetricsScrape(request({ "cf-connecting-ip": "1.2.3.4" }));
+
+    expect(authenticateInternalService).not.toHaveBeenCalled();
+  });
+
+  it("allows a signed internal caller arriving through the edge", async () => {
+    authenticateInternalService.mockResolvedValue({
+      authenticated: true,
+      caller: "mcp",
+      scheme: "hmac",
+    });
+
+    const result = await authorizeMetricsScrape(
+      request({
+        "cf-connecting-ip": "1.2.3.4",
+        "x-kh-caller": "mcp",
+        "x-kh-timestamp": "1700000000",
+        "x-kh-signature": "a".repeat(64),
+      })
+    );
+
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("propagates the verifier's rejection for a bad signature", async () => {
+    authenticateInternalService.mockResolvedValue({
+      authenticated: false,
+      error: "Invalid signature",
+      status: 401,
+    });
+
+    const result = await authorizeMetricsScrape(
+      request({
+        "x-kh-caller": "mcp",
+        "x-kh-timestamp": "1700000000",
+        "x-kh-signature": "b".repeat(64),
+      })
+    );
+
+    expect(result).toEqual({
+      allowed: false,
+      status: 401,
+      message: "Invalid signature",
+    });
+  });
+
+  it("verifies a partial HMAC claim rather than treating it as unsigned", async () => {
+    authenticateInternalService.mockResolvedValue({
+      authenticated: false,
+      error: "Missing HMAC headers",
+      status: 401,
+    });
+
+    const result = await authorizeMetricsScrape(
+      request({ "x-kh-caller": "mcp" })
+    );
+
+    expect(authenticateInternalService).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      allowed: false,
+      status: 401,
+      message: "Missing HMAC headers",
+    });
+  });
+});
+
+describe("metrics route handlers", () => {
+  // A new route added under app/api/metrics that forgets the guard would be
+  // publicly readable, so assert the wiring rather than only the helper.
+  it.each([
+    "app/api/metrics/route.ts",
+    "app/api/metrics/api/route.ts",
+    "app/api/metrics/db/route.ts",
+  ])("%s applies the scrape guard", (routePath) => {
+    const source = readFileSync(join(process.cwd(), routePath), "utf8");
+
+    expect(source).toContain("authorizeMetricsScrape");
+    expect(source).toMatch(/GET\(request: Request\)/);
+  });
+
+  it.each([
+    ["@/app/api/metrics/route", "/api/metrics"],
+    ["@/app/api/metrics/api/route", "/api/metrics/api"],
+    ["@/app/api/metrics/db/route", "/api/metrics/db"],
+  ])("%s answers 404 to an edge request", async (module, path) => {
+    vi.stubEnv("METRICS_COLLECTOR", "prometheus");
+    vi.stubEnv("METRICS_DB_OFFLOADED", "");
+
+    const { GET } = await import(module);
+    const response = await GET(
+      new Request(`https://app.keeperhub.com${path}`, {
+        headers: { "cf-connecting-ip": "1.2.3.4" },
+      })
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("Not Found");
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/tests/unit/metrics-scrape-guard.test.ts
+++ b/tests/unit/metrics-scrape-guard.test.ts
@@ -60,7 +60,7 @@ describe("authorizeMetricsScrape", () => {
     expect(authenticateInternalService).not.toHaveBeenCalled();
   });
 
-  it("allows a signed internal caller arriving through the edge", async () => {
+  it("allows a signed internal caller reaching the pod directly", async () => {
     authenticateInternalService.mockResolvedValue({
       authenticated: true,
       caller: "mcp",
@@ -69,7 +69,6 @@ describe("authorizeMetricsScrape", () => {
 
     const result = await authorizeMetricsScrape(
       request({
-        "cf-connecting-ip": "1.2.3.4",
         "x-kh-caller": "mcp",
         "x-kh-timestamp": "1700000000",
         "x-kh-signature": "a".repeat(64),
@@ -78,6 +77,42 @@ describe("authorizeMetricsScrape", () => {
 
     expect(result).toEqual({ allowed: true });
   });
+
+  // A caller header alone used to reach the verifier and come back 401, which
+  // told a prober the route was real. From the edge the answer is 404 whether
+  // the request is signed, half-signed or unsigned.
+  it.each([
+    ["unsigned", {}],
+    ["a caller header only", { "x-kh-caller": "mcp" }],
+    [
+      "a full valid signature",
+      {
+        "x-kh-caller": "mcp",
+        "x-kh-timestamp": "1700000000",
+        "x-kh-signature": "a".repeat(64),
+      },
+    ],
+  ])(
+    "refuses an edge request with %s, without reaching the verifier",
+    async (_label, headers) => {
+      authenticateInternalService.mockResolvedValue({
+        authenticated: true,
+        caller: "mcp",
+        scheme: "hmac",
+      });
+
+      const result = await authorizeMetricsScrape(
+        request({ "cf-connecting-ip": "1.2.3.4", ...headers })
+      );
+
+      expect(result).toEqual({
+        allowed: false,
+        status: 404,
+        message: "Not Found",
+      });
+      expect(authenticateInternalService).not.toHaveBeenCalled();
+    }
+  );
 
   it("propagates the verifier's rejection for a bad signature", async () => {
     authenticateInternalService.mockResolvedValue({


### PR DESCRIPTION
## Problem

The three routes under `app/api/metrics` gated only on `METRICS_COLLECTOR !== "prometheus"`. That variable is set to `prometheus` in both staging and production, so the gate is open and the routes answered any caller with no authentication.

The series they expose are not anonymous. They carry `org_slug`, `plan`, `workflow_id`, plugin and action names, endpoint paths and error breakdowns, so the response is a per-organization view of who is on the platform and what they run. `/api/metrics` additionally calls `updateDbMetrics()` on every request, which pulls the DB-sourced gauges and runs the aggregate scan, so an unauthenticated caller could also drive that load against the production database.

The app is the only component in the stack with `ingress.enabled: true`, and the chart templates a single catch-all `path: /` per host, so there is no way to exclude a path in values. Every `/api/metrics` path was therefore reachable on the public hostname. The executor, both dispatchers and the metrics collector are ClusterIP only and were never exposed.

## How Prometheus reaches these metrics

The scraper is Grafana Alloy, from the `k8s-monitoring` chart, running in the `monitoring` namespace of the same cluster. The `api-metrics` ServiceMonitor selects the app Service and scrapes the pod's `http` port directly over the cluster network. It does not use the public hostname and never has. That difference is what this change authorizes on.

## Change

New guard in `lib/metrics/scrape-guard.ts`, applied by all three handlers.

- A request carrying any header the edge adds (`cf-connecting-ip`, `cf-ray`, `x-forwarded-for`, `x-forwarded-host`, `x-forwarded-proto`, `forwarded`) came through Cloudflare and Traefik and gets 404. Cloudflare sets and strips `cf-connecting-ip` at its own edge and Traefik always adds `x-forwarded-for`, so this cannot be evaded from outside.
- A request carrying none of them reached the pod port directly on the cluster network, which is exactly what the scrape does, and is served.
- An in-cluster caller may additionally sign with the internal service HMAC from `lib/internal-service-auth.ts`, the same scheme the `/api/internal` routes use.

The edge check runs first and unconditionally. An earlier revision checked the HMAC headers first, which meant a request carrying nothing but `X-KH-Caller` reached the verifier and came back 401 rather than 404, letting an unauthenticated prober confirm the endpoint existed by naming a caller. It also left an internet-facing path to the data for any holder of the shared secret. From the edge the answer is now 404 in all three signature states, and the verifier is never reached from there.

Scraping is unaffected and no deploy change is required.

## Why not a scrape token, yet

A shared secret is the stronger control and is the intended end state, but it cannot be delivered today. Rendering the chart against the real prod values shows the ServiceMonitor sends no credential, and adding `authorization` or `bearerTokenSecret` to the values changes the rendered output not at all: the `common` chart passes only `port`, `path`, `interval`, `scrapeTimeout`, `scheme`, `tlsConfig` and the two relabeling lists through to the endpoint. The template is identical in the pinned chart version and in the latest published one, so a version bump does not help either.

Getting a token in needs, in order: a passthrough for the auth fields in the `common` chart, a chart release, a bump of the pinned version in `.github/workflows/deploy-keeperhub.yaml`, the token wired into SSM and the monitor, and only then enforcement in the route. Enforcing before the scraper is actually sending the token would 401 every scrape and lose all app metrics and the alerts built on them. That work is tracked separately and does not block this PR.

## Notes for review

`/api/metrics/db` is currently 404 in production via `METRICS_DB_OFFLOADED`, but that is a config flag rather than a control, so it is guarded alongside the other two.

The structural test asserts that every route file under `app/api/metrics` applies the guard, so a route added later cannot silently ship unprotected. The handler tests were mutation-checked by removing the guard call from one route, which failed them as intended.

Known limit, unchanged by this PR: a self-hosted install that exposes the Service directly, with no ingress in front, sends no forwarding headers and so is not covered by this guard. Installs using the shipped nginx ingress are covered, since nginx sets `x-forwarded-for`. The scrape token is what closes the direct-exposure case.

Worth deciding separately: the metrics have been publicly readable up to now, so the labels above should be assumed already collected by anyone who looked.
