### PR TITLE
fix: #2308 declare LayerZero approve with no outputs so USDT's empty return decodes

### DIFF
--- a/protocols/abis/layerzero-erc20.json
+++ b/protocols/abis/layerzero-erc20.json
@@ -7,7 +7,7 @@
       { "name": "spender", "type": "address" },
       { "name": "amount", "type": "uint256" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
   },
   {
     "type": "function",

--- a/protocols/layerzero.ts
+++ b/protocols/layerzero.ts
@@ -467,23 +467,24 @@ export default defineAbiProtocol({
       },
     },
 
-    // The ERC-20 ABI declares approve as returning bool, which is the
-    // general ERC-20 shape but not USDT's - USDT returns no data at all,
-    // and chain 1's reference token is USDT. That mismatch is inert on
-    // every path a protocol action can take, which was worth establishing
-    // rather than assuming:
-    //   - the write path (protocol-write.ts -> writeContractCore) never
-    //     calls decodeFunctionResult; a write step returns no result;
-    //   - the one simulate path that does decode
-    //     (lib/execute/simulate.ts) guards on `returnData !== "0x"` and
-    //     falls back to the raw data inside a catch, so USDT's empty
-    //     return takes neither branch;
-    //   - the one place a decode failure is fatal
-    //     (batch-write-contract-core.ts, "Failed to decode result") is the
-    //     web3/batch-write-contract node, reachable only with a
-    //     hand-written ABI, not through a protocol action.
-    // Keep bool: it is correct for every other token this contract entry
-    // accepts, and narrowing it to no outputs would misdescribe them.
+    // The ERC-20 ABI declares approve with no outputs, rather than the bool
+    // the general ERC-20 shape returns. USDT returns no data at all, and
+    // chain 1's reference token is USDT, so the declaration has to cover
+    // both shapes.
+    //
+    // The mismatch is not inert on the write path, which is what a bool
+    // declaration would assume. Before broadcasting,
+    // EvmChainAdapter.executeContractCall runs a preflight `staticCall`
+    // (lib/web3/chain-adapter/evm.ts), and ethers decodes that call's return
+    // data against the declared outputs. Against USDT it decodes "0x" as a
+    // bool and throws BAD_DATA, so the approve fails before it is sent, with
+    // "Contract returned no data, but the ABI you supplied declares 1 output
+    // (bool)". It is a decode error reported as a contract failure.
+    //
+    // An empty `outputs` decodes both shapes: ethers reads nothing and
+    // ignores the 32 bytes a conforming token returns. Nothing downstream
+    // loses information, because a write step surfaces no return value
+    // either way - writeContractCore returns `result: undefined`.
     oftToken: {
       label: "OFT Underlying Token (ERC-20)",
       userSpecifiedAddress: true,

--- a/tests/unit/protocol-layerzero.test.ts
+++ b/tests/unit/protocol-layerzero.test.ts
@@ -1,9 +1,11 @@
+import { ethers } from "ethers";
 import { describe, expect, it } from "vitest";
 import {
   getEncodeTransform,
   getEncodeTransformKind,
 } from "@/lib/protocol-encode-transforms";
 import { getProtocol, registerProtocol } from "@/lib/protocol-registry";
+import layerzeroErc20Abi from "@/protocols/abis/layerzero-erc20.json";
 import layerzeroDef, {
   DEFAULT_EXTRA_OPTIONS,
   LAYERZERO_CONFIG_DOCS,
@@ -229,6 +231,20 @@ describe("LayerZero Protocol Definition (ABI-driven)", () => {
 
   it("the approve write is not payable", () => {
     expect(action("oft-approve").payable).toBeUndefined();
+  });
+
+  // Chain 1's reference token is USDT, whose approve returns no data. The
+  // write path decodes the preflight staticCall's return against these
+  // outputs (lib/web3/chain-adapter/evm.ts), so a bool declaration throws
+  // BAD_DATA and the approve never broadcasts. Empty outputs decode both an
+  // absent return and the 32 bytes a conforming token sends.
+  it("declares approve with no outputs so USDT's empty return decodes", () => {
+    const iface = new ethers.Interface(layerzeroErc20Abi);
+    const bool32 = ethers.zeroPadValue("0x01", 32);
+
+    expect(iface.getFunction("approve")?.outputs).toHaveLength(0);
+    expect(() => iface.decodeFunctionResult("approve", "0x")).not.toThrow();
+    expect(() => iface.decodeFunctionResult("approve", bool32)).not.toThrow();
   });
 
   it("getConfig defaults configType to the ULN config", () => {


### PR DESCRIPTION
Fixes the `layerzero (Ethereum) > write > oft-approve` failure that has blocked the staging deploy since #2323 merged. Staging is still serving `app-9695fa6`; the two CI Pipeline runs after that (`873e0f34`, `048b8fe3`) both failed on `protocol-coverage-ephemeral (shard 4)`, and PR #2388 (release to prod) inherits the same failure.

## Root cause

Chain 1's reference OFT wraps USDT (`0xdAC17F958D2ee523a2206206994597C13D831ec7`), whose `approve` returns no data. `protocols/abis/layerzero-erc20.json` declared `approve` as returning `bool`.

Before broadcasting, `EvmChainAdapter.executeContractCall` runs a preflight `staticCall` (`lib/web3/chain-adapter/evm.ts:165-175`), and ethers decodes that call's return data against the declared outputs. Against USDT it decodes `"0x"` as a `bool` and throws `BAD_DATA`, so the approve fails before it is sent:

```
Contract call failed: Contract returned no data, but the ABI you supplied
declares 1 output (bool) for approve. If this function returns nothing, use
outputs: [].
```

The rationale comment #2323 shipped alongside the `bool` declaration argued the mismatch was inert on every path. Its first bullet - that the write path never decodes - misses this preflight, which is why the failure only surfaced once the coverage suite exercised a real USDT approve. That comment is corrected here rather than removed, so the next reader gets the path that actually decodes.

## Fix

`approve` is declared with no outputs. Verified against ethers 6.17.0:

| declaration | return `0x` | return 32-byte bool |
|---|---|---|
| `outputs: [bool]` | `BAD_DATA` | ok |
| `outputs: []` | ok | ok |

An empty list decodes both shapes, so it covers USDT and every conforming token this contract entry accepts. Nothing downstream loses information: a write step surfaces no return value either way (`writeContractCore` returns `result: undefined`).

## Scope

Narrow by intent. `lib/contracts/abis/erc20.json` declares `approve` returning `bool` too, so `web3/approve-token` and generic writes should hit the same preflight failure against USDT. That is a pre-existing defect with a wider blast radius and is tracked as KEEP-1345 rather than fixed on a release branch.

## Verification

- `tests/unit/protocol-layerzero.test.ts` - 22 passed, including a new regression test asserting `approve` decodes both an absent return and a 32-byte bool
- `tests/unit/protocol-calldata.test.ts` (508), `protocol-abi-derive` (21), `output-schema` (3) - all passed; the calldata goldens encode inputs and are unaffected
- `biome check` clean on all three changed files