### PR TITLE
fix(executor): raise runner memory limit and heap cap

### DIFF
--- a/keeperhub-executor/k8s-job.test.ts
+++ b/keeperhub-executor/k8s-job.test.ts
@@ -67,6 +67,28 @@ function getEnvVar(envVars: V1EnvVar[], name: string): string | undefined {
   return envVars.find((v) => v.name === name)?.value;
 }
 
+function getHeapCapMib(envVars: V1EnvVar[]): number {
+  const nodeOptions = getEnvVar(envVars, "NODE_OPTIONS") ?? "";
+  const match = nodeOptions.match(/--max-old-space-size=(\d+)/);
+  if (!match) {
+    throw new Error(`No heap cap in NODE_OPTIONS: "${nodeOptions}"`);
+  }
+  return Number(match[1]);
+}
+
+function getMemoryLimitMib(job: V1Job): number {
+  const limit =
+    job.spec?.template?.spec?.containers?.[0]?.resources?.limits?.memory;
+  if (typeof limit !== "string") {
+    throw new Error("Runner container declares no memory limit");
+  }
+  const match = limit.match(/^(\d+)(Mi|Gi)$/);
+  if (!match) {
+    throw new Error(`Unsupported memory limit format: "${limit}"`);
+  }
+  return match[2] === "Gi" ? Number(match[1]) * 1024 : Number(match[1]);
+}
+
 function getSecretRef(
   envVars: V1EnvVar[],
   name: string
@@ -445,7 +467,13 @@ describe("createWorkflowJob", () => {
       triggerType: "schedule",
     });
 
-    const envVars = getJobEnvVars(getSubmittedJob());
-    expect(getEnvVar(envVars, "NODE_OPTIONS")).toBe("--max-old-space-size=224");
+    const job = getSubmittedJob();
+    const heapCapMib = getHeapCapMib(getJobEnvVars(job));
+    const limitMib = getMemoryLimitMib(job);
+
+    // The kill lands on total RSS, so the heap cap has to leave room for the
+    // off-heap allocations that sit alongside it, not merely undercut the limit.
+    expect(heapCapMib).toBeLessThan(limitMib);
+    expect(limitMib - heapCapMib).toBeGreaterThanOrEqual(256);
   });
 });

--- a/keeperhub-executor/k8s-job.ts
+++ b/keeperhub-executor/k8s-job.ts
@@ -121,10 +121,14 @@ export async function createWorkflowJob(params: {
     // Node sizes its heap from the host's RAM, not the container's cgroup
     // limit, so on a large node it grows past the memory limit below and the
     // kernel SIGKILLs the pod mid-run with no error and no terminal status,
-    // orphaning another execution row. Capping the heap under the limit turns
-    // that silent kill into a recorded JS heap error, and leaves the remainder
-    // for off-heap RSS (the binary, buffers, native memory).
-    { name: "NODE_OPTIONS", value: "--max-old-space-size=224" },
+    // orphaning the execution row. Capping the heap keeps V8 from expanding
+    // into that kill.
+    //
+    // Stays well under the limit below because the kill lands on total RSS, not
+    // on the heap: a step that parses a large API response holds the response
+    // buffer off-heap while the parsed objects sit on it, so the gap has to
+    // cover both. Raise the two together or not at all.
+    { name: "NODE_OPTIONS", value: "--max-old-space-size=512" },
     // Derived from activeDeadlineSeconds so the drain watchdog always fires
     // while the pod is alive. See resolveDrainTimeoutMs in config.ts.
     {
@@ -237,7 +241,11 @@ export async function createWorkflowJob(params: {
                   "ephemeral-storage": CONFIG.runnerEphemeralStorageRequest,
                 },
                 limits: {
-                  memory: "320Mi",
+                  // Headroom for steps whose peak is driven by an external
+                  // response size rather than by the workflow's own shape. The
+                  // request stays put: it is what the scheduler packs on, and
+                  // the vast majority of runs never approach this ceiling.
+                  memory: "768Mi",
                   cpu: "750m",
                   "ephemeral-storage": CONFIG.runnerEphemeralStorageLimit,
                 },

--- a/specs/workflow-execution-runtime.md
+++ b/specs/workflow-execution-runtime.md
@@ -344,7 +344,7 @@ spec:
               cpu: "200m"
               ephemeral-storage: "64Mi"  # honest floor for accounting (env RUNNER_EPHEMERAL_STORAGE_REQUEST)
             limits:
-              memory: "320Mi"
+              memory: "768Mi"        # paired with --max-old-space-size=512; the gap covers off-heap RSS
               cpu: "750m"
               ephemeral-storage: "1Gi"   # runaway-/tmp guard (~2 MiB normal); evicts a pathological pod before it threatens the node (env RUNNER_EPHEMERAL_STORAGE_LIMIT)
       volumes:


### PR DESCRIPTION
Workflow runner pods run with `limits.memory: 320Mi` and `--max-old-space-size=224`. When a step's peak memory is driven by the size of an external API response rather than by the workflow's own shape, total RSS crosses the cgroup limit and the kernel SIGKILLs the pod with exit 137.

Two things make that failure hard to read:

- The kill lands on total RSS, not on the V8 heap, so the heap cap never fires and no JS heap error is recorded. Nothing reaches Sentry.
- `backoffLimit` is 0, so the job is finished the moment the pod dies. Nothing reconciles a dead job back to the execution row, so the run sits `running` until the stale execution reaper closes it about half an hour later. The duration recorded against the run is the reaper's clock, not work being done.

### Change

| | before | after |
|---|---|---|
| `limits.memory` | 320Mi | 768Mi |
| `--max-old-space-size` | 224 | 512 |
| `requests.memory` | 160Mi | 160Mi (unchanged) |

Requests are what the scheduler packs on, so leaving them alone keeps node count and pod placement unchanged. Only the burst ceiling moves, and it is reached by a very small fraction of runs.

The 256Mi gap between the heap cap and the container limit is deliberate rather than leftover: a step parsing a large response holds the response buffer off-heap while the parsed objects sit on the heap, so the gap has to cover both. The two values need to move together.

### Test

`caps the runner heap below the container memory limit` asserted a literal string, so it would have passed for any pair of values, including a heap cap at or above the container limit. It now reads both numbers off the generated job spec and asserts the relationship the test name describes.

### Not covered here

This raises the ceiling. It does not stop a step's memory from scaling with the size of an upstream response, so a step that accumulates a whole paginated result set before filtering it will climb back into the new limit as that data set grows. That is worth a separate change.
