### PR TITLE
fix(metrics): match only headers Next.js does not synthesize

### DIFF
--- a/lib/metrics/scrape-guard.ts
+++ b/lib/metrics/scrape-guard.ts
@@ -8,12 +8,16 @@
  *
  * Prometheus does not need the public edge. The ServiceMonitors in
  * deploy/keeperhub-stack/<env>/values.yaml select the app Service and scrape
- * the pod's http port directly over the cluster network, so a scrape reaches
- * the handler with none of the headers the edge adds. Cloudflare sets
- * cf-connecting-ip / cf-ray at its own edge and strips any client-supplied
- * copy, and Traefik adds the x-forwarded-* set to every request it routes.
- * Presence of any of them therefore means the request came through
- * app.keeperhub.com and is refused.
+ * the pod's http port directly over the cluster network, bypassing Cloudflare
+ * and Traefik. Cloudflare sets cf-connecting-ip / cf-ray at its own edge and
+ * strips any client-supplied copy, so their presence means the request came
+ * through app.keeperhub.com and is refused.
+ *
+ * The x-forwarded-* set cannot be used for this and must not be added back.
+ * Next.js fills in x-forwarded-for, -host, -port and -proto from the socket
+ * whenever the client did not send them (next/dist/server/base-server.js), so
+ * an in-cluster scrape arrives carrying them too. Matching on them refuses
+ * every request, which is what took the app-pod metrics down on 2026-09-09.
  *
  * The edge check runs first and is unconditional. An in-cluster caller may
  * additionally sign with the internal service HMAC (lib/internal-service-auth.ts),
@@ -26,15 +30,28 @@ import "server-only";
 import { authenticateInternalService } from "@/lib/internal-service-auth";
 
 /**
- * Headers only a proxied request carries. Absence of all of them is what
- * identifies a direct in-cluster scrape.
+ * Headers a request only carries when it came through the public edge, and
+ * that Next.js does not synthesize. Absence of all of them identifies a direct
+ * in-cluster scrape.
+ *
+ * Exported so a test can assert this list never overlaps the headers Next.js
+ * fills in on its own.
  */
-const EDGE_FORWARDED_HEADERS: readonly string[] = [
+export const EDGE_HEADERS: readonly string[] = [
   "cf-connecting-ip",
   "cf-ray",
   "forwarded",
+];
+
+/**
+ * Set by next/dist/server/base-server.js on every request whose client did not
+ * send them, so they are present on an in-cluster scrape and say nothing about
+ * where a request came from. Listed here to keep EDGE_HEADERS honest.
+ */
+export const NEXT_SYNTHESIZED_HEADERS: readonly string[] = [
   "x-forwarded-for",
   "x-forwarded-host",
+  "x-forwarded-port",
   "x-forwarded-proto",
 ];
 
@@ -63,7 +80,7 @@ export async function authorizeMetricsScrape(
   // Edge check first. Answering a signed request differently from an unsigned
   // one would let a prober confirm the route exists by sending a caller header
   // and reading 401 instead of 404, so nothing from the edge gets that far.
-  if (hasAnyHeader(request, EDGE_FORWARDED_HEADERS)) {
+  if (hasAnyHeader(request, EDGE_HEADERS)) {
     return { allowed: false, status: 404, message: "Not Found" };
   }
 

--- a/tests/unit/metrics-scrape-guard.test.ts
+++ b/tests/unit/metrics-scrape-guard.test.ts
@@ -18,7 +18,8 @@ vi.mock("@/lib/internal-service-auth", () => ({
     authenticateInternalService(request, rawBody),
 }));
 
-const { authorizeMetricsScrape } = await import("@/lib/metrics/scrape-guard");
+const { authorizeMetricsScrape, EDGE_HEADERS, NEXT_SYNTHESIZED_HEADERS } =
+  await import("@/lib/metrics/scrape-guard");
 
 function request(headers: Record<string, string> = {}): Request {
   return new Request("https://app.keeperhub.com/api/metrics", { headers });
@@ -35,22 +36,50 @@ describe("authorizeMetricsScrape", () => {
     });
   });
 
-  it.each([
-    "cf-connecting-ip",
-    "cf-ray",
-    "forwarded",
-    "x-forwarded-for",
-    "x-forwarded-host",
-    "x-forwarded-proto",
-  ])("refuses a request forwarded by the edge (%s)", async (header) => {
-    const result = await authorizeMetricsScrape(
-      request({ [header]: "1.2.3.4" })
+  it.each(["cf-connecting-ip", "cf-ray", "forwarded"])(
+    "refuses a request forwarded by the edge (%s)",
+    async (header) => {
+      const result = await authorizeMetricsScrape(
+        request({ [header]: "1.2.3.4" })
+      );
+
+      expect(result).toEqual({
+        allowed: false,
+        status: 404,
+        message: "Not Found",
+      });
+    }
+  );
+
+  // The 2026-09-09 outage: matching on x-forwarded-* refused every scrape,
+  // because Next.js fills those in from the socket when the client sent none.
+  // A guard header must be one Next.js never invents.
+  it("matches no header Next.js sets on its own", () => {
+    const overlap = EDGE_HEADERS.filter((header) =>
+      NEXT_SYNTHESIZED_HEADERS.includes(header)
     );
 
-    expect(result).toEqual({
-      allowed: false,
-      status: 404,
-      message: "Not Found",
+    expect(overlap).toEqual([]);
+  });
+
+  it.each(NEXT_SYNTHESIZED_HEADERS)(
+    "allows an in-cluster scrape carrying %s, which Next.js adds itself",
+    async (header) => {
+      const result = await authorizeMetricsScrape(
+        request({ [header]: "10.0.2.244" })
+      );
+
+      expect(result).toEqual({ allowed: true });
+    }
+  );
+
+  it("allows a scrape carrying the full set Next.js synthesizes", async () => {
+    const headers = Object.fromEntries(
+      NEXT_SYNTHESIZED_HEADERS.map((header) => [header, "10.0.2.244"])
+    );
+
+    await expect(authorizeMetricsScrape(request(headers))).resolves.toEqual({
+      allowed: true,
     });
   });
 


### PR DESCRIPTION
## What broke

The scrape guard treated the `x-forwarded-*` set as proof that a request arrived through the public edge. It is not.

`next/dist/server/base-server.js`:

```js
req.headers['x-forwarded-host']  ??= req.headers['host'] ?? this.hostname
req.headers['x-forwarded-port']  ??= ...
req.headers['x-forwarded-proto'] ??= isHttps ? 'https' : 'http'
req.headers['x-forwarded-for']   ??= originalRequest.socket...
```

Next.js fills those in from the socket whenever the client did not send them. A scrape that reaches the pod directly on the cluster network arrives carrying all of them, exactly like a request that came through Cloudflare and Traefik.

So the guard matched on every request and refused every request. All four app pods stopped serving metrics in both environments, and `up{job="keeperhub-common"}` went to 0.

The in-process registry is the only source of the workflow, error, billing, plugin, RPC, memory and gas-sponsorship series, so those went dark. The DB-sourced gauges were unaffected, because the metrics-collector pod serves those on its own port.

## The fix

Match on the Cloudflare pair instead. Cloudflare sets `cf-connecting-ip` and `cf-ray` at its own edge and strips any client-supplied copy, and Next.js never invents them, so they separate the two paths where `x-forwarded-*` cannot. `forwarded` is kept for the same reason.

Nothing else in the guard changes. The edge check still runs first and still answers 404, so the public endpoint stays closed.

## Not a change to IP handling

This is a match list, not a strip list. No header is removed from any request. `x-forwarded-for` still arrives and is still read by `lib/security/trusted-proxies.ts`, `lib/security/login-risk.ts`, the rate limiters and the session paths. Only what the metrics guard matches on has changed, and those three routes never resolve a user IP.

## Why the tests missed it

They build a `Request` by hand, which never passes through the Next.js server, so the header set under test was not the header set in production.

Three tests close that gap. The two header lists are exported and asserted not to overlap. A scrape carrying the synthesized headers is asserted to pass, both one at a time and as a full set. I mutation-checked them by putting `x-forwarded-host` back: all three fail.

## Verifying on staging

After deploy, this should return 1 for every app pod:

```
up{job="keeperhub-common", cluster="techops-staging"}
```

And this should be 404 from outside:

```
curl -o /dev/null -w '%{http_code}\n' https://app-staging.keeperhub.com/api/metrics
```

## Follow-up, not in this PR

The route still exists on the public port, so this is a check rather than a wall. Moving the metrics to their own port removes the route entirely, and the ingress would not route to it. That needs a `common` chart fix first, because the chart's `helm test` pod dereferences `service.port`, which the two-port form leaves unset. Tracked separately.
