### PR TITLE
fix: #2308 declare CCIP approve with no outputs and narrow the LayerZero rationale

### DIFF
--- a/docs/plugins/layerzero.md
+++ b/docs/plugins/layerzero.md
@@ -256,7 +256,10 @@ Approve an OFT Adapter to pull the underlying token. Needed only when OFT Approv
 
 | Output | Type | Description |
 |--------|------|-------------|
-| result | bool | Result |
+| success | bool | Whether the approval succeeded |
+| error | string | Error message if the approval failed |
+| transactionHash | string | Transaction hash |
+| transactionLink | string | Explorer link to the transaction |
 
 Note which contract this runs against: the approval is granted on the token, not on the OFT, so `contractAddress` is the underlying token address from OFT Underlying Token, and `spender` is the OFT Adapter.
 

--- a/protocols/abis/ccip-erc20.json
+++ b/protocols/abis/ccip-erc20.json
@@ -7,7 +7,7 @@
       { "name": "spender", "type": "address" },
       { "name": "amount", "type": "uint256" }
     ],
-    "outputs": [{ "name": "", "type": "bool" }]
+    "outputs": []
   },
   {
     "type": "function",

--- a/protocols/chainlink.ts
+++ b/protocols/chainlink.ts
@@ -504,6 +504,17 @@ export default defineAbiProtocol({
       },
     },
 
+    // Both token contracts below declare approve with no outputs rather
+    // than the bool the general ERC-20 shape returns, for the reason set
+    // out on layerzero.ts's oftToken entry: they take a user-supplied
+    // token address, USDT is a CCIP-supported bridge and fee token, and
+    // USDT's approve returns no data. On the EOA path the adapter's
+    // preflight staticCall decodes that return against these outputs and
+    // throws BAD_DATA, failing the approve before it is broadcast.
+    //
+    // The coverage fixture does not catch this: CCIP_ERC20_ADDRESSES
+    // points at WETH/WBNB/WMATIC/WAVAX, which all return bool, and both
+    // approve actions are skipped there in any case.
     ccipBridgeToken: {
       label: "Bridge Token (ERC-20 for CCIP)",
       userSpecifiedAddress: true,

--- a/protocols/layerzero.ts
+++ b/protocols/layerzero.ts
@@ -472,14 +472,21 @@ export default defineAbiProtocol({
     // chain 1's reference token is USDT, so the declaration has to cover
     // both shapes.
     //
-    // The mismatch is not inert on the write path, which is what a bool
-    // declaration would assume. Before broadcasting,
-    // EvmChainAdapter.executeContractCall runs a preflight `staticCall`
-    // (lib/web3/chain-adapter/evm.ts), and ethers decodes that call's return
-    // data against the declared outputs. Against USDT it decodes "0x" as a
-    // bool and throws BAD_DATA, so the approve fails before it is sent, with
-    // "Contract returned no data, but the ABI you supplied declares 1 output
-    // (bool)". It is a decode error reported as a contract failure.
+    // The mismatch is not inert, which is what a bool declaration would
+    // assume. On the EOA path, EvmChainAdapter.executeContractCall runs a
+    // preflight `staticCall` before broadcasting (lib/web3/chain-adapter/
+    // evm.ts), and ethers decodes that call's return data against the
+    // declared outputs. Against USDT it decodes "0x" as a bool and throws
+    // BAD_DATA, so the approve fails before it is sent, with "Contract
+    // returned no data, but the ABI you supplied declares 1 output (bool)".
+    // It is a decode error reported as a contract failure.
+    //
+    // Only that path decodes. Safe, Safe-role and Turnkey-sponsored sends
+    // encode the call and estimate gas without a staticCall
+    // (lib/safe/execute-as-safe.ts, lib/web3/sponsored-transaction-manager.ts),
+    // so a bool declaration survives them. Stating this precisely matters:
+    // the same node, ABI and token fails for an EOA connection and succeeds
+    // for a Safe one, so a repro that omits the signer mode proves nothing.
     //
     // An empty `outputs` decodes both shapes: ethers reads nothing and
     // ignores the 32 bytes a conforming token returns. Nothing downstream

--- a/tests/unit/protocol-chainlink.test.ts
+++ b/tests/unit/protocol-chainlink.test.ts
@@ -1,5 +1,7 @@
+import { ethers } from "ethers";
 import { describe, expect, it } from "vitest";
 import { getProtocol, registerProtocol } from "@/lib/protocol-registry";
+import ccipErc20Abi from "@/protocols/abis/ccip-erc20.json";
 import chainlinkDef from "@/protocols/chainlink";
 
 const KEBAB_CASE_REGEX = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
@@ -285,6 +287,20 @@ describe("Chainlink Protocol Definition", () => {
     expect(action?.type).toBe("write");
     expect(action?.contract).toBe("ccipBnM");
     expect(action?.inputs).toHaveLength(1);
+  });
+
+  // USDT is a CCIP-supported bridge and fee token and returns no data from
+  // approve. Both CCIP token contracts take a user-supplied address, so the
+  // ABI has to cover that shape: the EOA write path decodes the preflight
+  // staticCall's return against these outputs (lib/web3/chain-adapter/evm.ts),
+  // and a bool declaration throws BAD_DATA before the approve is broadcast.
+  // The coverage suite cannot catch this - its reference tokens all return
+  // bool, and both approve actions are skipped there.
+  it("declares approve with no outputs so a no-data return decodes", () => {
+    const iface = new ethers.Interface(ccipErc20Abi);
+
+    expect(iface.getFunction("approve")?.outputs).toHaveLength(0);
+    expect(() => iface.decodeFunctionResult("approve", "0x")).not.toThrow();
   });
 
   it("registers in the protocol registry and is retrievable", () => {

--- a/tests/unit/protocol-layerzero.test.ts
+++ b/tests/unit/protocol-layerzero.test.ts
@@ -234,17 +234,14 @@ describe("LayerZero Protocol Definition (ABI-driven)", () => {
   });
 
   // Chain 1's reference token is USDT, whose approve returns no data. The
-  // write path decodes the preflight staticCall's return against these
+  // EOA write path decodes the preflight staticCall's return against these
   // outputs (lib/web3/chain-adapter/evm.ts), so a bool declaration throws
-  // BAD_DATA and the approve never broadcasts. Empty outputs decode both an
-  // absent return and the 32 bytes a conforming token sends.
+  // BAD_DATA and the approve never broadcasts.
   it("declares approve with no outputs so USDT's empty return decodes", () => {
     const iface = new ethers.Interface(layerzeroErc20Abi);
-    const bool32 = ethers.zeroPadValue("0x01", 32);
 
     expect(iface.getFunction("approve")?.outputs).toHaveLength(0);
     expect(() => iface.decodeFunctionResult("approve", "0x")).not.toThrow();
-    expect(() => iface.decodeFunctionResult("approve", bool32)).not.toThrow();
   });
 
   it("getConfig defaults configType to the ULN config", () => {


### PR DESCRIPTION
Follow-up to #2389, from an independent review of that PR. Four fixes, none of which change runtime behaviour for a conforming token.

## 1. `protocols/abis/ccip-erc20.json` had the same defect, one file over

`approve` declared a `bool` output. Both contracts bound to that ABI - `ccipBridgeToken` and `ccipFeeToken` - are `userSpecifiedAddress: true`, and USDT is a CCIP-supported bridge and fee token. So on the EOA path the adapter's preflight `staticCall` decodes USDT's empty return as a bool, throws `BAD_DATA`, and the approve fails before it is broadcast - byte for byte the failure #2389 fixed for LayerZero.

The coverage suite cannot catch this. `CCIP_ERC20_ADDRESSES` points at WETH/WBNB/WMATIC/WAVAX, which all return `bool`, and both approve actions are skipped in the fixture regardless. Guarded here with a unit test instead; verified it fails when the `bool` declaration is restored.

## 2. #2389's comment overstated the failure, in the same direction as the comment it replaced

It said the mismatch "is not inert on the write path". Only the EOA path decodes:

| Route | Preflight `staticCall`? |
|---|---|
| EOA direct | yes - breaks |
| Safe | no - `encodeFunctionData` + `estimateGas` |
| Safe-role | no - same |
| Turnkey sponsored | no - `encodeFunctionData` only |

The comment it corrected claimed the write path *never* decodes; its replacement implied it *always* does. Both wrong, opposite directions. This matters practically: the same node, ABI and token fails for an EOA connection and succeeds for a Safe one, so a repro that omits the signer mode proves nothing either way.

## 3. One assertion in #2389's test discriminated nothing

`decodeFunctionResult("approve", bool32)` not throwing holds under `outputs: [bool]` as well as `outputs: []`, so it documented rather than tested. Dropped.

Worth noting what this test still is not: a guard on the mechanism. Nothing exercises `EvmChainAdapter.executeContractCall` against a provider returning `"0x"`. A stubbed-provider test there would cover every write ABI at once, including `lib/contracts/abis/erc20.json`, which still declares `bool` on `approve`/`transfer`/`transferFrom`. Both are left to the separately tracked ticket rather than widened onto a release branch.

## 4. `docs/plugins/layerzero.md` documented an output that never existed

The OFT Approve page listed `result | bool | Result`. `buildOutputFieldsFromAction` gates ABI outputs on `action.type === "read"`, so a write action surfaces `success`, `error`, `transactionHash`, `transactionLink`. That row was wrong before this change and contradicted the shipped ABI after it.

## Verification

- `tests/unit/protocol-layerzero.test.ts` (22) and `tests/unit/protocol-chainlink.test.ts` (30) pass; `protocol-calldata` (508) unaffected
- The new CCIP test fails when the `bool` declaration is restored, so it is a real guard
- `biome check` clean on all five changed files