### PR TITLE
docs: #2380 fix stale README documentation links and keeperhub/ paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Base URL: `https://app.keeperhub.com/api`
 | `/api/integrations`              | Manage connections |
 | `/api/chains`                    | Supported networks |
 
-See [API Documentation](docs/api/index.md) for full reference.
+See [API Overview](docs/api/index.md) for full reference.
 
 ## Observability
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ pnpm test:e2e         # E2E tests
 
 | Service | Description | Source |
 |---------|-------------|--------|
-| **App** | Next.js application with workflow builder UI and API | `app/`, `keeperhub/` |
+| **App** | Next.js application with workflow builder UI and API | `app/` |
 | **Schedule Dispatcher** | Evaluates cron schedules every minute, dispatches matching workflows to SQS | `keeperhub-scheduler/schedule-dispatcher/` |
 | **Block Dispatcher** | Monitors blockchain blocks via WebSocket, dispatches matching workflows to SQS | `keeperhub-scheduler/block-dispatcher/` |
 | **Event Tracker** | Monitors blockchain events via Redis streams and routes to SQS | `keeperhub-events/event-tracker/` |
@@ -225,7 +225,7 @@ All trigger services (schedule dispatcher, block dispatcher, event tracker) send
 
 ### Plugin System
 
-Plugins extend workflow capabilities. Located in `keeperhub/plugins/`:
+Plugins extend workflow capabilities. Located in `plugins/`:
 
 - `web3` - Blockchain operations (balance, transfers, contract calls)
 - `evm-chain` - Read-only EVM chain diagnostics via any public JSON-RPC endpoint (no credentials)
@@ -259,16 +259,16 @@ Prometheus metrics exposed at `/api/metrics`, readable from inside the cluster o
 - Plugin action metrics
 - User and organization stats
 
-See [Metrics Reference](keeperhub/lib/metrics/METRICS_REFERENCE.md) for details.
+See [Metrics Reference](lib/metrics/METRICS_REFERENCE.md) for details.
 
 ## Documentation
 
 Full documentation available at [docs.keeperhub.com](https://docs.keeperhub.com) or in the `docs/` directory:
 
-- [Quick Start Guide](docs/getting-started/quickstart.md)
-- [Core Concepts](docs/intro/concepts.md)
-- [Workflow Examples](docs/workflows/examples.md)
-- [API Reference](docs/api/index.md)
+- [Getting Started](docs/getting-started/index.md)
+- [Core Concepts](docs/concepts.md)
+- [Workflows](docs/workflows/index.md)
+- [API Overview](docs/api/index.md)
 - [Security Best Practices](docs/practices/security.md)
 
 ## License


### PR DESCRIPTION
Fixes #2380.

Repoints the three Documentation links that 404 on `staging`, and drops the `keeperhub/` prefix from the three places that carry it. There is no top-level `keeperhub/` directory in the tree.

**Documentation links (all three returned 404):**
- `docs/getting-started/quickstart.md` -> `docs/getting-started/index.md`
- `docs/intro/concepts.md` -> `docs/concepts.md` (there is no `docs/intro/` folder; the page is at the docs root)
- `docs/workflows/examples.md` -> `docs/workflows/index.md` (the workflows folder has creating, templating, schema-reference, import-export, hub and marketplace)

The replacement targets match the docs nav: `docs/_meta.ts` maps `concepts` to "Core Concepts" and `docs/getting-started/_meta.ts` lists `index` as the Overview.

**`keeperhub/` prefix (nonexistent path), three places:**
- `README.md:197` Services table, App source: `app/`, `keeperhub/` -> `app/`. The App is the Next.js application and `app/` is its directory; the second path never existed.
- `README.md:228` Plugin System sentence: `` `keeperhub/plugins/` `` -> `` `plugins/` ``
- `README.md:262` Metrics Reference link: `keeperhub/lib/metrics/METRICS_REFERENCE.md` -> `lib/metrics/METRICS_REFERENCE.md` (the file exists at that path)

**Verification on the branch:**
- All seven relative links in the README resolve against the tree (checked each with `git cat-file -e`; the four that were broken now resolve, the three that were already fine are unchanged).
- No `keeperhub/` reference remains in the README outside the real `keeperhub-*` service directories.
- `npx tsx scripts/check-api-docs-routes.ts` reports no docs-vs-code drift.
- Type-check and lint are unaffected (README only; Biome does not lint markdown).

Docs only, no code change.
