### PR TITLE
fix: #2374 never report a sponsored send as pre-broadcast when its outcome is unknown

### DIFF
--- a/lib/web3/sponsored-send-error.ts
+++ b/lib/web3/sponsored-send-error.ts
@@ -76,7 +76,9 @@ export function resolveSponsoredSendError(
         plugin_name: "web3",
         action_name: actionName,
         chain_id: String(chainId),
-        send_transaction_status_id: error.sendTransactionStatusId,
+        ...(error.sendTransactionStatusId
+          ? { send_transaction_status_id: error.sendTransactionStatusId }
+          : {}),
         ...(error.txHash ? { tx_hash: error.txHash } : {}),
       }
     );

--- a/lib/web3/turnkey-revert.ts
+++ b/lib/web3/turnkey-revert.ts
@@ -75,7 +75,14 @@ export function isSponsoredTxRevertError(
  */
 export class SponsoredTxPendingError extends Error {
   readonly kind = "sponsored-tx-pending" as const;
-  readonly sendTransactionStatusId: string;
+  /**
+   * Turnkey's activity id, when one was assigned. Absent when the send request
+   * itself threw with an undetermined outcome (a transport failure or timeout):
+   * Turnkey may or may not have accepted the activity, and no id came back to
+   * poll. Callers key their "never re-send" decision on the error kind, not on
+   * this field.
+   */
+  readonly sendTransactionStatusId?: string;
   /**
    * Set when Turnkey already handed back a hash, i.e. the send is on the
    * network but its outcome could not be read. Absent when the wait window
@@ -86,7 +93,7 @@ export class SponsoredTxPendingError extends Error {
 
   constructor(opts: {
     message: string;
-    sendTransactionStatusId: string;
+    sendTransactionStatusId?: string;
     txHash?: Hex;
   }) {
     super(opts.message);

--- a/lib/web3/turnkey-sponsored-tx.ts
+++ b/lib/web3/turnkey-sponsored-tx.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { TurnkeyRequestError } from "@turnkey/sdk-server";
 import { getAddress, type Hex } from "viem";
 import { ErrorCategory, logSystemError } from "@/lib/logging";
 import { sleep } from "@/lib/sleep";
@@ -21,9 +22,15 @@ import { toCaip2 } from "@/lib/web3/turnkey-sponsorship-config";
  * which we poll until the transaction is broadcast and a hash is available.
  *
  * Return contract:
- *   - `null` only for failures that happened BEFORE anything was broadcast
- *     (unsupported chain, `ethSendTransaction` rejected, or a terminal-failure
- *     status with no tx hash). Callers may safely fall back to direct signing.
+ *   - `null` only for failures that are certain to have happened BEFORE
+ *     anything was broadcast: an unsupported chain, an `ethSendTransaction`
+ *     rejection that Turnkey returned without accepting the activity, or a
+ *     terminal-failure status with no tx hash. Callers may safely fall back to
+ *     direct signing.
+ *   - A transport failure or timeout on the send request is NOT one of those,
+ *     because it cannot distinguish "not received" from "received and
+ *     executing". It is reported as a pending error so the caller never
+ *     re-sends.
  *   - `SponsoredTxRevertError` when the tx broadcast and reverted on-chain.
  *   - `SponsoredTxPendingError` when the send was accepted but we could not
  *     confirm its outcome within the wait window (Turnkey slow to broadcast,
@@ -58,6 +65,31 @@ const TERMINAL_FAILURE_STATUSES = new Set([
   "TIMEOUT",
   "REVERTED",
 ]);
+
+// gRPC status codes that mean Turnkey read the request and refused it before
+// any broadcast was attempted: bad arguments, no signing resource for the
+// wallet, denied, failed precondition, unauthenticated. A send that fails with
+// one of these never left, so the caller may fall back to direct signing.
+//
+// Anything else - DEADLINE_EXCEEDED, UNAVAILABLE, INTERNAL, or a transport
+// error that never reached Turnkey's API - leaves it unknown whether the
+// activity was accepted and broadcast. A timeout in particular cannot
+// distinguish "not received" from "received and executing", so it must not be
+// reported as "nothing happened".
+const PRE_BROADCAST_REJECTION_CODES = new Set([
+  3, // INVALID_ARGUMENT
+  5, // NOT_FOUND (no signing resource for this wallet)
+  7, // PERMISSION_DENIED
+  9, // FAILED_PRECONDITION
+  16, // UNAUTHENTICATED
+]);
+
+function isDefinitePreBroadcastRejection(error: unknown): boolean {
+  return (
+    error instanceof TurnkeyRequestError &&
+    PRE_BROADCAST_REJECTION_CODES.has(error.code)
+  );
+}
 
 export type TurnkeySponsoredTxParams = {
   subOrgId: string;
@@ -122,7 +154,19 @@ export async function submitTurnkeySponsoredTransaction(
         chain_id: params.chainId.toString(),
       }
     );
-    return null;
+    // Only a definite rejection means the activity was never accepted. A
+    // timeout or transport failure leaves it unknown whether Turnkey accepted
+    // and broadcast the send; returning null there would let the caller fall
+    // back to direct signing and broadcast a second transaction, which is the
+    // double-send this path exists to prevent. Surface a pending error with no
+    // status id instead, and never fall back.
+    if (isDefinitePreBroadcastRejection(error)) {
+      return null;
+    }
+    throw new SponsoredTxPendingError({
+      message:
+        "Turnkey send request failed with an undetermined outcome; not falling back to avoid a duplicate broadcast",
+    });
   }
 
   const txHash = await pollForTxHash(params.subOrgId, statusId, pollOptions);
@@ -180,31 +224,37 @@ async function pollForTxHash(
     }
 
     const hash = response.eth?.txHash;
-    const hasFailure =
-      TERMINAL_FAILURE_STATUSES.has(response.txStatus) ||
-      Boolean(response.txError) ||
-      Boolean(response.error);
+    const hasHash = hash !== undefined && hash !== "";
+    const terminalFailure = TERMINAL_FAILURE_STATUSES.has(response.txStatus);
+    const failureFlagged = Boolean(response.txError) || Boolean(response.error);
 
-    if (hasFailure) {
+    if (hasHash && (terminalFailure || failureFlagged)) {
       // Post-broadcast revert: txHash is set, the underlying call is already
       // on-chain. Throw a typed error carrying Turnkey's structured revert
       // chain so callers can surface the real revert reason and skip the
       // direct-signing fallback (which would just revert again).
-      if (hash !== undefined && hash !== "") {
-        const revertChain = (response.error?.eth?.revertChain ??
-          []) as readonly RevertChainEntry[];
-        const message = response.txError ?? formatRevertChain(revertChain);
-        throw new SponsoredTxRevertError({
-          message,
-          txHash: hash as Hex,
-          sendTransactionStatusId,
-          revertChain,
-        });
-      }
+      const revertChain = (response.error?.eth?.revertChain ??
+        []) as readonly RevertChainEntry[];
+      const message = response.txError ?? formatRevertChain(revertChain);
+      throw new SponsoredTxRevertError({
+        message,
+        txHash: hash as Hex,
+        sendTransactionStatusId,
+        revertChain,
+      });
+    }
 
-      // Pre-broadcast failure (policy denial, gas-cap exhaustion, simulation
-      // error). Nothing happened on-chain; return null so the caller falls
-      // back to direct signing.
+    // Turnkey assigned a hash -> the tx is broadcast and we own it. Return it
+    // so the caller waits for the receipt and reports the real on-chain outcome
+    // (included or reverted) as the node result, and never re-sends.
+    if (hasHash) {
+      return hash as Hex;
+    }
+
+    if (terminalFailure) {
+      // Definite pre-broadcast failure (policy denial, gas-cap exhaustion,
+      // simulation error). The activity ended before broadcast; return null so
+      // the caller falls back to direct signing.
       logSystemError(
         ErrorCategory.EXTERNAL_SERVICE,
         "[Turnkey Sponsorship] Transaction terminated before broadcast",
@@ -218,11 +268,26 @@ async function pollForTxHash(
       return null;
     }
 
-    // Turnkey assigned a hash -> the tx is broadcast and we own it. Return it
-    // so the caller waits for the receipt and reports the real on-chain outcome
-    // (included or reverted) as the node result, and never re-sends.
-    if (hash !== undefined && hash !== "") {
-      return hash as Hex;
+    if (failureFlagged) {
+      // An error flag without a terminal status. Turnkey has accepted the
+      // activity and no hash has come back yet, so it may still broadcast;
+      // reporting "nothing happened" here would let the caller re-send and
+      // double-broadcast. Surface a pending error and never fall back.
+      logSystemError(
+        ErrorCategory.EXTERNAL_SERVICE,
+        "[Turnkey Sponsorship] Error flagged without a terminal status; outcome unknown",
+        new Error(response.txError ?? response.txStatus),
+        {
+          service: "turnkey",
+          send_transaction_status_id: sendTransactionStatusId,
+          tx_status: response.txStatus,
+        }
+      );
+      throw new SponsoredTxPendingError({
+        message:
+          "Turnkey reported an error without a terminal status; sponsored transaction outcome unknown",
+        sendTransactionStatusId,
+      });
     }
 
     await sleep(intervalMs);

--- a/tests/unit/turnkey-sponsored-tx.test.ts
+++ b/tests/unit/turnkey-sponsored-tx.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/web3/turnkey-sponsorship-config", () => ({
 
 // turnkey-revert is intentionally NOT mocked so `instanceof` works against the
 // real error classes.
+import { TurnkeyRequestError } from "@turnkey/sdk-server";
 import {
   SponsoredTxPendingError,
   SponsoredTxRevertError,
@@ -111,14 +112,58 @@ describe("submitTurnkeySponsoredTransaction", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when ethSendTransaction rejects", async () => {
+  it("returns null when ethSendTransaction rejects before accepting the activity", async () => {
     mockEthSend.mockRejectedValue(
-      new Error("Turnkey error 5: Could not find any resource to sign with")
+      new TurnkeyRequestError({
+        code: 5, // NOT_FOUND: no signing resource for this wallet
+        message: "Could not find any resource to sign with",
+        details: null,
+      })
     );
 
     const result = await submitTurnkeySponsoredTransaction(baseParams());
 
     expect(result).toBeNull();
+  });
+
+  it("throws SponsoredTxPendingError when ethSendTransaction fails with an unknown outcome", async () => {
+    // A transport failure or timeout cannot distinguish "not received" from
+    // "received and executing", so it must not be reported as pre-broadcast.
+    mockEthSend.mockRejectedValue(new Error("fetch failed"));
+
+    await expect(
+      submitTurnkeySponsoredTransaction(baseParams())
+    ).rejects.toBeInstanceOf(SponsoredTxPendingError);
+  });
+
+  it("throws SponsoredTxPendingError when the send fails with a retryable Turnkey code", async () => {
+    // UNAVAILABLE (14) is not a refusal: the activity may have been accepted.
+    mockEthSend.mockRejectedValue(
+      new TurnkeyRequestError({
+        code: 14,
+        message: "service unavailable",
+        details: null,
+      })
+    );
+
+    await expect(
+      submitTurnkeySponsoredTransaction(baseParams())
+    ).rejects.toBeInstanceOf(SponsoredTxPendingError);
+  });
+
+  it("throws SponsoredTxPendingError on an error flag without a terminal status", async () => {
+    // The activity was accepted (a status id came back) and no hash is known
+    // yet, so an error flag alone must not be read as "nothing happened".
+    mockEthSend.mockResolvedValue({ sendTransactionStatusId: "sid-flag" });
+    mockGetStatus.mockResolvedValue({
+      txStatus: "BROADCASTING",
+      txError: "transient",
+      eth: {},
+    });
+
+    await expect(
+      submitTurnkeySponsoredTransaction(baseParams(), FAST_POLL)
+    ).rejects.toBeInstanceOf(SponsoredTxPendingError);
   });
 
   it("returns the hash as soon as Turnkey assigns one, before a terminal-success status", async () => {


### PR DESCRIPTION
Fixes #2374.

## The invariant

`plugins/web3/steps/write-contract-core.ts:516` reads `sponsoredResult !== null` as "nothing was broadcast", and falls through to direct signing at `:595` when it is `null`. That is only sound if `null` really means nothing left. Two paths in `submitTurnkeySponsoredTransaction` returned `null` without being able to tell:

1. The `ethSendTransaction` catch returned `null` for every failure, including a timeout or a transport error - which cannot distinguish "not received" from "received and executing".
2. The status poll treated a bare `response.error` / `response.txError` flag as a pre-broadcast failure and returned `null`, even when `txStatus` was not terminal and the activity had been accepted.

Either one let the caller fall back to direct signing and broadcast a second transaction from the same wallet. That is the double-send in the report, and it is why the reconciler cannot repair the row: a `failed` execution with a null hash is excluded from the `status = 'unconfirmed' AND transaction_hash IS NOT NULL` scan twice over.

## The fix

`null` now means only "certain that nothing was broadcast".

- **Send request.** A `TurnkeyRequestError` whose gRPC code is a refusal (`INVALID_ARGUMENT`, `NOT_FOUND`, `PERMISSION_DENIED`, `FAILED_PRECONDITION`, `UNAUTHENTICATED`) is a definite rejection before acceptance, so it still returns `null` and the caller may fall back. Any other failure - `DEADLINE_EXCEEDED`, `UNAVAILABLE`, `INTERNAL`, or a transport error that never reached the API - throws `SponsoredTxPendingError`, and the caller does not fall back.
- **Status poll.** A `null` return now requires a terminal-failure status (`FAILED`, `DROPPED`, `REJECTED`, `TIMEOUT`, `REVERTED`). An error flag with a non-terminal status throws `SponsoredTxPendingError` instead, because the activity was accepted and no hash has come back yet.

`SponsoredTxPendingError.sendTransactionStatusId` becomes optional: a send-request failure has no activity id to carry. The "never re-send" decision already keys on the error kind in `resolveSponsoredSendError`, not on that field, so nothing downstream changes except the log line, which now omits an absent id.

Scope is every sponsored EVM write on a sponsorship chain, not the Aave route that surfaced it, as you noted.

## Existing behaviour preserved

- A terminal-failure status with no hash still returns `null` (fallback allowed).
- A hash with any failure still throws `SponsoredTxRevertError`.
- A hash with no failure still returns the hash immediately.
- A deadline with no terminal status, and repeated status-API failures, still throw `SponsoredTxPendingError`.

## Tests

`tests/unit/turnkey-sponsored-tx.test.ts` gains three cases and makes the rejection mock realistic:

- `ethSendTransaction` rejects with `TurnkeyRequestError{code: 5}` (NOT_FOUND) -> `null` (fallback allowed), unchanged behaviour with a real SDK error instead of a plain `Error`.
- `ethSendTransaction` rejects with a transport error -> `SponsoredTxPendingError`.
- `ethSendTransaction` rejects with `TurnkeyRequestError{code: 14}` (UNAVAILABLE) -> `SponsoredTxPendingError`.
- An error flag with `txStatus: "BROADCASTING"` and no hash -> `SponsoredTxPendingError`.

## Verification

- 97 unit tests green across `turnkey-sponsored-tx`, `sponsored-transaction-manager`, `sponsored-send-error`, `approve-token`, `transfer-token-core`, `turnkey-operations`, `sponsored-client`, `turnkey-revert`.
- `tsc --noEmit` clean for these files (the only remaining errors are the pre-existing missing generated modules, `@/lib/step-registry` and `@/lib/credential-map`, which are gitignored build outputs).
- Biome clean on the four changed files.
