### PR TITLE
fix: #2359 render template tokens inside array-valued config

### DIFF
--- a/lib/abi/struct-args.ts
+++ b/lib/abi/struct-args.ts
@@ -71,6 +71,36 @@ function buildTupleArg(
  *
  * If args is empty or the ABI has no tuple inputs, the array passes through unchanged.
  */
+/**
+ * The function arguments as given, or undefined when the field carries none.
+ *
+ * An array is taken as it is. The executor renders templates inside arrays, so
+ * a config authored over MCP reaches a step as an array rather than the JSON
+ * string the visual builder sends. A string is passed on unless it trims empty.
+ *
+ * Anything else follows the truthiness test these steps applied before arrays
+ * were admitted, so null, 0 and false stay absent rather than becoming a parse
+ * error. That matters because `isMissingRequiredValue` in
+ * lib/workflow/validation/action-config.ts treats null as missing and skips
+ * field validation, so a workflow carrying one persists and then has to run.
+ *
+ * A truthy value that is neither an array nor a string is printed and handed to
+ * the caller's parse, which rejects it as a user error. Testing the shape here
+ * rather than at the call site is what keeps that off the throwing path: both
+ * steps used to call `.trim()` on it in the condition guarding their `try`.
+ */
+export function asRawFunctionArgs(
+  functionArgs: unknown
+): string | unknown[] | undefined {
+  if (Array.isArray(functionArgs)) {
+    return functionArgs;
+  }
+  if (typeof functionArgs === "string") {
+    return functionArgs.trim() === "" ? undefined : functionArgs;
+  }
+  return functionArgs ? String(functionArgs) : undefined;
+}
+
 export function reshapeArgsForAbi(
   args: unknown[],
   functionAbi: FunctionAbiEntry

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -986,6 +986,20 @@ export function processTemplates(
  * null) is passed through as it is. Arrays and objects take the same path so
  * that this and scanForLeftoverLiterals agree on what a container is.
  */
+/*
+ * No depth limit here, where scanForLeftoverLiterals stops at 10
+ * (template-resolution.ts). The two walk for different reasons and the
+ * difference is deliberate: this one has to render whatever the config
+ * actually holds, so a limit would leave a token unrendered at the bottom of a
+ * deep config and pass it to the action verbatim. The scan is a backstop for
+ * tokens the resolver returned unchanged, and its limit bounds a diagnostic
+ * rather than the run.
+ *
+ * What makes the asymmetry safe is the tracker: this function records an
+ * unresolved reference as it renders, at any depth, so assertResolved still
+ * fails the step for a token the scan never reaches. Pinned in
+ * tests/unit/template-fail-closed.test.ts.
+ */
 function renderTemplateValue(
   value: unknown,
   outputs: NodeOutputs,

--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -955,7 +955,14 @@ function replaceConfigTemplate(
 
 /**
  * Process template variables in config.
- * Recurses into nested objects; supports array paths like data.recipes[0].
+ *
+ * Recurses into nested objects and arrays, rendering every string it reaches.
+ * A reference may itself carry an index, `data.recipes[0]`; that is a path
+ * inside the reference and the resolver's business. Array-valued config is a
+ * different thing: each element is rendered here the way an object's values
+ * are. Until #2359 arrays were copied verbatim, so a token in one was never
+ * rendered and was then found by scanForLeftoverLiterals, which does walk
+ * arrays, and the run aborted naming a reference that was correct.
  *
  * KEEP-468: optional `tracker` records every reference that fell through to
  * the empty-string or literal-pass-through path so the caller can fail
@@ -967,45 +974,61 @@ export function processTemplates(
   tracker?: TemplateResolutionTracker
 ): Record<string, unknown> {
   const processed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    processed[key] = renderTemplateValue(value, outputs, tracker);
+  }
+  return processed;
+}
+
+/**
+ * One config value. A string is rendered, an array element by element, an
+ * object through processTemplates, and anything else (numbers, booleans,
+ * null) is passed through as it is. Arrays and objects take the same path so
+ * that this and scanForLeftoverLiterals agree on what a container is.
+ */
+function renderTemplateValue(
+  value: unknown,
+  outputs: NodeOutputs,
+  tracker?: TemplateResolutionTracker
+): unknown {
+  if (typeof value === "string") {
+    return renderTemplateString(value, outputs, tracker);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => renderTemplateValue(item, outputs, tracker));
+  }
+  if (typeof value === "object" && value !== null) {
+    return processTemplates(value as Record<string, unknown>, outputs, tracker);
+  }
+  return value;
+}
+
+function renderTemplateString(
+  value: string,
+  outputs: NodeOutputs,
+  tracker?: TemplateResolutionTracker
+): string {
   const storedPattern = /\{\{@([^:]+):([^}]+)\}\}/g;
   // Fallback: resolve display-format templates {{Label.field}} that were not
   // converted to stored format by the editor (mirrors extractTemplateParameters).
   const displayPattern = /\{\{([^@}][^}]*)\}\}/g;
 
-  for (const [key, value] of Object.entries(config)) {
-    if (typeof value === "string") {
-      let result = value.replace(storedPattern, (m, nodeId, rest) =>
-        replaceConfigTemplate(m, nodeId, rest, outputs, tracker)
-      );
-      result = result.replace(displayPattern, (full, displayRef) => {
-        const resolved = resolveDisplayTemplate(displayRef, outputs);
-        if (resolved === null || resolved === undefined) {
-          recordUnresolved(tracker, {
-            token: full,
-            reason: "no-path",
-            detail: `Display reference "${displayRef}" did not resolve.`,
-          });
-          return full;
-        }
-        return formatConfigValue(resolved);
+  let result = value.replace(storedPattern, (m, nodeId, rest) =>
+    replaceConfigTemplate(m, nodeId, rest, outputs, tracker)
+  );
+  result = result.replace(displayPattern, (full, displayRef) => {
+    const resolved = resolveDisplayTemplate(displayRef, outputs);
+    if (resolved === null || resolved === undefined) {
+      recordUnresolved(tracker, {
+        token: full,
+        reason: "no-path",
+        detail: `Display reference "${displayRef}" did not resolve.`,
       });
-      processed[key] = result;
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      processed[key] = processTemplates(
-        value as Record<string, unknown>,
-        outputs,
-        tracker
-      );
-    } else {
-      processed[key] = value;
+      return full;
     }
-  }
-
-  return processed;
+    return formatConfigValue(resolved);
+  });
+  return result;
 }
 
 /**

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -37,7 +37,11 @@ export type ReadContractCoreInput = {
   network: string;
   abi: string;
   abiFunction: string;
-  functionArgs?: string;
+  // A JSON string from the abi-function-args UI field, or a native array from
+  // a direct/MCP caller and, since #2359, from the executor rendering a
+  // template inside one. query-transactions has taken both shapes for the
+  // same widget all along; this step declared the string only.
+  functionArgs?: string | unknown[];
   // See applyReadFailOnError in read-fail-on-error-core.ts. When false, no
   // failure of this step fails the run.
   failOnError?: boolean;
@@ -198,11 +202,19 @@ async function readContractInner(
     };
   }
 
-  // Parse function arguments
+  // Parse function arguments. A native array is taken as it is and a string
+  // is parsed as JSON; an empty string means no arguments, as does an absent
+  // value.
   let args: unknown[] = [];
-  if (functionArgs && functionArgs.trim() !== "") {
+  const rawArgs: string | unknown[] | undefined =
+    typeof functionArgs === "string" && functionArgs.trim() === ""
+      ? undefined
+      : functionArgs;
+  if (rawArgs !== undefined) {
     try {
-      const parsedArgs = JSON.parse(functionArgs);
+      const parsedArgs: unknown = Array.isArray(rawArgs)
+        ? rawArgs
+        : JSON.parse(rawArgs);
       if (!Array.isArray(parsedArgs)) {
         logUserError(
           ErrorCategory.VALIDATION,

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -10,7 +10,11 @@ import { getRpcPreferenceUserId } from "@/lib/workflow/executor/helpers";
 import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 
 import { ethers } from "ethers";
-import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import {
+  asRawFunctionArgs,
+  coerceArgsForAbi,
+  reshapeArgsForAbi,
+} from "@/lib/abi/struct-args";
 import { validateArgsForAbi } from "@/lib/abi/validate-args";
 import { ErrorCategory, logUserError } from "@/lib/logging";
 import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
@@ -203,13 +207,9 @@ async function readContractInner(
   }
 
   // Parse function arguments. A native array is taken as it is and a string
-  // is parsed as JSON; an empty string means no arguments, as does an absent
-  // value.
+  // is parsed as JSON; an empty, absent or falsy value means no arguments.
   let args: unknown[] = [];
-  const rawArgs: string | unknown[] | undefined =
-    typeof functionArgs === "string" && functionArgs.trim() === ""
-      ? undefined
-      : functionArgs;
+  const rawArgs = asRawFunctionArgs(functionArgs);
   if (rawArgs !== undefined) {
     try {
       const parsedArgs: unknown = Array.isArray(rawArgs)

--- a/plugins/web3/steps/write-contract-core.ts
+++ b/plugins/web3/steps/write-contract-core.ts
@@ -10,7 +10,11 @@ import { ExecutionErrorType } from "@/lib/errors/execution-error-type";
 
 import { eq } from "drizzle-orm";
 import { ethers } from "ethers";
-import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import {
+  asRawFunctionArgs,
+  coerceArgsForAbi,
+  reshapeArgsForAbi,
+} from "@/lib/abi/struct-args";
 import { validateArgsForAbi } from "@/lib/abi/validate-args";
 import { db } from "@/lib/db";
 import { explorerConfigs, workflowExecutions } from "@/lib/db/schema";
@@ -71,7 +75,7 @@ export type WriteContractCoreInput = {
   network: string;
   abi: string;
   abiFunction: string;
-  functionArgs?: string;
+  functionArgs?: string | unknown[];
   ethValue?: string;
   gasLimitMultiplier?: string;
   // Explicit caller override for maxPriorityFeePerGas (in gwei). Bypasses the
@@ -299,11 +303,22 @@ export async function writeContractCore(
   const functionAbi = resolution.entry;
   const abiFunctionKey = getAbiFunctionKey(parsedAbi, abiFunction, functionAbi);
 
-  // Parse function arguments
+  // Parse function arguments. A native array is taken as it is and a string
+  // is parsed as JSON; an empty, absent or falsy value means no arguments.
+  //
+  // The shape test used to sit in the condition guarding this try, so an array
+  // - what the executor hands over once a template inside one renders - threw
+  // a TypeError from the condition itself. Nothing catches that: this function
+  // is awaited inside applyWriteFailOnError, so the rejection escapes the
+  // softener and failOnError: false cannot turn it into a step result. On a
+  // path that broadcasts a transaction.
   let args: unknown[] = [];
-  if (functionArgs && functionArgs.trim() !== "") {
+  const rawArgs = asRawFunctionArgs(functionArgs);
+  if (rawArgs !== undefined) {
     try {
-      const parsedArgs = JSON.parse(functionArgs);
+      const parsedArgs: unknown = Array.isArray(rawArgs)
+        ? rawArgs
+        : JSON.parse(rawArgs);
       if (!Array.isArray(parsedArgs)) {
         return {
           success: false,

--- a/tests/unit/abi-struct-args.test.ts
+++ b/tests/unit/abi-struct-args.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { coerceArgsForAbi, reshapeArgsForAbi } from "@/lib/abi/struct-args";
+import {
+  asRawFunctionArgs,
+  coerceArgsForAbi,
+  reshapeArgsForAbi,
+} from "@/lib/abi/struct-args";
+
+describe("asRawFunctionArgs", () => {
+  it("keeps an array and a non-empty string", () => {
+    const array = ["0xabc", "1"];
+    expect(asRawFunctionArgs(array)).toBe(array);
+    expect(asRawFunctionArgs('["1"]')).toBe('["1"]');
+    expect(asRawFunctionArgs([])).toEqual([]);
+  });
+
+  it("reads every falsy value as absent, not as a parse error", () => {
+    // isMissingRequiredValue in lib/workflow/validation/action-config.ts
+    // treats null as missing and skips field validation, so a workflow
+    // authored over MCP with one of these persists and then has to run.
+    // The steps read them as absent through a truthiness test before
+    // arrays were admitted, and still do.
+    for (const absent of [null, undefined, 0, false, "", "   ", Number.NaN]) {
+      expect([String(absent), asRawFunctionArgs(absent)]).toEqual([
+        String(absent),
+        undefined,
+      ]);
+    }
+  });
+
+  it("prints a truthy non-array so the caller's parse rejects it", () => {
+    // Testing the shape here rather than in the condition guarding the
+    // caller's try is what keeps these off the throwing path. What comes
+    // back is a string, so JSON.parse raises inside the try.
+    expect(asRawFunctionArgs(5)).toBe("5");
+    expect(asRawFunctionArgs(true)).toBe("true");
+    expect(typeof asRawFunctionArgs({ a: 1 })).toBe("string");
+  });
+});
 
 describe("reshapeArgsForAbi", () => {
   it("returns empty array unchanged", () => {

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -126,6 +126,16 @@ const PURE_ABI = [
   },
 ];
 
+const NO_ARG_ABI = [
+  {
+    name: "totalSupply",
+    type: "function",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "supply", type: "uint256" }],
+  },
+];
+
 const NONPAYABLE_ABI = [
   {
     name: "quoteExactInputSingle",
@@ -613,5 +623,66 @@ describe("ABI fragment validation before RPC failover", () => {
     }
     expect(mockGetRpcProvider).not.toHaveBeenCalled();
     expect(mockContractFunction).not.toHaveBeenCalled();
+  });
+});
+
+describe("read-contract-core - functionArgs as a native array (#2359)", () => {
+  // The executor renders templates inside arrays now, so functionArgs can
+  // reach this step as an array rather than the JSON string the UI sends.
+  // Before, the declared type was string only and the step called .trim() on
+  // it, so an array threw a TypeError instead of running or being refused.
+  it("produces the same call from an array as from its JSON string", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValue(BigInt(42));
+    const fromString = await readContractCore(
+      makeInput({
+        abi: JSON.stringify(PURE_ABI),
+        abiFunction: "add",
+        functionArgs: JSON.stringify(["10", "32"]),
+      })
+    );
+    const stringCall = mockContractFunction.mock.calls[0];
+
+    vi.clearAllMocks();
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValue(BigInt(42));
+    const fromArray = await readContractCore(
+      makeInput({
+        abi: JSON.stringify(PURE_ABI),
+        abiFunction: "add",
+        functionArgs: ["10", "32"],
+      })
+    );
+    const arrayCall = mockContractFunction.mock.calls[0];
+
+    expect(fromString.success).toBe(true);
+    expect(fromArray.success).toBe(true);
+    expect(arrayCall).toEqual(stringCall);
+  });
+
+  it("refuses a JSON string that is not an array, as before", async () => {
+    setupRpcMocks();
+    const result = await readContractCore(
+      makeInput({ functionArgs: JSON.stringify({ account: VALID_ADDRESS }) })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Function arguments must be a JSON array");
+    }
+    expect(mockContractFunction).not.toHaveBeenCalled();
+  });
+
+  it("treats an empty string as no arguments, as before", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValue(BigInt(7));
+    const result = await readContractCore(
+      makeInput({
+        abi: JSON.stringify(NO_ARG_ABI),
+        abiFunction: "totalSupply",
+        functionArgs: "",
+      })
+    );
+    expect(result.success).toBe(true);
+    expect(mockContractFunction).toHaveBeenCalledWith();
   });
 });

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -672,6 +672,27 @@ describe("read-contract-core - functionArgs as a native array (#2359)", () => {
     expect(mockContractFunction).not.toHaveBeenCalled();
   });
 
+  it("treats null, 0 and false as no arguments, as the base did", async () => {
+    // Only a string that trims empty was absent, so these reached JSON.parse:
+    // JSON.parse(null) coerces to JSON.parse("null"), yields null, fails
+    // Array.isArray and became "Function arguments must be a JSON array". The
+    // same call succeeds on staging, whose truthiness test read them as absent.
+    for (const absent of [null, 0, false]) {
+      vi.clearAllMocks();
+      setupRpcMocks();
+      mockContractFunction.mockResolvedValue(BigInt(7));
+      const result = await readContractCore(
+        makeInput({
+          abi: JSON.stringify(NO_ARG_ABI),
+          abiFunction: "totalSupply",
+          functionArgs: absent as unknown as string,
+        })
+      );
+      expect([String(absent), result.success]).toEqual([String(absent), true]);
+      expect(mockContractFunction).toHaveBeenCalledWith();
+    }
+  });
+
   it("treats an empty string as no arguments, as before", async () => {
     setupRpcMocks();
     mockContractFunction.mockResolvedValue(BigInt(7));

--- a/tests/unit/template-fail-closed.test.ts
+++ b/tests/unit/template-fail-closed.test.ts
@@ -77,6 +77,56 @@ describe("processTemplate tracker (lib/utils/template)", () => {
   });
 });
 
+describe("renderTemplateValue depth against the post-scan's limit", () => {
+  // scanForLeftoverLiterals returns at depth > 10; renderTemplateValue has no
+  // limit. Nothing recorded which was intended, so both halves are asserted
+  // here: rendering reaches the leaf, and an unresolved token that deep still
+  // fails the step through the tracker rather than through the post-scan.
+  const nest = (depth: number, leaf: unknown): unknown =>
+    depth === 0 ? leaf : [nest(depth - 1, leaf)];
+
+  const leafOf = (value: unknown): unknown => {
+    let cursor = value;
+    while (Array.isArray(cursor)) {
+      cursor = cursor[0];
+    }
+    return cursor;
+  };
+
+  it("renders a reference nested well past depth 10", () => {
+    const tracker = createTracker();
+    const rendered = processTemplates(
+      { functionArgs: nest(14, "{{@trigger:Trigger.ts}}") } as Record<
+        string,
+        unknown
+      >,
+      baseOutputs,
+      tracker
+    );
+    expect(leafOf(rendered.functionArgs)).toBe("1715000000");
+    expect(tracker.unresolved).toHaveLength(0);
+    expect(() =>
+      assertResolved(tracker, rendered, { actionType: "web3/write-contract" })
+    ).not.toThrow();
+  });
+
+  it("fails the step for an unresolved token that deep", () => {
+    const tracker = createTracker();
+    const rendered = processTemplates(
+      { functionArgs: nest(14, "{{@trigger:Trigger.does.not.exist}}") } as Record<
+        string,
+        unknown
+      >,
+      baseOutputs,
+      tracker
+    );
+    expect(tracker.unresolved.map((u) => u.reason)).toContain("no-path");
+    expect(() =>
+      assertResolved(tracker, rendered, { actionType: "web3/write-contract" })
+    ).toThrow(UNRESOLVED_REF_MESSAGE);
+  });
+});
+
 describe("assertResolved (executor strict gate)", () => {
   it("throws TemplateResolutionError in strict mode (default)", () => {
     const tracker = createTracker();

--- a/tests/unit/template-fail-closed.test.ts
+++ b/tests/unit/template-fail-closed.test.ts
@@ -698,3 +698,145 @@ describe("extractTemplateParameters strict integration", () => {
     expect(tracker.unresolved[0]?.reason).toBe("no-path");
   });
 });
+
+describe("processTemplates renders tokens inside arrays (#2359)", () => {
+  // scanForLeftoverLiterals walks arrays, so as long as the renderer skipped
+  // them a token in an array was never rendered and then always reported, and
+  // the error named a reference that was correct. Both halves have to agree
+  // on what a container is; these pin that they do.
+  const WHO = "0x4F256eD4420136dfD1e595044626F0dDb9Ac2503";
+  const outputs = {
+    trigger: {
+      label: "Trigger",
+      data: { who: WHO, amount: "250000", note: "payroll" },
+    },
+  };
+  const render = (config: Record<string, unknown>) => {
+    const tracker = createTracker();
+    const processed = processTemplates(config, outputs, tracker);
+    return { tracker, processed };
+  };
+
+  it("renders a token that is an array element", () => {
+    const { tracker, processed } = render({
+      functionArgs: ["{{@trigger:Trigger.who}}"],
+    });
+    expect(processed.functionArgs).toEqual([WHO]);
+    expect(tracker.unresolved).toHaveLength(0);
+    expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+  });
+
+  it("renders a token inside an object inside an array", () => {
+    const { tracker, processed } = render({
+      calls: [
+        {
+          contractAddress: "{{@trigger:Trigger.who}}",
+          abi: "[]",
+          abiFunction: "transfer",
+        },
+      ],
+    });
+    expect(processed.calls).toEqual([
+      { contractAddress: WHO, abi: "[]", abiFunction: "transfer" },
+    ]);
+    expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+  });
+
+  it("renders a token inside an array inside an object inside an array", () => {
+    const { tracker, processed } = render({
+      calls: [
+        { args: ["{{@trigger:Trigger.who}}", "{{@trigger:Trigger.amount}}"] },
+      ],
+    });
+    expect(processed.calls).toEqual([{ args: [WHO, "250000"] }]);
+    expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+  });
+
+  it("passes non-string elements through and keeps their order", () => {
+    const { processed } = render({
+      list: [1, true, null, "{{@trigger:Trigger.note}}", { n: 2 }, [3]],
+    });
+    expect(processed.list).toEqual([1, true, null, "payroll", { n: 2 }, [3]]);
+  });
+
+  it("still reports an unresolved token inside an array", () => {
+    // Rendering arrays must not make the scan blind to them: a reference that
+    // does not resolve is recorded by the tracker exactly as a scalar one is,
+    // and the gate still closes.
+    const { tracker, processed } = render({
+      functionArgs: ["{{@trigger:Trigger.missing}}"],
+    });
+    expect(tracker.unresolved[0]?.reason).toBe("no-path");
+    expect(() => assertResolved(tracker, processed, {})).toThrow(
+      UNRESOLVED_REF_MESSAGE
+    );
+  });
+
+  it("leaves scalar and nested-object rendering as it was", () => {
+    const { processed } = render({
+      to: "{{@trigger:Trigger.who}}",
+      meta: { to: "{{@trigger:Trigger.who}}", keep: 7 },
+    });
+    expect(processed.to).toBe(WHO);
+    expect(processed.meta).toEqual({ to: WHO, keep: 7 });
+  });
+
+  describe("the step inputs that accept a native array", () => {
+    // These three declare `string | unknown[]` and are the cases where the
+    // array shape is supported end to end, so the renderer skipping them was
+    // a functional hole rather than a shape mismatch: a token in `payouts`
+    // was a literal {{...}} where a recipient address belongs, and the
+    // KEEP-468 gate was the only thing stopping it.
+
+    it("calls on web3/batch-write-contract", () => {
+      const { tracker, processed } = render({
+        network: "ethereum",
+        calls: [
+          {
+            contractAddress: "{{@trigger:Trigger.who}}",
+            abi: "[]",
+            abiFunction: "transfer",
+            args: ["{{@trigger:Trigger.who}}", "{{@trigger:Trigger.amount}}"],
+          },
+        ],
+      });
+      expect(processed.calls).toEqual([
+        {
+          contractAddress: WHO,
+          abi: "[]",
+          abiFunction: "transfer",
+          args: [WHO, "250000"],
+        },
+      ]);
+      expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+    });
+
+    it("functionArgs on web3/query-transactions", () => {
+      const { tracker, processed } = render({
+        abiFunction: "transfer",
+        functionArgs: ["{{@trigger:Trigger.who}}", ""],
+      });
+      expect(processed.functionArgs).toEqual([WHO, ""]);
+      expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+    });
+
+    it("payouts on tempo/batch-payout", () => {
+      const { tracker, processed } = render({
+        network: "tempo",
+        payouts: [
+          {
+            recipient: "{{@trigger:Trigger.who}}",
+            amount: "{{@trigger:Trigger.amount}}",
+            memo: "{{@trigger:Trigger.note}}",
+          },
+          { recipient: WHO, amount: "1" },
+        ],
+      });
+      expect(processed.payouts).toEqual([
+        { recipient: WHO, amount: "250000", memo: "payroll" },
+        { recipient: WHO, amount: "1" },
+      ]);
+      expect(() => assertResolved(tracker, processed, {})).not.toThrow();
+    });
+  });
+});

--- a/tests/unit/write-contract-core.test.ts
+++ b/tests/unit/write-contract-core.test.ts
@@ -135,7 +135,11 @@ vi.mock("@/lib/explorer", () => ({
     mockExplorerGetTransactionUrl(...args),
 }));
 
-vi.mock("@/lib/abi/struct-args", () => ({
+// asRawFunctionArgs stays real: it is what decides whether functionArgs is
+// absent, an array or a string to parse, and stubbing it would leave that
+// decision untested. The two shaping helpers remain identity stubs.
+vi.mock("@/lib/abi/struct-args", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/abi/struct-args")>()),
   reshapeArgsForAbi: vi.fn().mockImplementation((args: unknown[]) => args),
   coerceArgsForAbi: vi.fn().mockImplementation((args: unknown[]) => args),
 }));
@@ -712,6 +716,106 @@ describe("writeContractCore sponsored-relay failure link", () => {
       { chainId: 1 },
       "0xsponsored"
     );
+    expect(mockExecuteContractCall).not.toHaveBeenCalled();
+  });
+});
+
+describe("writeContractCore functionArgs shape (#2359)", () => {
+  const SHAPE_ABI = JSON.stringify([
+    {
+      type: "function",
+      name: "transfer",
+      stateMutability: "nonpayable",
+      inputs: [
+        { name: "to", type: "address" },
+        { name: "amount", type: "uint256" },
+      ],
+      outputs: [{ name: "", type: "bool" }],
+    },
+    {
+      type: "function",
+      name: "pause",
+      stateMutability: "nonpayable",
+      inputs: [],
+      outputs: [],
+    },
+  ]);
+
+  const sendSucceeds = () => {
+    mockExecuteContractCall.mockResolvedValue({
+      hash: "0xhash",
+      gasUsed: BigInt(21_000),
+      effectiveGasPrice: BigInt(1_000_000_000),
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sendSucceeds();
+  });
+
+  it("takes a native array instead of throwing past the softener", async () => {
+    // The executor renders templates inside arrays, so a config authored over
+    // MCP reaches this step as an array rather than the JSON string the visual
+    // builder sends. The shape test used to sit in the condition guarding the
+    // try - `functionArgs && functionArgs.trim() !== ""` - so an array threw a
+    // TypeError from the condition itself. writeContractCore is awaited inside
+    // applyWriteFailOnError, so that rejection escaped the softener and
+    // failOnError: false could not turn it into a step result. On a path that
+    // broadcasts a transaction.
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "16602",
+      abi: SHAPE_ABI,
+      abiFunction: "transfer",
+      functionArgs: [
+        "0x1111111111111111111111111111111111111111",
+        "1000",
+      ] as unknown as string,
+      _context: { organizationId: "org-1" },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockExecuteContractCall).toHaveBeenCalled();
+    const sent = mockExecuteContractCall.mock.calls[0]?.[1] as {
+      args: unknown[];
+    };
+    expect(sent.args).toEqual([
+      "0x1111111111111111111111111111111111111111",
+      "1000",
+    ]);
+  });
+
+  it("reads null, 0 and false as no arguments rather than a parse error", async () => {
+    for (const absent of [null, 0, false, "", "   "]) {
+      vi.clearAllMocks();
+      sendSucceeds();
+      const result = await writeContractCore({
+        contractAddress: "0x1234567890123456789012345678901234567890",
+        network: "16602",
+        abi: SHAPE_ABI,
+        abiFunction: "pause",
+        functionArgs: absent as unknown as string,
+        _context: { organizationId: "org-1" },
+      });
+      expect([String(absent), result.success]).toEqual([String(absent), true]);
+      const sent = mockExecuteContractCall.mock.calls[0]?.[1] as {
+        args: unknown[];
+      };
+      expect(sent.args).toEqual([]);
+    }
+  });
+
+  it("still rejects a JSON object as a user error", async () => {
+    const result = await writeContractCore({
+      contractAddress: "0x1234567890123456789012345678901234567890",
+      network: "16602",
+      abi: SHAPE_ABI,
+      abiFunction: "pause",
+      functionArgs: '{"to":"0x1"}',
+      _context: { organizationId: "org-1" },
+    });
+    expect(result).toMatchObject({ success: false, errorClass: "user" });
     expect(mockExecuteContractCall).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #2359

## What this changes

`processTemplates` in `lib/workflow/executor/executor.workflow.ts` now recurses into arrays. The string, array and object cases go through one helper, `renderTemplateValue`, so the renderer and `scanForLeftoverLiterals` agree on what a container is. The doc comment that said "supports array paths like `data.recipes[0]`" is rewritten, since that was about an index inside a reference rather than array-valued config.

Per the amendment on the issue, `web3/read-contract`'s `functionArgs` accepts `string | unknown[]`, as `web3/query-transactions` already does for the same widget. A native array is taken as it is, a string is parsed as JSON, an empty string still means no arguments. Without this the renderer's change would have turned the guard's message into `TypeError: functionArgs.trim is not a function`.

## What does not change

- `scanForLeftoverLiterals`: correct as written.
- `condition`, `conditionConfig`, `dbQuery` and `code` are lifted out before the renderer runs, so array recursion cannot reach the rules array under `conditionConfig`.
- `processCodeTemplates` and `extractTemplateParameters` take a string, not a container; no array case exists for them.
- `valueContainsTemplate` and `walkNodeConfigStrings`, the create-time and PATCH-time counterparts noted on the issue, are left for their own change.
- Array recursion has no depth cap, matching the object recursion beside it; the scan is what is capped.

## Tests

`tests/unit/template-fail-closed.test.ts`: a token as an array element, inside an object inside an array, and inside an array inside an object inside an array; non-string elements and order preserved; an unresolved token inside an array still recorded and still closing the gate; scalar and nested-object rendering unchanged; and the three step inputs that accept a native array end to end (`calls` on `web3/batch-write-contract`, `functionArgs` on `web3/query-transactions`, `payouts` on `tempo/batch-payout`).

`tests/unit/read-contract-core.test.ts`: the array shape produces the same contract call as its JSON-string shape; a non-array JSON string is still refused; an empty string still means no arguments.

Run against `staging`'s own executor and step with the new tests in place, exactly the nine new cases fail and the TypeError reproduces. With this change, 95 of 95 pass across the two files. `biome check` is clean on the four changed files.

I could not run the full `tests/unit` suite or `tsgo` locally this round; those are on the CI jobs pending approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
