### PR TITLE
fix(sandbox): run Code node user code in its own realm

### DIFF
--- a/docs/plugins/code.md
+++ b/docs/plugins/code.md
@@ -55,7 +55,7 @@ const events = {{QueryEvents.events}};
 
 ### Available Globals
 
-- **I/O:** `console`, `fetch`
+- **I/O:** `console` (`log`, `warn`, `error`), `fetch`
 - **Core types:** `BigInt`, `JSON`, `Math`, `Date`, `Array`, `Object`, `String`, `Number`, `Boolean`, `RegExp`, `Symbol`, `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`
 - **Error types:** `Error`, `TypeError`, `RangeError`, `SyntaxError`, `ReferenceError`, `URIError`
 - **Numeric/parsing:** `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `Infinity`, `NaN`
@@ -63,14 +63,28 @@ const events = {{QueryEvents.events}};
 - **Base64:** `atob`, `btoa`
 - **Text encoding:** `TextEncoder`, `TextDecoder`
 - **Binary/typed arrays:** `ArrayBuffer`, `DataView`, `Uint8Array`, `Uint16Array`, `Uint32Array`, `Int8Array`, `Int16Array`, `Int32Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`
-- **Fetch API:** `URL`, `URLSearchParams`, `Headers`, `Request`, `Response`, `AbortController`, `AbortSignal`
+- **URLs and headers:** `URL`, `URLSearchParams`, `Headers`, `AbortController`, `AbortSignal`
 - **Utilities:** `structuredClone`, `Intl`, `crypto.randomUUID`
 
-**Not available:** `require`, `import`, `process`, `fs`, `eval`, `Function` constructor, `setTimeout`, `setInterval`, or any Node.js built-in modules.
+**Not available:** `require`, `import`, `process`, `fs`, `setTimeout`, `setInterval`, the `Request` and `Response` constructors, or any Node.js built-in modules.
+
+### Working with a fetch response
+
+`fetch` resolves to a response object carrying `ok`, `status`, `statusText`, `url`, `redirected`, and `headers`, plus `text()`, `json()`, `arrayBuffer()`, `bytes()` and `clone()`. The body is read in full before the promise resolves, so there is no streaming `body` property; a response body larger than 96 MB fails the request.
+
+```javascript
+const response = await fetch("https://api.example.com/prices");
+if (!response.ok) {
+  throw new Error(`Request failed with ${response.status}`);
+}
+const prices = await response.json();
+```
+
+Request bodies accept a string, a `URLSearchParams`, an `ArrayBuffer` or a typed array. Pass request headers as a plain object or a `Headers` instance.
 
 ### Security
 
-The sandbox uses `node:vm` which prevents accidental access to Node.js internals but is not a security boundary against determined attackers. This is appropriate for a self-hosted platform where users are authenticated team members. `maxRetries` is set to 0 (fail-safe).
+User code runs in a separate, disposable process, inside a fresh `node:vm` context that owns its own set of JavaScript built-ins. Nothing from the surrounding process is shared into that context: `console`, `fetch` and `crypto.randomUUID` are bridged across the boundary as plain values, so the built-ins user code touches lead back to the sandbox rather than to the host. The child's environment is reduced to a short allowlist of variables, and `maxRetries` is set to 0 (fail-safe).
 
 `fetch` is wrapped with an `AbortController` deadline matching the configured timeout, so network requests cannot hang indefinitely. A wall-clock `Promise.race` timeout also guards the entire execution, covering any async operation (not just fetch). Only `crypto.randomUUID` is exposed (`crypto.subtle` and other methods are not available).
 

--- a/lib/sandbox/child-source.ts
+++ b/lib/sandbox/child-source.ts
@@ -62,7 +62,8 @@ import blocklist from "../ssrf-blocklist.json" with { type: "json" };
  * Residual: a sandbox escape is still arbitrary code running AS the user, so
  * it can return any DATA it likes (exactly as legitimate user code can). What
  * it can no longer do is hand the parent untrusted bytes to deserialize. The
- * vector is gated behind a vm escape; the child is env-scrubbed and
+ * vector is gated behind a vm escape, the sandbox context shares no object
+ * with this realm (see sandboxBootstrap), and the child is env-scrubbed and
  * NetworkPolicy-isolated.
  */
 export const SANDBOX_RESULT_FD = 3;
@@ -498,8 +499,9 @@ export function encodeSandboxResult(value: unknown): string {
  *
  * Responsibilities:
  *   - Read a JSON payload from stdin: `{ code: string, timeoutMs: number }`
- *   - Execute `code` inside a vm.createContext sandbox with a scrubbed set
- *     of globals
+ *   - Execute `code` inside a fresh vm.createContext realm, then rebuild the
+ *     non-ECMAScript globals (console, fetch, URL, TextEncoder, ...) inside
+ *     that realm rather than copying this process's objects in
  *   - Apply an SSRF guard to `fetch` (DNS-resolved denylist mirroring
  *     lib/safe-fetch.ts from KEEP-314)
  *   - Apply a wall-clock timeout (beyond the vm's sync CPU timeout) that
@@ -511,6 +513,10 @@ export const SANDBOX_CHILD_SOURCE = `
 "use strict";
 const { createContext, runInContext } = require("node:vm");
 const fs = require("node:fs");
+// Cross-realm type predicates. User values now come from the sandbox's own
+// realm, so \`value instanceof Date\` (host Date) is false for a sandbox Date;
+// these read internal slots instead and work across realms.
+const types = require("node:util").types;
 const dnsPromises = require("node:dns").promises;
 const { BlockList, isIP } = require("node:net");
 const http = require("node:http");
@@ -811,6 +817,12 @@ const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 // across chunks would otherwise slip past it.
 const GZIP_MAX_OUTPUT_BYTES = ${SANDBOX_RESULT_MAX_BYTES};
 
+// Upper bound on a response body the sandbox will buffer before handing it to
+// user code. The body is marshalled into the sandbox realm as base64 text (a
+// host Response object would hand user code the host realm), so it has to be
+// read fully; this bounds that read at the same budget as the gzip path.
+const MAX_RESPONSE_BODY_BYTES = ${SANDBOX_RESULT_MAX_BYTES};
+
 // Transform that errors the stream once cumulative bytes exceed maxBytes. zlib's
 // maxOutputLength is per-output-buffer, so this is the load-bearing cumulative
 // cap on a decompressed body; it tears the pipe down with an error rather than
@@ -884,9 +896,10 @@ function buildResponseHeaders(rawHeaders) {
 // Drop-in replacement for global fetch used by the wrapped sandbox fetch. Dials
 // only the pre-validated pinnedAddresses (resolved + validated once by the
 // caller) instead of letting the network layer re-resolve, and returns a
-// genuine WHATWG Response so user code keeps the full fetch contract (.ok /
-// .status / .headers / .json() / .text() / .body). Redirects are NOT
-// auto-followed here; the caller's loop re-validates and follows each hop.
+// genuine WHATWG Response so status, headers and body decoding all behave as
+// the network layer would; marshalResponse then flattens it for the sandbox
+// realm. Redirects are NOT auto-followed here; the caller's loop re-validates
+// and follows each hop.
 async function pinnedFetch(request, pinnedAddresses, signal) {
   // request is the WHATWG Request the caller already built and validated.
   // pinnedFetch reads the dial URL from THIS object and never re-derives it from
@@ -1035,6 +1048,1184 @@ async function cancelResponseBody(response) {
   }
 }
 
+// Bootstrap evaluated INSIDE the vm context (via Function.prototype.toString,
+// see installSandboxGlobals), so every object it builds belongs to the sandbox
+// realm.
+//
+// The sandbox used to be populated by copying ~55 host intrinsics into
+// createContext(): Array, JSON, Math, Object, the typed arrays, URL, Response
+// and so on. Each of them was an object from THIS process's realm, so
+// X.constructor.constructor resolved to the host Function and user code could
+// compile a function that runs outside the sandbox and reach process /
+// process.binding from there. A fresh createContext({}) already owns a
+// complete set of ECMAScript intrinsics that lead nowhere, so the fix is to
+// inject none of them and rebuild the non-ECMAScript surface here, in-realm.
+//
+// Two rules keep it closed, and both are load-bearing:
+//   - This function must stay self-contained. It runs in the other realm, so
+//     it can reference only its own locals, its parameter, and the realm's own
+//     globals -- never an identifier from the surrounding (host) scope.
+//   - The host \`bridge\` functions it closes over are the only host values that
+//     cross, they are never exposed to user code, and they exchange PRIMITIVES
+//     only. Handing back a host object (a Response, a plain {} built in the
+//     host realm, a rejected host Error) would reopen the hole, so fetch
+//     results arrive as JSON text and are rebuilt here.
+function sandboxBootstrap(bridge) {
+  "use strict";
+
+  const HEX = "0123456789ABCDEF";
+  const B64_CHARS =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  const B64_INDEX = new Map();
+  for (let i = 0; i < B64_CHARS.length; i++) {
+    B64_INDEX.set(B64_CHARS.charAt(i), i);
+  }
+
+  // Every bridge call that can fail answers with this envelope, so a host
+  // exception never crosses into user code as a catchable host Error.
+  function unwrap(json) {
+    const envelope = JSON.parse(json);
+    if (envelope.ok !== true) {
+      throw new TypeError(envelope.e);
+    }
+    return envelope.v;
+  }
+
+  function isAsciiWhitespace(charCode) {
+    return (
+      charCode === 32 ||
+      charCode === 9 ||
+      charCode === 10 ||
+      charCode === 13 ||
+      charCode === 12
+    );
+  }
+
+  function bytesToBase64(bytes) {
+    let out = "";
+    for (let i = 0; i < bytes.length; i += 3) {
+      const hasSecond = i + 1 < bytes.length;
+      const hasThird = i + 2 < bytes.length;
+      const b0 = bytes[i];
+      const b1 = hasSecond ? bytes[i + 1] : 0;
+      const b2 = hasThird ? bytes[i + 2] : 0;
+      out += B64_CHARS.charAt(b0 >> 2);
+      out += B64_CHARS.charAt(((b0 & 3) << 4) | (b1 >> 4));
+      out += hasSecond ? B64_CHARS.charAt(((b1 & 15) << 2) | (b2 >> 6)) : "=";
+      out += hasThird ? B64_CHARS.charAt(b2 & 63) : "=";
+    }
+    return out;
+  }
+
+  function base64ToBytes(input) {
+    let clean = "";
+    for (let i = 0; i < input.length; i++) {
+      if (!isAsciiWhitespace(input.charCodeAt(i))) {
+        clean += input.charAt(i);
+      }
+    }
+    while (clean.length > 0 && clean.charAt(clean.length - 1) === "=") {
+      clean = clean.slice(0, -1);
+    }
+    if (clean.length % 4 === 1) {
+      throw new TypeError("atob: invalid base64 length");
+    }
+    const out = new Uint8Array(Math.floor((clean.length * 3) / 4));
+    let bits = 0;
+    let bitCount = 0;
+    let outIndex = 0;
+    for (let i = 0; i < clean.length; i++) {
+      const value = B64_INDEX.get(clean.charAt(i));
+      if (value === undefined) {
+        throw new TypeError("atob: invalid base64 character");
+      }
+      bits = (bits << 6) | value;
+      bitCount += 6;
+      if (bitCount >= 8) {
+        bitCount -= 8;
+        out[outIndex] = (bits >> bitCount) & 255;
+        outIndex += 1;
+      }
+    }
+    return out;
+  }
+
+  function utf8Encode(text) {
+    const bytes = [];
+    for (let i = 0; i < text.length; i++) {
+      let point = text.charCodeAt(i);
+      if (point >= 0xd800 && point <= 0xdbff && i + 1 < text.length) {
+        const next = text.charCodeAt(i + 1);
+        if (next >= 0xdc00 && next <= 0xdfff) {
+          point = (point - 0xd800) * 0x400 + (next - 0xdc00) + 0x10000;
+          i += 1;
+        }
+      }
+      if (point >= 0xd800 && point <= 0xdfff) {
+        point = 0xfffd;
+      }
+      if (point < 0x80) {
+        bytes.push(point);
+      } else if (point < 0x800) {
+        bytes.push(0xc0 | (point >> 6), 0x80 | (point & 63));
+      } else if (point < 0x10000) {
+        bytes.push(
+          0xe0 | (point >> 12),
+          0x80 | ((point >> 6) & 63),
+          0x80 | (point & 63)
+        );
+      } else {
+        bytes.push(
+          0xf0 | (point >> 18),
+          0x80 | ((point >> 12) & 63),
+          0x80 | ((point >> 6) & 63),
+          0x80 | (point & 63)
+        );
+      }
+    }
+    return new Uint8Array(bytes);
+  }
+
+  function utf8Decode(bytes) {
+    let out = "";
+    let i = 0;
+    while (i < bytes.length) {
+      const first = bytes[i];
+      i += 1;
+      let point;
+      let continuation;
+      if (first < 0x80) {
+        point = first;
+        continuation = 0;
+      } else if ((first & 0xe0) === 0xc0) {
+        point = first & 31;
+        continuation = 1;
+      } else if ((first & 0xf0) === 0xe0) {
+        point = first & 15;
+        continuation = 2;
+      } else if ((first & 0xf8) === 0xf0) {
+        point = first & 7;
+        continuation = 3;
+      } else {
+        out += String.fromCharCode(0xfffd);
+        continue;
+      }
+      let valid = true;
+      for (let k = 0; k < continuation; k++) {
+        const next = bytes[i];
+        if (next === undefined || (next & 0xc0) !== 0x80) {
+          valid = false;
+          break;
+        }
+        point = (point << 6) | (next & 63);
+        i += 1;
+      }
+      if (!valid || point > 0x10ffff) {
+        out += String.fromCharCode(0xfffd);
+        continue;
+      }
+      if (point > 0xffff) {
+        const rest = point - 0x10000;
+        out += String.fromCharCode(0xd800 + (rest >> 10), 0xdc00 + (rest & 1023));
+      } else {
+        out += String.fromCharCode(point);
+      }
+    }
+    return out;
+  }
+
+  function toByteView(input) {
+    if (input instanceof Uint8Array) {
+      return input;
+    }
+    if (ArrayBuffer.isView(input)) {
+      return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+    }
+    if (input instanceof ArrayBuffer) {
+      return new Uint8Array(input);
+    }
+    throw new TypeError("expected an ArrayBuffer or a typed array");
+  }
+
+  function btoa(data) {
+    const text = String(data);
+    const bytes = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i++) {
+      const charCode = text.charCodeAt(i);
+      if (charCode > 255) {
+        throw new TypeError(
+          "btoa: the string contains characters outside of the Latin1 range"
+        );
+      }
+      bytes[i] = charCode;
+    }
+    return bytesToBase64(bytes);
+  }
+
+  function atob(data) {
+    const bytes = base64ToBytes(String(data));
+    let out = "";
+    for (let i = 0; i < bytes.length; i++) {
+      out += String.fromCharCode(bytes[i]);
+    }
+    return out;
+  }
+
+  class TextEncoder {
+    get encoding() {
+      return "utf-8";
+    }
+    encode(input) {
+      return utf8Encode(input === undefined ? "" : String(input));
+    }
+    encodeInto(source, destination) {
+      const text = String(source);
+      let read = 0;
+      let written = 0;
+      let i = 0;
+      while (i < text.length) {
+        const high = text.charCodeAt(i);
+        const isPair =
+          high >= 0xd800 &&
+          high <= 0xdbff &&
+          i + 1 < text.length &&
+          text.charCodeAt(i + 1) >= 0xdc00 &&
+          text.charCodeAt(i + 1) <= 0xdfff;
+        const unit = text.slice(i, i + (isPair ? 2 : 1));
+        const encoded = utf8Encode(unit);
+        if (written + encoded.length > destination.length) {
+          break;
+        }
+        destination.set(encoded, written);
+        written += encoded.length;
+        read += unit.length;
+        i += unit.length;
+      }
+      return { read: read, written: written };
+    }
+  }
+
+  class TextDecoder {
+    constructor(label) {
+      const name = label === undefined ? "utf-8" : String(label).toLowerCase();
+      if (name !== "utf-8" && name !== "utf8" && name !== "unicode-1-1-utf-8") {
+        throw new RangeError(
+          "TextDecoder: the sandbox only supports the utf-8 encoding"
+        );
+      }
+    }
+    get encoding() {
+      return "utf-8";
+    }
+    decode(input) {
+      if (input === undefined) {
+        return "";
+      }
+      return utf8Decode(toByteView(input));
+    }
+  }
+
+  function cloneValue(value, seen) {
+    if (value === null || typeof value !== "object") {
+      if (typeof value === "function" || typeof value === "symbol") {
+        throw new TypeError(
+          "structuredClone: a " + typeof value + " could not be cloned"
+        );
+      }
+      return value;
+    }
+    if (seen.has(value)) {
+      return seen.get(value);
+    }
+    if (value instanceof Date) {
+      const clone = new Date(value.getTime());
+      seen.set(value, clone);
+      return clone;
+    }
+    if (value instanceof RegExp) {
+      const clone = new RegExp(value.source, value.flags);
+      seen.set(value, clone);
+      return clone;
+    }
+    if (value instanceof ArrayBuffer) {
+      const clone = value.slice(0);
+      seen.set(value, clone);
+      return clone;
+    }
+    if (ArrayBuffer.isView(value)) {
+      const buffer = cloneValue(value.buffer, seen);
+      const clone =
+        value instanceof DataView
+          ? new DataView(buffer, value.byteOffset, value.byteLength)
+          : new value.constructor(buffer, value.byteOffset, value.length);
+      seen.set(value, clone);
+      return clone;
+    }
+    if (Array.isArray(value)) {
+      const clone = new Array(value.length);
+      seen.set(value, clone);
+      for (let i = 0; i < value.length; i++) {
+        clone[i] = cloneValue(value[i], seen);
+      }
+      return clone;
+    }
+    if (value instanceof Map) {
+      const clone = new Map();
+      seen.set(value, clone);
+      for (const pair of value) {
+        clone.set(cloneValue(pair[0], seen), cloneValue(pair[1], seen));
+      }
+      return clone;
+    }
+    if (value instanceof Set) {
+      const clone = new Set();
+      seen.set(value, clone);
+      for (const item of value) {
+        clone.add(cloneValue(item, seen));
+      }
+      return clone;
+    }
+    if (value instanceof Error) {
+      const clone = new value.constructor(value.message);
+      clone.name = value.name;
+      clone.stack = value.stack;
+      seen.set(value, clone);
+      return clone;
+    }
+    const clone = {};
+    seen.set(value, clone);
+    for (const key of Object.keys(value)) {
+      clone[key] = cloneValue(value[key], seen);
+    }
+    return clone;
+  }
+
+  function structuredClone(value) {
+    return cloneValue(value, new Map());
+  }
+
+  // ---- Headers -------------------------------------------------------------
+
+  const headerEntries = new WeakMap();
+
+  function normalizeHeaderName(name) {
+    const normalized = String(name).toLowerCase();
+    if (normalized.length === 0) {
+      throw new TypeError("Headers: the header name must not be empty");
+    }
+    return normalized;
+  }
+
+  function combinedHeaderNames(list) {
+    const names = [];
+    for (const entry of list) {
+      if (!names.includes(entry[0])) {
+        names.push(entry[0]);
+      }
+    }
+    names.sort();
+    return names;
+  }
+
+  class Headers {
+    constructor(init) {
+      headerEntries.set(this, []);
+      if (init === undefined || init === null) {
+        return;
+      }
+      if (init instanceof Headers) {
+        for (const entry of headerEntries.get(init)) {
+          this.append(entry[0], entry[1]);
+        }
+        return;
+      }
+      if (Array.isArray(init)) {
+        for (const entry of init) {
+          this.append(entry[0], entry[1]);
+        }
+        return;
+      }
+      if (typeof init === "object") {
+        for (const key of Object.keys(init)) {
+          this.append(key, init[key]);
+        }
+        return;
+      }
+      throw new TypeError("Headers: unsupported initializer");
+    }
+    append(name, value) {
+      headerEntries.get(this).push([normalizeHeaderName(name), String(value).trim()]);
+    }
+    set(name, value) {
+      const key = normalizeHeaderName(name);
+      const kept = [];
+      for (const entry of headerEntries.get(this)) {
+        if (entry[0] !== key) {
+          kept.push(entry);
+        }
+      }
+      kept.push([key, String(value).trim()]);
+      headerEntries.set(this, kept);
+    }
+    get(name) {
+      const key = normalizeHeaderName(name);
+      const values = [];
+      for (const entry of headerEntries.get(this)) {
+        if (entry[0] === key) {
+          values.push(entry[1]);
+        }
+      }
+      return values.length === 0 ? null : values.join(", ");
+    }
+    getSetCookie() {
+      const values = [];
+      for (const entry of headerEntries.get(this)) {
+        if (entry[0] === "set-cookie") {
+          values.push(entry[1]);
+        }
+      }
+      return values;
+    }
+    has(name) {
+      return this.get(name) !== null;
+    }
+    delete(name) {
+      const key = normalizeHeaderName(name);
+      const kept = [];
+      for (const entry of headerEntries.get(this)) {
+        if (entry[0] !== key) {
+          kept.push(entry);
+        }
+      }
+      headerEntries.set(this, kept);
+    }
+    get size() {
+      return combinedHeaderNames(headerEntries.get(this)).length;
+    }
+    entries() {
+      const out = [];
+      for (const name of combinedHeaderNames(headerEntries.get(this))) {
+        out.push([name, this.get(name)]);
+      }
+      return out[Symbol.iterator]();
+    }
+    keys() {
+      return combinedHeaderNames(headerEntries.get(this))[Symbol.iterator]();
+    }
+    values() {
+      const out = [];
+      for (const name of combinedHeaderNames(headerEntries.get(this))) {
+        out.push(this.get(name));
+      }
+      return out[Symbol.iterator]();
+    }
+    forEach(callback, thisArg) {
+      for (const entry of this.entries()) {
+        callback.call(thisArg, entry[1], entry[0], this);
+      }
+    }
+    [Symbol.iterator]() {
+      return this.entries();
+    }
+  }
+
+  // ---- URLSearchParams -----------------------------------------------------
+
+  const searchParamsState = new WeakMap();
+
+  function encodeFormComponent(text) {
+    const bytes = utf8Encode(String(text));
+    let out = "";
+    for (let i = 0; i < bytes.length; i++) {
+      const byte = bytes[i];
+      const char = String.fromCharCode(byte);
+      const isUnreserved =
+        (byte >= 0x30 && byte <= 0x39) ||
+        (byte >= 0x41 && byte <= 0x5a) ||
+        (byte >= 0x61 && byte <= 0x7a) ||
+        char === "*" ||
+        char === "-" ||
+        char === "." ||
+        char === "_";
+      if (isUnreserved) {
+        out += char;
+      } else if (byte === 0x20) {
+        out += "+";
+      } else {
+        out += "%" + HEX.charAt(byte >> 4) + HEX.charAt(byte & 15);
+      }
+    }
+    return out;
+  }
+
+  function decodeFormComponent(text) {
+    const bytes = [];
+    for (let i = 0; i < text.length; i++) {
+      const char = text.charAt(i);
+      if (char === "+") {
+        bytes.push(0x20);
+        continue;
+      }
+      if (char === "%" && i + 2 < text.length) {
+        const hex = text.slice(i + 1, i + 3);
+        const parsed = Number.parseInt(hex, 16);
+        if (!Number.isNaN(parsed)) {
+          bytes.push(parsed);
+          i += 2;
+          continue;
+        }
+      }
+      const encoded = utf8Encode(char);
+      for (let k = 0; k < encoded.length; k++) {
+        bytes.push(encoded[k]);
+      }
+    }
+    return utf8Decode(new Uint8Array(bytes));
+  }
+
+  function parseQueryString(query) {
+    const list = [];
+    let text = String(query);
+    if (text.charAt(0) === "?") {
+      text = text.slice(1);
+    }
+    if (text.length === 0) {
+      return list;
+    }
+    for (const chunk of text.split("&")) {
+      if (chunk.length === 0) {
+        continue;
+      }
+      const separator = chunk.indexOf("=");
+      const rawName = separator === -1 ? chunk : chunk.slice(0, separator);
+      const rawValue = separator === -1 ? "" : chunk.slice(separator + 1);
+      list.push([decodeFormComponent(rawName), decodeFormComponent(rawValue)]);
+    }
+    return list;
+  }
+
+  function notifyParamsOwner(params) {
+    const state = searchParamsState.get(params);
+    if (state.onChange) {
+      state.onChange(params.toString());
+    }
+  }
+
+  class URLSearchParams {
+    constructor(init) {
+      searchParamsState.set(this, { list: [], onChange: null });
+      if (init === undefined || init === null) {
+        return;
+      }
+      if (init instanceof URLSearchParams) {
+        for (const entry of searchParamsState.get(init).list) {
+          this.append(entry[0], entry[1]);
+        }
+        return;
+      }
+      if (typeof init === "string") {
+        searchParamsState.get(this).list = parseQueryString(init);
+        return;
+      }
+      if (Array.isArray(init)) {
+        for (const entry of init) {
+          this.append(entry[0], entry[1]);
+        }
+        return;
+      }
+      if (typeof init === "object") {
+        for (const key of Object.keys(init)) {
+          this.append(key, init[key]);
+        }
+        return;
+      }
+      throw new TypeError("URLSearchParams: unsupported initializer");
+    }
+    append(name, value) {
+      searchParamsState.get(this).list.push([String(name), String(value)]);
+      notifyParamsOwner(this);
+    }
+    set(name, value) {
+      const key = String(name);
+      const state = searchParamsState.get(this);
+      const kept = [];
+      let replaced = false;
+      for (const entry of state.list) {
+        if (entry[0] !== key) {
+          kept.push(entry);
+          continue;
+        }
+        if (!replaced) {
+          kept.push([key, String(value)]);
+          replaced = true;
+        }
+      }
+      if (!replaced) {
+        kept.push([key, String(value)]);
+      }
+      state.list = kept;
+      notifyParamsOwner(this);
+    }
+    get(name) {
+      const key = String(name);
+      for (const entry of searchParamsState.get(this).list) {
+        if (entry[0] === key) {
+          return entry[1];
+        }
+      }
+      return null;
+    }
+    getAll(name) {
+      const key = String(name);
+      const out = [];
+      for (const entry of searchParamsState.get(this).list) {
+        if (entry[0] === key) {
+          out.push(entry[1]);
+        }
+      }
+      return out;
+    }
+    has(name) {
+      return this.get(name) !== null;
+    }
+    delete(name) {
+      const key = String(name);
+      const state = searchParamsState.get(this);
+      const kept = [];
+      for (const entry of state.list) {
+        if (entry[0] !== key) {
+          kept.push(entry);
+        }
+      }
+      state.list = kept;
+      notifyParamsOwner(this);
+    }
+    sort() {
+      const state = searchParamsState.get(this);
+      state.list.sort(function byName(left, right) {
+        if (left[0] < right[0]) {
+          return -1;
+        }
+        return left[0] > right[0] ? 1 : 0;
+      });
+      notifyParamsOwner(this);
+    }
+    get size() {
+      return searchParamsState.get(this).list.length;
+    }
+    entries() {
+      const out = [];
+      for (const entry of searchParamsState.get(this).list) {
+        out.push([entry[0], entry[1]]);
+      }
+      return out[Symbol.iterator]();
+    }
+    keys() {
+      const out = [];
+      for (const entry of searchParamsState.get(this).list) {
+        out.push(entry[0]);
+      }
+      return out[Symbol.iterator]();
+    }
+    values() {
+      const out = [];
+      for (const entry of searchParamsState.get(this).list) {
+        out.push(entry[1]);
+      }
+      return out[Symbol.iterator]();
+    }
+    forEach(callback, thisArg) {
+      for (const entry of this.entries()) {
+        callback.call(thisArg, entry[1], entry[0], this);
+      }
+    }
+    toString() {
+      const parts = [];
+      for (const entry of searchParamsState.get(this).list) {
+        parts.push(
+          encodeFormComponent(entry[0]) + "=" + encodeFormComponent(entry[1])
+        );
+      }
+      return parts.join("&");
+    }
+    [Symbol.iterator]() {
+      return this.entries();
+    }
+  }
+
+  // ---- URL -----------------------------------------------------------------
+  //
+  // Parsing stays with the host's WHATWG implementation through the bridge, so
+  // normalisation matches what the fetch guard will later re-parse; only
+  // strings cross, and the component bag is rebuilt in this realm.
+
+  const urlState = new WeakMap();
+
+  function applyUrlComponents(url, components) {
+    const state = urlState.get(url);
+    state.components = components;
+    if (state.params) {
+      const paramsState = searchParamsState.get(state.params);
+      paramsState.onChange = null;
+      paramsState.list = parseQueryString(components.search);
+      paramsState.onChange = state.onParamsChange;
+    }
+  }
+
+  function hrefOf(value) {
+    return value instanceof URL ? value.href : String(value);
+  }
+
+  class URL {
+    constructor(input, base) {
+      const state = { components: null, params: null, onParamsChange: null };
+      urlState.set(this, state);
+      const baseHref =
+        base === undefined || base === null ? null : hrefOf(base);
+      state.components = unwrap(bridge.parseUrl(hrefOf(input), baseHref));
+      const self = this;
+      state.onParamsChange = function onParamsChange(query) {
+        const next = unwrap(
+          bridge.setUrl(urlState.get(self).components.href, "search", query)
+        );
+        urlState.get(self).components = next;
+      };
+    }
+    get searchParams() {
+      const state = urlState.get(this);
+      if (!state.params) {
+        state.params = new URLSearchParams(state.components.search);
+        searchParamsState.get(state.params).onChange = state.onParamsChange;
+      }
+      return state.params;
+    }
+    get origin() {
+      return urlState.get(this).components.origin;
+    }
+    toString() {
+      return this.href;
+    }
+    toJSON() {
+      return this.href;
+    }
+  }
+
+  for (const name of [
+    "href",
+    "protocol",
+    "username",
+    "password",
+    "host",
+    "hostname",
+    "port",
+    "pathname",
+    "search",
+    "hash",
+  ]) {
+    Object.defineProperty(URL.prototype, name, {
+      enumerable: true,
+      configurable: true,
+      get: function readComponent() {
+        return urlState.get(this).components[name];
+      },
+      set: function writeComponent(value) {
+        applyUrlComponents(
+          this,
+          unwrap(
+            bridge.setUrl(
+              urlState.get(this).components.href,
+              name,
+              String(value)
+            )
+          )
+        );
+      },
+    });
+  }
+
+  // ---- AbortController -----------------------------------------------------
+
+  const signalState = new WeakMap();
+
+  function makeAbortError(reason) {
+    if (reason !== undefined) {
+      return reason;
+    }
+    const error = new Error("This operation was aborted");
+    error.name = "AbortError";
+    return error;
+  }
+
+  class AbortSignal {
+    constructor() {
+      signalState.set(this, { aborted: false, reason: undefined, listeners: [], onabort: null });
+    }
+    get aborted() {
+      return signalState.get(this).aborted;
+    }
+    get reason() {
+      return signalState.get(this).reason;
+    }
+    get onabort() {
+      return signalState.get(this).onabort;
+    }
+    set onabort(listener) {
+      signalState.get(this).onabort = listener;
+    }
+    throwIfAborted() {
+      const state = signalState.get(this);
+      if (state.aborted) {
+        throw state.reason;
+      }
+    }
+    addEventListener(type, listener, options) {
+      if (type !== "abort" || typeof listener !== "function") {
+        return;
+      }
+      signalState.get(this).listeners.push({
+        listener: listener,
+        once: Boolean(options && options.once),
+      });
+    }
+    removeEventListener(type, listener) {
+      if (type !== "abort") {
+        return;
+      }
+      const state = signalState.get(this);
+      const kept = [];
+      for (const entry of state.listeners) {
+        if (entry.listener !== listener) {
+          kept.push(entry);
+        }
+      }
+      state.listeners = kept;
+    }
+    static abort(reason) {
+      const signal = new AbortSignal();
+      abortSignal(signal, reason);
+      return signal;
+    }
+  }
+
+  function abortSignal(signal, reason) {
+    const state = signalState.get(signal);
+    if (state.aborted) {
+      return;
+    }
+    state.aborted = true;
+    state.reason = makeAbortError(reason);
+    const event = { type: "abort", target: signal };
+    const pending = state.listeners;
+    state.listeners = [];
+    for (const entry of pending) {
+      if (!entry.once) {
+        state.listeners.push(entry);
+      }
+      entry.listener.call(signal, event);
+    }
+    if (typeof state.onabort === "function") {
+      state.onabort.call(signal, event);
+    }
+  }
+
+  const controllerSignals = new WeakMap();
+
+  class AbortController {
+    constructor() {
+      controllerSignals.set(this, new AbortSignal());
+    }
+    get signal() {
+      return controllerSignals.get(this);
+    }
+    abort(reason) {
+      abortSignal(controllerSignals.get(this), reason);
+    }
+  }
+
+  // ---- fetch ---------------------------------------------------------------
+
+  const responseState = new WeakMap();
+
+  class SandboxResponse {
+    constructor(payload) {
+      responseState.set(this, { payload: payload, bytes: null });
+      this.status = payload.status;
+      this.statusText = payload.statusText;
+      this.url = payload.url;
+      this.redirected = payload.redirected;
+      this.ok = payload.status >= 200 && payload.status <= 299;
+      this.headers = new Headers(payload.headers);
+      this.bodyUsed = false;
+    }
+    bytes() {
+      const state = responseState.get(this);
+      if (!state.bytes) {
+        state.bytes = base64ToBytes(state.payload.bodyBase64);
+      }
+      this.bodyUsed = true;
+      return Promise.resolve(state.bytes);
+    }
+    arrayBuffer() {
+      return this.bytes().then(function toBuffer(bytes) {
+        return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+      });
+    }
+    text() {
+      return this.bytes().then(function toText(bytes) {
+        return utf8Decode(bytes);
+      });
+    }
+    json() {
+      return this.text().then(function toJson(text) {
+        return JSON.parse(text);
+      });
+    }
+    clone() {
+      return new SandboxResponse(responseState.get(this).payload);
+    }
+  }
+
+  function headerPairsFrom(init) {
+    const headers = new Headers(init === undefined ? undefined : init);
+    const pairs = [];
+    for (const entry of headers.entries()) {
+      pairs.push([entry[0], entry[1]]);
+    }
+    return pairs;
+  }
+
+  function encodeRequestBody(body, pairs) {
+    if (body === undefined || body === null) {
+      return null;
+    }
+    let hasContentType = false;
+    for (const pair of pairs) {
+      if (pair[0] === "content-type") {
+        hasContentType = true;
+      }
+    }
+    if (body instanceof URLSearchParams) {
+      if (!hasContentType) {
+        pairs.push([
+          "content-type",
+          "application/x-www-form-urlencoded;charset=UTF-8",
+        ]);
+      }
+      return bytesToBase64(utf8Encode(body.toString()));
+    }
+    if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+      return bytesToBase64(toByteView(body));
+    }
+    if (!hasContentType) {
+      pairs.push(["content-type", "text/plain;charset=UTF-8"]);
+    }
+    return bytesToBase64(utf8Encode(String(body)));
+  }
+
+  function buildRequestSpec(resource, init) {
+    // The resource is coerced to a string EXACTLY ONCE here, and that single
+    // string is what the host validates and dials. A resource whose toString()
+    // and .url disagree therefore cannot show one URL to the SSRF guard and
+    // another to the socket.
+    const url = hrefOf(resource);
+    const options = init === undefined || init === null ? {} : init;
+    const method = options.method === undefined ? "GET" : String(options.method).toUpperCase();
+    const pairs = headerPairsFrom(options.headers);
+    const bodyBase64 =
+      method === "GET" || method === "HEAD"
+        ? null
+        : encodeRequestBody(options.body, pairs);
+    return { url: url, method: method, headers: pairs, bodyBase64: bodyBase64 };
+  }
+
+  function fetch(resource, init) {
+    return new Promise(function startRequest(resolve, reject) {
+      if (resource === undefined) {
+        throw new TypeError("fetch: the resource argument is required");
+      }
+      const spec = buildRequestSpec(resource, init);
+      const signal = init === undefined || init === null ? undefined : init.signal;
+      if (signal && signal.aborted) {
+        reject(signal.reason);
+        return;
+      }
+      const id = bridge.startFetch(
+        JSON.stringify(spec),
+        function onFulfilled(payloadJson) {
+          resolve(new SandboxResponse(JSON.parse(payloadJson)));
+        },
+        function onRejected(message, kind) {
+          if (kind === "TypeError") {
+            reject(new TypeError(message));
+            return;
+          }
+          if (kind === "AbortError") {
+            const error = new Error(message);
+            error.name = "AbortError";
+            reject(error);
+            return;
+          }
+          reject(new Error(message));
+        }
+      );
+      if (signal && typeof signal.addEventListener === "function") {
+        signal.addEventListener(
+          "abort",
+          function onAbort() {
+            bridge.abortFetch(id);
+          },
+          { once: true }
+        );
+      }
+    });
+  }
+
+  // ---- install -------------------------------------------------------------
+
+  const provided = {
+    console: {
+      log: function log() {
+        bridge.log("log", Array.prototype.slice.call(arguments));
+      },
+      warn: function warn() {
+        bridge.log("warn", Array.prototype.slice.call(arguments));
+      },
+      error: function error() {
+        bridge.log("error", Array.prototype.slice.call(arguments));
+      },
+    },
+    crypto: {
+      randomUUID: function randomUUID() {
+        return bridge.randomUUID();
+      },
+    },
+    fetch: fetch,
+    atob: atob,
+    btoa: btoa,
+    TextEncoder: TextEncoder,
+    TextDecoder: TextDecoder,
+    structuredClone: structuredClone,
+    Headers: Headers,
+    URL: URL,
+    URLSearchParams: URLSearchParams,
+    AbortController: AbortController,
+    AbortSignal: AbortSignal,
+  };
+
+  for (const key of Object.keys(provided)) {
+    Object.defineProperty(globalThis, key, {
+      value: provided[key],
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
+}
+
+// Defense in depth on the bridge: with a null prototype, a bridge function
+// that somehow leaked into the sandbox would still have no .constructor, and
+// so no path to the host Function. The bridge is never published to user code
+// in the first place; this makes a future mistake non-fatal.
+function severPrototypes(target) {
+  for (const key of Object.keys(target)) {
+    if (typeof target[key] === "function") {
+      Object.setPrototypeOf(target[key], null);
+    }
+  }
+  Object.setPrototypeOf(target, null);
+  return target;
+}
+
+const URL_SETTABLE_COMPONENTS = new Set([
+  "protocol",
+  "username",
+  "password",
+  "host",
+  "hostname",
+  "port",
+  "pathname",
+  "search",
+  "hash",
+  "href",
+]);
+
+// Flatten a host URL into the plain string bag the sandbox realm's own URL
+// class is backed by. Parsing stays on the host's WHATWG implementation so
+// normalisation matches what the fetch guard re-parses later.
+function urlComponents(url) {
+  return {
+    href: url.href,
+    protocol: url.protocol,
+    username: url.username,
+    password: url.password,
+    host: url.host,
+    hostname: url.hostname,
+    port: url.port,
+    pathname: url.pathname,
+    search: url.search,
+    hash: url.hash,
+    origin: url.origin,
+  };
+}
+
+// Read a response body into a single buffer, bounded by MAX_RESPONSE_BODY_BYTES.
+// The sandbox realm cannot be handed the host Response itself, so the bytes are
+// buffered here and cross as base64 text.
+async function readResponseBody(response) {
+  if (!response.body) {
+    return Buffer.alloc(0);
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const step = await reader.read();
+    if (step.done) {
+      break;
+    }
+    total += step.value.byteLength;
+    if (total > MAX_RESPONSE_BODY_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        "sandbox fetch: response body exceeds " +
+          String(MAX_RESPONSE_BODY_BYTES) +
+          " bytes"
+      );
+    }
+    chunks.push(
+      Buffer.from(step.value.buffer, step.value.byteOffset, step.value.byteLength)
+    );
+  }
+  return Buffer.concat(chunks);
+}
+
+// Flatten a host Response into the plain, primitive-only payload the sandbox
+// realm rebuilds its own Response-shaped object from. Returning the host
+// Response itself would hand user code a host object, and with it the host
+// realm through Response.constructor.constructor.
+async function marshalResponse(response, finalUrl, redirected) {
+  const body = await readResponseBody(response);
+  const headerPairs = [];
+  response.headers.forEach(function collectHeader(value, key) {
+    // forEach joins repeated headers with ", "; set-cookie is carried
+    // separately below so each cookie survives as its own entry.
+    if (key !== "set-cookie") {
+      headerPairs.push([key, value]);
+    }
+  });
+  for (const cookie of response.headers.getSetCookie()) {
+    headerPairs.push(["set-cookie", cookie]);
+  }
+  return {
+    url: finalUrl,
+    status: response.status,
+    statusText: response.statusText,
+    redirected: redirected,
+    headers: headerPairs,
+    bodyBase64: body.toString("base64"),
+  };
+}
+
 function safeCloneArg(value) {
   try {
     return JSON.parse(JSON.stringify(value));
@@ -1051,45 +2242,55 @@ function run(input) {
   const { code, timeoutMs } = input;
   const logs = [];
 
-  function capture(level) {
-    return function capturedLogger() {
-      if (logs.length >= MAX_LOG_ENTRIES) {
-        return;
-      }
-      const args = new Array(arguments.length);
-      for (let i = 0; i < arguments.length; i++) {
-        args[i] = safeCloneArg(arguments[i]);
-      }
-      logs.push({ level: level, args: args });
-    };
+  function captureLog(level, args) {
+    if (logs.length >= MAX_LOG_ENTRIES) {
+      return;
+    }
+    const cloned = new Array(args.length);
+    for (let i = 0; i < args.length; i++) {
+      cloned[i] = safeCloneArg(args[i]);
+    }
+    logs.push({ level: level, args: cloned });
   }
 
-  const capturedConsole = {
-    log: capture("log"),
-    warn: capture("warn"),
-    error: capture("error"),
-  };
-
-  async function sandboxedFetch(resource, init) {
-    // Build the WHATWG Request EXACTLY ONCE. Both the SSRF validation below and
-    // the actual dial (pinnedFetch) read the URL from this single object, so the
-    // address validated is provably the address dialed. The earlier code
-    // validated extractUrl(resource) (=resource.url) while pinnedFetch dialed
-    // new Request(resource).url (=String(resource)); a crafted resource
-    // ({ url: <allowed>, toString: () => <IMDS> }) made those diverge, and when
-    // the dialed value was an IP literal it skipped the pinned lookup entirely
-    // and reached the blocked target (F-024 follow-up). Building once also means
-    // a hostile toString / Symbol.toPrimitive is invoked a single time, so it
-    // cannot hand one value to the guard and another to the socket.
+  // Turn the request spec the sandbox realm handed over (strings only) back
+  // into a WHATWG Request. spec.url was coerced from the user's resource
+  // EXACTLY ONCE, in-realm, and both the SSRF validation below and the actual
+  // dial (pinnedFetch) read the URL from the single Request built from it, so
+  // the address validated is provably the address dialed. An earlier version
+  // validated resource.url while pinnedFetch dialed String(resource); a
+  // crafted resource ({ url: <allowed>, toString: () => <IMDS> }) made those
+  // diverge, and when the dialed value was an IP literal it skipped the pinned
+  // lookup entirely and reached the blocked target (F-024 follow-up). Coercing
+  // once also means a hostile toString / Symbol.toPrimitive runs a single
+  // time, so it cannot hand one value to the guard and another to the socket.
+  async function performFetch(spec, externalSignal) {
     let request;
     try {
-      request = new Request(resource, init);
+      const headers = new Headers();
+      for (const pair of spec.headers) {
+        headers.append(pair[0], pair[1]);
+      }
+      const requestInit = {
+        method: spec.method,
+        headers: headers,
+        redirect: "manual",
+      };
+      if (spec.bodyBase64 !== null) {
+        requestInit.body = Buffer.from(spec.bodyBase64, "base64");
+      }
+      request = new Request(spec.url, requestInit);
     } catch (err) {
       throw new TypeError(
         "sandbox fetch: invalid request: " +
           (err && err.message ? err.message : String(err))
       );
     }
+    const init = {
+      method: request.method,
+      headers: request.headers,
+      body: spec.bodyBase64 === null ? undefined : Buffer.from(spec.bodyBase64, "base64"),
+    };
     let parsed;
     try {
       parsed = new URL(request.url);
@@ -1118,11 +2319,10 @@ function run(input) {
       controller.abort();
     }, timeoutMs);
 
-    const callerSignal = init && init.signal ? init.signal : undefined;
-    if (callerSignal && callerSignal.aborted) {
+    if (externalSignal && externalSignal.aborted) {
       controller.abort();
-    } else if (callerSignal) {
-      callerSignal.addEventListener(
+    } else if (externalSignal) {
+      externalSignal.addEventListener(
         "abort",
         function onCallerAbort() {
           controller.abort();
@@ -1165,7 +2365,13 @@ function run(input) {
           ? response.headers.get("location")
           : null;
         if (location === null) {
-          return response;
+          // Marshal inside the try so the wall-clock timer above still covers
+          // the body read.
+          return await marshalResponse(
+            response,
+            currentRequest.url,
+            redirectsLeft !== MAX_SANDBOX_REDIRECTS
+          );
         }
         if (redirectsLeft <= 0) {
           await cancelResponseBody(response);
@@ -1216,41 +2422,128 @@ function run(input) {
     }
   }
 
-  const sandbox = createContext({
-    console: capturedConsole,
-    fetch: sandboxedFetch,
+  let nextFetchId = 1;
+  const inflightFetches = new Map();
 
-    BigInt: BigInt, JSON: JSON, Math: Math, Date: Date, Array: Array,
-    Object: Object, String: String, Number: Number, Boolean: Boolean,
-    RegExp: RegExp, Symbol: Symbol,
-    Map: Map, Set: Set, WeakMap: WeakMap, WeakSet: WeakSet, Promise: Promise,
+  function errorMessageOf(err) {
+    return err && err.message ? String(err.message) : String(err);
+  }
 
-    Error: Error, TypeError: TypeError, RangeError: RangeError,
-    SyntaxError: SyntaxError, ReferenceError: ReferenceError, URIError: URIError,
+  function errorKindOf(err) {
+    if (err && err.name === "AbortError") {
+      return "AbortError";
+    }
+    return err instanceof TypeError ? "TypeError" : "Error";
+  }
 
-    parseInt: parseInt, parseFloat: parseFloat,
-    isNaN: isNaN, isFinite: isFinite, Infinity: Infinity, NaN: NaN,
+  // The bridge is the ONLY host value the sandbox realm can reach, and it is
+  // held in the bootstrap's closure rather than published as a global. Every
+  // entry takes and returns primitives, and none of them may throw: a host
+  // exception crossing into user code would be a catchable host Error, and
+  // err.constructor.constructor is the host Function again. Failures therefore
+  // come back as a JSON envelope or through the reject callback.
+  const bridge = {
+    log: function bridgeLog(level, args) {
+      try {
+        captureLog(level, args);
+      } catch (_e) {
+        // a hostile toString on a logged value must not break the run
+      }
+    },
+    randomUUID: function bridgeRandomUUID() {
+      return crypto.randomUUID();
+    },
+    parseUrl: function bridgeParseUrl(input, base) {
+      try {
+        const url = base === null ? new URL(input) : new URL(input, base);
+        return JSON.stringify({ ok: true, v: urlComponents(url) });
+      } catch (_e) {
+        return JSON.stringify({ ok: false, e: "Invalid URL: " + input });
+      }
+    },
+    setUrl: function bridgeSetUrl(href, name, value) {
+      try {
+        if (!URL_SETTABLE_COMPONENTS.has(name)) {
+          return JSON.stringify({ ok: false, e: "Invalid URL component: " + name });
+        }
+        const url = new URL(href);
+        url[name] = value;
+        return JSON.stringify({ ok: true, v: urlComponents(url) });
+      } catch (err) {
+        return JSON.stringify({ ok: false, e: errorMessageOf(err) });
+      }
+    },
+    startFetch: function bridgeStartFetch(specJson, onFulfilled, onRejected) {
+      const id = nextFetchId;
+      nextFetchId += 1;
+      try {
+        const abort = new AbortController();
+        inflightFetches.set(id, abort);
+        performFetch(JSON.parse(specJson), abort.signal).then(
+          function onSettled(payload) {
+            inflightFetches.delete(id);
+            try {
+              onFulfilled(JSON.stringify(payload));
+            } catch (_e) {
+              // the sandbox realm rejected its own promise; nothing to do here
+            }
+          },
+          function onFailed(err) {
+            inflightFetches.delete(id);
+            try {
+              onRejected(errorMessageOf(err), errorKindOf(err));
+            } catch (_e) {
+              // as above
+            }
+          }
+        );
+      } catch (err) {
+        inflightFetches.delete(id);
+        try {
+          onRejected(errorMessageOf(err), "Error");
+        } catch (_e) {
+          // as above
+        }
+      }
+      return id;
+    },
+    abortFetch: function bridgeAbortFetch(id) {
+      const abort = inflightFetches.get(id);
+      if (!abort) {
+        return;
+      }
+      inflightFetches.delete(id);
+      try {
+        abort.abort();
+      } catch (_e) {
+        // already settled
+      }
+    },
+  };
+  severPrototypes(bridge);
 
-    encodeURIComponent: encodeURIComponent, decodeURIComponent: decodeURIComponent,
-    encodeURI: encodeURI, decodeURI: decodeURI,
-    atob: atob, btoa: btoa,
-    TextEncoder: TextEncoder, TextDecoder: TextDecoder,
-
-    ArrayBuffer: ArrayBuffer, DataView: DataView,
-    Uint8Array: Uint8Array, Uint16Array: Uint16Array, Uint32Array: Uint32Array,
-    Int8Array: Int8Array, Int16Array: Int16Array, Int32Array: Int32Array,
-    Float32Array: Float32Array, Float64Array: Float64Array,
-    BigInt64Array: BigInt64Array, BigUint64Array: BigUint64Array,
-
-    URL: URL, URLSearchParams: URLSearchParams, Headers: Headers,
-    Request: Request, Response: Response,
-    AbortController: AbortController, AbortSignal: AbortSignal,
-
-    structuredClone: structuredClone, Intl: Intl,
-    crypto: { randomUUID: crypto.randomUUID.bind(crypto) },
-
-    SharedArrayBuffer: undefined,
-  });
+  // A fresh context owns a complete set of realm-local intrinsics (Array,
+  // JSON, Math, Object, the typed arrays, the Error hierarchy, Intl) whose
+  // constructor chain terminates inside the sandbox. Nothing from this realm
+  // is copied in; SharedArrayBuffer is the one deliberate override, blanking
+  // the realm's own.
+  //
+  // The carrier object is null-prototype on purpose. createContext keeps it as
+  // the context's contextified object and the global proxy forwards property
+  // lookups to it, INCLUDING inherited ones -- so a plain {} carrier publishes
+  // this realm's Object.prototype as globalThis.constructor, and
+  // globalThis.constructor.constructor is the host Function. With no prototype
+  // there is nothing to inherit and the lookup falls through to the context's
+  // own global.
+  const carrier = Object.create(null);
+  carrier.SharedArrayBuffer = undefined;
+  const sandbox = createContext(carrier);
+  const installSandboxGlobals = runInContext(
+    "(" + sandboxBootstrap.toString() + ")",
+    sandbox,
+    { filename: "sandbox-bootstrap.js" }
+  );
+  installSandboxGlobals(bridge);
 
   const wrappedCode = "(async () => {\\n" + code + "\\n})()";
 
@@ -1346,27 +2639,29 @@ function encodeResult(value, seen) {
       }
       return arr;
     }
-    if (value instanceof Date) {
+    // node:util type predicates, not instanceof: the value was built by the
+    // sandbox realm's own Date / Map / Set, which are not this realm's.
+    if (types.isDate(value)) {
       return { "$": "date", "v": value.getTime() };
     }
-    if (value instanceof RegExp) {
+    if (types.isRegExp(value)) {
       return { "$": "regexp", "src": value.source, "flags": value.flags };
     }
-    if (value instanceof Map) {
+    if (types.isMap(value)) {
       const entries = [];
       for (const pair of value) {
         entries.push([encodeResult(pair[0], seen), encodeResult(pair[1], seen)]);
       }
       return { "$": "map", "v": entries };
     }
-    if (value instanceof Set) {
+    if (types.isSet(value)) {
       const items = [];
       for (const item of value) {
         items.push(encodeResult(item, seen));
       }
       return { "$": "set", "v": items };
     }
-    if (value instanceof ArrayBuffer) {
+    if (types.isArrayBuffer(value)) {
       return {
         "$": "bytes",
         "k": "ArrayBuffer",

--- a/sandbox/src/index.test.ts
+++ b/sandbox/src/index.test.ts
@@ -197,22 +197,22 @@ describe("sandbox HTTP server", () => {
     expect(outcome.errorMessage).toContain("boom");
   });
 
-  it("POST /run with env-escape payload does not leak injected secret", async () => {
+  it("POST /run cannot reach process through the sandbox realm", async () => {
     const FAKE = "SBX_TEST_FAKE_SECRET_AAA";
     process.env[FAKE] = "must-not-leak";
     try {
       const body = makeRunBody({
-        code: `const p = Error.constructor("return process")(); return Object.keys(p.env);`,
+        code: 'return String(Error.constructor("return typeof process")());',
         timeout: 5,
       });
       const res = await request(port, "POST", "/run", body);
       expect(res.status).toBe(200);
       const outcome = parseRunResponse(res.body) as {
         ok: boolean;
-        result?: string[];
+        result?: string;
       };
       expect(outcome.ok).toBe(true);
-      expect(outcome.result).not.toContain(FAKE);
+      expect(outcome.result).toBe("undefined");
     } finally {
       delete process.env[FAKE];
     }

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -1,5 +1,28 @@
 import { serialize } from "node:v8";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+const { spawnedEnvs } = vi.hoisted(() => ({
+  spawnedEnvs: [] as Array<NodeJS.ProcessEnv | undefined>,
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process"
+    );
+  return {
+    ...actual,
+    spawn: (
+      command: string,
+      args: readonly string[],
+      options: { env?: NodeJS.ProcessEnv }
+    ) => {
+      spawnedEnvs.push(options?.env);
+      return actual.spawn(command, args, options as never);
+    },
+  };
+});
+
 import {
   decodeSandboxResult,
   SANDBOX_RESULT_FD,
@@ -94,6 +117,37 @@ describe("runCode — sandbox child_process runner", () => {
       expect(outcome.ok).toBe(true);
       if (outcome.ok) {
         expect(outcome.result).toBe("undefined");
+      }
+    } finally {
+      delete process.env[SECRET_KEY];
+    }
+  });
+
+  // Second line of defence behind the realm containment above: the child is
+  // spawned with an env cut down to CHILD_ENV_ALLOWLIST, so even a future
+  // escape reads an environ holding no secrets. Asserted at the spawn boundary
+  // because user code can no longer observe the child's process object.
+  it("spawns the child with an env cut down to the allowlist", async () => {
+    const SECRET_KEY = "SANDBOX_TEST_ENV_SCRUB_SENTINEL";
+    process.env[SECRET_KEY] = "leaked-value-must-not-appear";
+    spawnedEnvs.length = 0;
+    try {
+      const outcome = await runCode({ code: "return 1;", timeoutMs: 5000 });
+      expect(outcome.ok).toBe(true);
+      expect(spawnedEnvs).toHaveLength(1);
+      const childEnv = spawnedEnvs[0] ?? {};
+      expect(Object.hasOwn(childEnv, SECRET_KEY)).toBe(false);
+      // Only the allowlist may reach the child.
+      const allowed = new Set([
+        "NODE_ENV",
+        "NODE_EXTRA_CA_CERTS",
+        "PATH",
+        "TZ",
+        "LANG",
+        "LC_ALL",
+      ]);
+      for (const key of Object.keys(childEnv)) {
+        expect(allowed.has(key)).toBe(true);
       }
     } finally {
       delete process.env[SECRET_KEY];

--- a/sandbox/src/run-code.test.ts
+++ b/sandbox/src/run-code.test.ts
@@ -78,38 +78,22 @@ describe("runCode — sandbox child_process runner", () => {
     }
   });
 
-  it("scrubs the child environment to the CHILD_ENV_ALLOWLIST only", async () => {
-    // Canonical escape payload: Error.constructor("return process")() reaches
-    // the host `process` object inside the vm context. Because the child was
-    // spawned with execve and a scrubbed env, process.env contains ONLY the
-    // allowlist keys.
+  it("keeps user code inside the sandbox realm, away from process", async () => {
+    // The context used to be populated with host intrinsics, so
+    // Error.constructor("return process")() compiled a function in the host
+    // realm and reached the child's process object. The context is now a
+    // fresh realm whose intrinsics lead nowhere.
     const SECRET_KEY = "SANDBOX_TEST_FAKE_SECRET_XYZ";
-    const SECRET_VALUE = "leaked-value-must-not-appear";
-    process.env[SECRET_KEY] = SECRET_VALUE;
+    process.env[SECRET_KEY] = "leaked-value-must-not-appear";
 
     try {
       const outcome = await runCode({
-        code: `const p = Error.constructor("return process")(); return Object.keys(p.env);`,
+        code: 'return String(Error.constructor("return typeof process")());',
         timeoutMs: 5000,
       });
       expect(outcome.ok).toBe(true);
       if (outcome.ok) {
-        const envKeys = outcome.result as string[];
-        // The allowlist is: NODE_ENV, NODE_EXTRA_CA_CERTS, PATH, TZ, LANG, LC_ALL.
-        // The fake secret we injected must NOT be present — this is the
-        // load-bearing security property. Individual OSes may inject their
-        // own system-level vars (e.g. macOS __CF_USER_TEXT_ENCODING); those
-        // are harmless and not under CHILD_ENV_ALLOWLIST control.
-        expect(envKeys).not.toContain(SECRET_KEY);
-        // Every key that IS under our control (from CHILD_ENV_ALLOWLIST)
-        // may legitimately appear. Assert no non-allowlisted KeeperHub-style
-        // variable leaked (anything matching uppercase APP/SECRET/KEY names).
-        const leaked = envKeys.filter((k) =>
-          /^(DATABASE|WALLET|STRIPE|GITHUB|GOOGLE|AGENTIC|INTEGRATION|BETTER_AUTH|OAUTH|TURNKEY|CDP|AWS|KUBERNETES)_/i.test(
-            k
-          )
-        );
-        expect(leaked).toEqual([]);
+        expect(outcome.result).toBe("undefined");
       }
     } finally {
       delete process.env[SECRET_KEY];

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -10,6 +10,28 @@ vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
   (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
 );
 
+const { spawnedEnvs } = vi.hoisted(() => ({
+  spawnedEnvs: [] as Array<NodeJS.ProcessEnv | undefined>,
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process"
+    );
+  return {
+    ...actual,
+    spawn: (
+      command: string,
+      args: readonly string[],
+      options: { env?: NodeJS.ProcessEnv }
+    ) => {
+      spawnedEnvs.push(options?.env);
+      return actual.spawn(command, args, options as never);
+    },
+  };
+});
+
 vi.mock("@/lib/logging", () => ({
   ErrorCategory: { VALIDATION: "VALIDATION" },
   // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op mock
@@ -396,40 +418,78 @@ describe("code/run-code - sandbox globals", () => {
     expect(result.error).toContain("setTimeout is not defined");
   });
 
-  // --- Sandbox escape: env scrubbing ----------------------------------------
+  // --- Sandbox realm containment --------------------------------------------
   //
-  // node:vm is not a security boundary -- `Error.constructor("return process")()`
-  // reaches the host `process` via the primordial chain. The mitigation is to
-  // run user code in a separate child node process whose env is scrubbed, so
-  // the escape returns an empty env instead of pod secrets.
+  // The sandbox context used to be populated by copying host intrinsics into
+  // createContext(), so X.constructor.constructor resolved to the host
+  // Function and user code could compile a function that runs outside the
+  // sandbox -- from there process, process.env and process.binding("spawn_sync")
+  // were all reachable. The context is now a fresh realm that owns its own
+  // intrinsics, and the few bridged values hand back primitives only. These
+  // tests pin that: no global the sandbox exposes may lead back to the host.
 
-  it("Error.constructor escape returns a scrubbed env, not host secrets", async () => {
+  it("Array.constructor cannot compile a function that sees the host realm", async () => {
+    const result = await expectSuccess({
+      code: "return String(Array.constructor('return typeof process')());",
+    });
+    expect(result.result).toBe("undefined");
+  });
+
+  it.each([
+    ["Object", "Object"],
+    ["Error", "Error"],
+    ["JSON", "JSON"],
+    ["Math", "Math"],
+    ["Uint8Array", "Uint8Array"],
+    ["console.log", "console.log"],
+    ["fetch", "fetch"],
+    ["crypto.randomUUID", "crypto.randomUUID"],
+    ["structuredClone", "structuredClone"],
+    ["new URL", "new URL('https://example.com/')"],
+    ["new TextEncoder", "new TextEncoder()"],
+    ["new AbortController", "new AbortController()"],
+  ])("%s does not expose the host realm", async (_label, expression) => {
+    const result = await expectSuccess({
+      code: `
+        try {
+          const escape = (${expression}).constructor.constructor;
+          return String(escape("return typeof process")());
+        } catch (err) {
+          return "throws";
+        }
+      `,
+    });
+    expect(["undefined", "throws"]).toContain(result.result);
+  });
+
+  it("cannot reach the spawn_sync binding the escape used for network egress", async () => {
+    const result = await expectSuccess({
+      code: `
+        try {
+          const escape = Object.constructor("return process.binding('spawn_sync')");
+          return String(typeof escape());
+        } catch (err) {
+          return "throws";
+        }
+      `,
+    });
+    expect(["undefined", "throws"]).toContain(result.result);
+  });
+
+  // Second line of defence, unchanged by the realm fix: the child is spawned
+  // with a scrubbed env, so even a future escape sees an environ holding only
+  // the allowlist rather than pod secrets. Asserted at the spawn boundary
+  // because user code can no longer observe the child's process object.
+  it("spawns the sandbox child with a scrubbed env", async () => {
     const marker = "KEEPERHUB_SCRUB_TEST_SECRET_SHOULD_NOT_LEAK";
-    const markerValue = `leaked-${Date.now().toString(36)}`;
-    process.env[marker] = markerValue;
+    process.env[marker] = `leaked-${Date.now().toString(36)}`;
+    spawnedEnvs.length = 0;
     try {
-      const result = await expectSuccess({
-        code: `
-          const proc = Error.constructor("return process")();
-          return {
-            hasMarker: Object.prototype.hasOwnProperty.call(proc.env, ${JSON.stringify(marker)}),
-            markerValue: proc.env[${JSON.stringify(marker)}] ?? null,
-            envKeyCount: Object.keys(proc.env).length,
-            envKeys: Object.keys(proc.env).sort(),
-          };
-        `,
-      });
-      const out = result.result as {
-        hasMarker: boolean;
-        markerValue: string | null;
-        envKeyCount: number;
-        envKeys: string[];
-      };
-      expect(out.hasMarker).toBe(false);
-      expect(out.markerValue).toBeNull();
-      // Sanity: none of the known high-value secret keys may appear.
-      const mustNotLeak = new Set([
-        marker,
+      await expectSuccess({ code: "return 1;" });
+      expect(spawnedEnvs).toHaveLength(1);
+      const childEnv = spawnedEnvs[0] ?? {};
+      expect(Object.hasOwn(childEnv, marker)).toBe(false);
+      const mustNotLeak = [
         "AGENTIC_WALLET_HMAC_KMS_KEY",
         "WALLET_ENCRYPTION_KEY",
         "INTEGRATION_ENCRYPTION_KEY",
@@ -444,68 +504,14 @@ describe("code/run-code - sandbox globals", () => {
         "STRIPE_SECRET_KEY",
         "GITHUB_CLIENT_SECRET",
         "GOOGLE_CLIENT_SECRET",
-      ]);
-      for (const key of out.envKeys) {
-        expect(mustNotLeak.has(key)).toBe(false);
+      ];
+      for (const key of mustNotLeak) {
+        expect(Object.hasOwn(childEnv, key)).toBe(false);
       }
     } finally {
       delete process.env[marker];
     }
   });
-
-  // A worker_threads.Worker shares the OS process with the parent, so
-  // /proc/self/environ still contains the parent's full env. A separate child
-  // process started via execve has an OS-level environ matching only the
-  // allowlist. This test exercises the deeper hole: fs.readFileSync on
-  // /proc/self/environ inside the escape must not leak the parent's env.
-  // Skipped on non-Linux because /proc/self/environ does not exist.
-  const maybeSkip = process.platform === "linux" ? it : it.skip;
-  maybeSkip(
-    "fs.readFileSync('/proc/self/environ') in the escape cannot see host env",
-    async () => {
-      const marker = "KEEPERHUB_PROC_ENVIRON_SENTINEL_SHOULD_NOT_LEAK";
-      const markerValue = `leaked-${Date.now().toString(36)}`;
-      process.env[marker] = markerValue;
-      try {
-        const result = await expectSuccess({
-          code: `
-            const proc = Error.constructor("return process")();
-            // mainModule.require is the canonical post-escape path to fs in
-            // script-mode node ('node -e ...'). If this ever starts returning
-            // a non-null value that contains the marker, the env scrub is
-            // broken at the OS level.
-            const mod = proc.mainModule;
-            const req = mod && typeof mod.require === "function" ? mod.require : null;
-            if (!req) {
-              return { reachedFs: false, hasMarker: false, environLen: 0 };
-            }
-            const fs = req("fs");
-            const environ = fs.readFileSync("/proc/self/environ", "utf8");
-            return {
-              reachedFs: true,
-              hasMarker: environ.indexOf(${JSON.stringify(marker)}) !== -1,
-              hasMarkerValue: environ.indexOf(${JSON.stringify(markerValue)}) !== -1,
-              environLen: environ.length,
-            };
-          `,
-        });
-        const out = result.result as {
-          reachedFs: boolean;
-          hasMarker: boolean;
-          hasMarkerValue?: boolean;
-          environLen: number;
-        };
-        // Either the escape could not reach fs (defence in depth) or the
-        // environ it read was the child's scrubbed one (our primary claim).
-        if (out.reachedFs) {
-          expect(out.hasMarker).toBe(false);
-          expect(out.hasMarkerValue).toBe(false);
-        }
-      } finally {
-        delete process.env[marker];
-      }
-    }
-  );
 
   it("blocks fetch to cloud metadata endpoints", async () => {
     const result = await expectFailure({

--- a/tests/unit/code-run-code.test.ts
+++ b/tests/unit/code-run-code.test.ts
@@ -480,7 +480,15 @@ describe("code/run-code - sandbox globals", () => {
   // with a scrubbed env, so even a future escape sees an environ holding only
   // the allowlist rather than pod secrets. Asserted at the spawn boundary
   // because user code can no longer observe the child's process object.
-  it("spawns the sandbox child with a scrubbed env", async () => {
+  //
+  // Local backend only. Under SANDBOX_BACKEND=remote this process spawns
+  // nothing: the code goes to the sandbox service over HTTP, and that service
+  // scrubs the env of the child IT spawns. sandbox/src/run-code.test.ts holds
+  // the matching assertion for that path.
+  const itLocalBackend =
+    process.env.SANDBOX_BACKEND === "remote" ? it.skip : it;
+
+  itLocalBackend("spawns the sandbox child with a scrubbed env", async () => {
     const marker = "KEEPERHUB_SCRUB_TEST_SECRET_SHOULD_NOT_LEAK";
     process.env[marker] = `leaked-${Date.now().toString(36)}`;
     spawnedEnvs.length = 0;

--- a/tests/unit/sandbox-child-source.test.ts
+++ b/tests/unit/sandbox-child-source.test.ts
@@ -215,6 +215,423 @@ function expectBlocked(outcome: SandboxOutcome): void {
 // prefixes, and the pre-DNS hostname denylist). These cases use IP
 // literals or pre-DNS-blocked hostnames so the test is deterministic and
 // performs no real DNS / network IO.
+// The sandbox context used to be built by copying ~55 host intrinsics into
+// createContext(): Array, JSON, Math, Object, the typed arrays, URL, Response.
+// Each was an object from the spawning realm, so X.constructor.constructor
+// resolved to the host Function and user code could compile a function running
+// outside the sandbox -- process, process.env and process.binding("spawn_sync")
+// all followed, and spawn_sync reaches the network directly, past pinnedFetch
+// and the SSRF blocklist the rest of the grandchild exists to enforce. The
+// context is now a fresh realm that supplies its own intrinsics, and the three
+// bridged values exchange primitives only. These tests pin that property.
+describe("sandbox grandchild runs user code in its own realm", () => {
+  it("injects no host intrinsics into the sandbox context", () => {
+    expect(SANDBOX_CHILD_SOURCE).toContain(
+      "const carrier = Object.create(null)"
+    );
+    expect(SANDBOX_CHILD_SOURCE).toContain("createContext(carrier)");
+    for (const injected of [
+      "Object: Object",
+      "Array: Array",
+      "JSON: JSON",
+      "Math: Math",
+      "Uint8Array: Uint8Array",
+      "Response: Response",
+      "Intl: Intl",
+    ]) {
+      expect(SANDBOX_CHILD_SOURCE).not.toContain(injected);
+    }
+  });
+
+  it("evaluates Array.constructor('return typeof process')() to undefined", async () => {
+    const outcome = await runSandboxed(
+      "return String(Array.constructor('return typeof process')());"
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("undefined");
+    }
+  }, 10_000);
+
+  it.each([
+    ["Object", "Object"],
+    ["Error", "Error"],
+    ["JSON", "JSON"],
+    ["Uint8Array", "Uint8Array"],
+    ["a plain object literal", "({})"],
+    ["console.log", "console.log"],
+    ["fetch", "fetch"],
+    ["crypto.randomUUID", "crypto.randomUUID"],
+    ["structuredClone", "structuredClone"],
+    ["a URL instance", "new URL('https://example.com/')"],
+    ["a TextEncoder instance", "new TextEncoder()"],
+    ["an AbortController instance", "new AbortController()"],
+    ["a Headers instance", "new Headers({ a: '1' })"],
+  ])(
+    "%s leads to no host realm",
+    async (_label, expression) => {
+      const outcome = await runSandboxed(`
+      try {
+        const escape = (${expression}).constructor.constructor;
+        return String(escape("return typeof process")());
+      } catch (_err) {
+        return "throws";
+      }
+    `);
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(["undefined", "throws"]).toContain(outcome.result);
+      }
+    },
+    10_000
+  );
+
+  it("cannot reach process.binding('spawn_sync')", async () => {
+    const outcome = await runSandboxed(`
+      try {
+        const escape = Object.constructor("return process.binding('spawn_sync')");
+        return String(typeof escape());
+      } catch (_err) {
+        return "throws";
+      }
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(["undefined", "throws"]).toContain(outcome.result);
+    }
+  }, 10_000);
+
+  it("still blanks SharedArrayBuffer in the fresh realm", async () => {
+    const outcome = await runSandboxed("return typeof SharedArrayBuffer;");
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("undefined");
+    }
+  }, 10_000);
+
+  it("rebuilds the non-ECMAScript globals inside the realm", async () => {
+    const outcome = await runSandboxed(`
+      return {
+        url: typeof URL,
+        urlSearchParams: typeof URLSearchParams,
+        headers: typeof Headers,
+        textEncoder: typeof TextEncoder,
+        textDecoder: typeof TextDecoder,
+        structuredClone: typeof structuredClone,
+        atob: typeof atob,
+        btoa: typeof btoa,
+        abortController: typeof AbortController,
+        fetch: typeof fetch,
+        randomUUID: typeof crypto.randomUUID,
+        intl: typeof Intl,
+        json: typeof JSON,
+      };
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const kinds = outcome.result as Record<string, string>;
+      for (const key of Object.keys(kinds)) {
+        expect(kinds[key]).not.toBe("undefined");
+      }
+    }
+  }, 10_000);
+
+  it("round-trips URL, encoding and clone helpers through the in-realm implementations", async () => {
+    const outcome = await runSandboxed(`
+      const url = new URL("https://example.com/path?a=1");
+      url.searchParams.set("b", "2");
+      const bytes = new TextEncoder().encode("hi \u00e9");
+      const original = { nested: [1, 2] };
+      const clone = structuredClone(original);
+      clone.nested.push(3);
+      return {
+        href: url.toString(),
+        origin: url.origin,
+        decoded: new TextDecoder().decode(bytes),
+        base64: btoa("hello"),
+        plain: atob(btoa("hello")),
+        original: original.nested.length,
+        clone: clone.nested.length,
+      };
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toEqual({
+        href: "https://example.com/path?a=1&b=2",
+        origin: "https://example.com",
+        decoded: "hi \u00e9",
+        base64: "aGVsbG8=",
+        plain: "hello",
+        original: 2,
+        clone: 3,
+      });
+    }
+  }, 10_000);
+
+  // Spot checks only prove the vectors someone thought to name. These two
+  // enumerate instead: every global the sandbox exposes, and then the whole
+  // object graph reachable from globalThis.
+  it("exposes no global that reaches the host realm", async () => {
+    const outcome = await runSandboxed(`
+      const results = [];
+      function probe(label, value) {
+        try {
+          const ctor = value.constructor;
+          const compile = ctor && ctor.constructor;
+          if (typeof compile !== "function") {
+            results.push([label, "no-ctor"]);
+            return;
+          }
+          const reached = compile("return typeof process === 'object' ? 'HOST' : 'none'")();
+          results.push([label, reached === "HOST" ? "HOST" : "contained"]);
+        } catch (_err) {
+          results.push([label, "throws"]);
+        }
+      }
+      for (const name of Object.getOwnPropertyNames(globalThis).sort()) {
+        let value;
+        try {
+          value = globalThis[name];
+        } catch (_err) {
+          continue;
+        }
+        if (value === undefined || value === null) {
+          continue;
+        }
+        probe(name, value);
+        if (typeof value === "function" && value.prototype) {
+          probe(name + ".prototype", value.prototype);
+        }
+      }
+      return results;
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const results = outcome.result as [string, string][];
+      // Sanity: the enumeration actually ran over a populated realm.
+      expect(results.length).toBeGreaterThan(60);
+      expect(results.filter(([, verdict]) => verdict === "HOST")).toEqual([]);
+    }
+  }, 15_000);
+
+  it("reaches no host-realm object anywhere in the graph from globalThis", async () => {
+    // Breadth-first over own properties (accessors included, both the accessor
+    // functions and what they return), prototypes, and function .prototype.
+    // A value is flagged when its prototype chain never reaches this realm's
+    // Object.prototype or Function.prototype; each flag is then confirmed with
+    // the actual exploit, so a legitimately null-prototype in-realm object
+    // (Array.prototype[Symbol.unscopables]) reports as inert rather than as a
+    // leak.
+    const outcome = await runSandboxed(
+      `
+      const REALM_OBJECT_PROTO = Object.prototype;
+      const REALM_FN_PROTO = Function.prototype;
+      const seen = new Set();
+      const findings = [];
+      let visited = 0;
+
+      function isAlien(value) {
+        let current = value;
+        let hops = 0;
+        while (current !== null && hops < 100) {
+          if (current === REALM_OBJECT_PROTO || current === REALM_FN_PROTO) {
+            return false;
+          }
+          current = Object.getPrototypeOf(current);
+          hops++;
+        }
+        return true;
+      }
+
+      function exploit(value) {
+        try {
+          const ctor = value.constructor;
+          const compile = ctor && ctor.constructor;
+          if (typeof compile !== "function") {
+            return "no-ctor";
+          }
+          return compile("return typeof process === 'object' ? 'HOST' : 'none'")();
+        } catch (_err) {
+          return "throws";
+        }
+      }
+
+      const queue = [["globalThis", globalThis]];
+      while (queue.length > 0 && visited < 200000) {
+        const entry = queue.shift();
+        const path = entry[0];
+        const value = entry[1];
+        if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+          continue;
+        }
+        if (seen.has(value)) {
+          continue;
+        }
+        seen.add(value);
+        visited++;
+
+        if (isAlien(value)) {
+          findings.push({ path: path, exploit: exploit(value) });
+        }
+
+        let keys = [];
+        try {
+          keys = Object.getOwnPropertyNames(value).concat(
+            Object.getOwnPropertySymbols(value)
+          );
+        } catch (_err) {
+          keys = [];
+        }
+        for (const key of keys) {
+          let descriptor;
+          try {
+            descriptor = Object.getOwnPropertyDescriptor(value, key);
+          } catch (_err) {
+            continue;
+          }
+          if (!descriptor) {
+            continue;
+          }
+          const label = path + "." + String(key);
+          if ("value" in descriptor) {
+            queue.push([label, descriptor.value]);
+          } else {
+            if (descriptor.get) {
+              queue.push([label + "[[get]]", descriptor.get]);
+              try {
+                queue.push([label, descriptor.get.call(value)]);
+              } catch (_err) {
+                // a getter that throws exposes nothing
+              }
+            }
+            if (descriptor.set) {
+              queue.push([label + "[[set]]", descriptor.set]);
+            }
+          }
+        }
+        try {
+          const proto = Object.getPrototypeOf(value);
+          if (proto) {
+            queue.push([path + ".__proto__", proto]);
+          }
+        } catch (_err) {
+          // exotic object with no observable prototype
+        }
+      }
+      return { visited: visited, exhausted: queue.length === 0, findings: findings };
+    `,
+      15_000
+    );
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const crawl = outcome.result as {
+        visited: number;
+        exhausted: boolean;
+        findings: Array<{ path: string; exploit: string }>;
+      };
+      // The crawl must have covered the realm, not bailed early.
+      expect(crawl.exhausted).toBe(true);
+      expect(crawl.visited).toBeGreaterThan(400);
+      expect(crawl.findings.filter((f) => f.exploit === "HOST")).toEqual([]);
+    }
+  }, 20_000);
+
+  it("does not publish the carrier object's prototype as globalThis.constructor", async () => {
+    // createContext keeps the object it is given as the context's contextified
+    // object, and the global proxy forwards lookups to it INCLUDING inherited
+    // ones. A plain {} carrier therefore hands user code this realm's
+    // Object.prototype through globalThis.constructor, and the host Function
+    // through globalThis.constructor.constructor -- a live route even once
+    // every intrinsic is realm-local. The carrier is null-prototype for that
+    // reason.
+    const outcome = await runSandboxed(`
+      const escape = globalThis.constructor && globalThis.constructor.constructor;
+      if (typeof escape !== "function") {
+        return "no-ctor";
+      }
+      return String(escape("return typeof process")());
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(["undefined", "no-ctor"]).toContain(outcome.result);
+    }
+  }, 10_000);
+
+  it.each([
+    ["a Date instance", "new Date()"],
+    ["an Error instance", "new Error('x')"],
+    ["a Map instance", "new Map()"],
+    ["a Set instance", "new Set()"],
+    ["a WeakMap instance", "new WeakMap()"],
+    ["a Promise", "Promise.resolve()"],
+    ["an ArrayBuffer", "new ArrayBuffer(1)"],
+    ["a DataView", "new DataView(new ArrayBuffer(8))"],
+    ["a typed array", "new Float64Array(1)"],
+    ["an array iterator", "[].values()"],
+    ["a RegExp", "/re/"],
+    ["a Symbol", "Symbol('s')"],
+    ["an Intl formatter", "new Intl.NumberFormat('en-US')"],
+    ["an Intl bound format", "new Intl.NumberFormat('en-US').format"],
+    ["a Proxy", "new Proxy({}, {})"],
+    ["a URLSearchParams", "new URLSearchParams('a=1')"],
+    ["a URL searchParams", "new URL('https://a.test/?a=1').searchParams"],
+    ["a Headers iterator", "new Headers().entries()"],
+    ["an AbortSignal", "new AbortController().signal"],
+    ["an abort reason", "AbortSignal.abort().reason"],
+    ["a structuredClone result", "structuredClone({ a: 1 })"],
+    ["an encoded byte array", "new TextEncoder().encode('a')"],
+  ])(
+    "%s built by user code stays in the realm",
+    async (_label, expression) => {
+      const outcome = await runSandboxed(`
+      try {
+        const compile = (${expression}).constructor.constructor;
+        return String(compile("return typeof process")());
+      } catch (_err) {
+        return "throws";
+      }
+    `);
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(["undefined", "throws"]).toContain(outcome.result);
+      }
+    },
+    10_000
+  );
+
+  it("preserves structured-type fidelity for values built by the sandbox realm", async () => {
+    // The result encoder runs in the host realm on values the sandbox realm
+    // created, so it has to identify them with cross-realm predicates rather
+    // than instanceof.
+    const outcome = await runSandboxed(`
+      return {
+        date: new Date(0),
+        set: new Set([1, 2]),
+        map: new Map([["k", 1]]),
+        bytes: new Uint8Array([1, 2, 3]),
+        pattern: /ab+/gi,
+      };
+    `);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as {
+        date: Date;
+        set: Set<number>;
+        map: Map<string, number>;
+        bytes: Uint8Array;
+        pattern: RegExp;
+      };
+      expect(r.date).toBeInstanceOf(Date);
+      expect(r.date.getTime()).toBe(0);
+      expect([...r.set]).toEqual([1, 2]);
+      expect(r.map.get("k")).toBe(1);
+      expect([...r.bytes]).toEqual([1, 2, 3]);
+      expect(r.pattern.source).toBe("ab+");
+      expect(r.pattern.flags).toBe("gi");
+    }
+  }, 10_000);
+}, 60_000);
+
 describe("sandbox grandchild SSRF guard fires on every category", () => {
   it.each([
     ['await fetch("http://169.254.169.254/")', "IMDSv2 link-local"],
@@ -778,6 +1195,158 @@ describe("sandbox grandchild pinned fetch preserves the Response contract", () =
       expect(r.header).toBe("yes");
       expect(r.body.ok).toBe(true);
       expect(r.body.path).toBe("/ping");
+    }
+  }, 10_000);
+}, 30_000);
+
+// The host Response cannot be handed to user code (Response.constructor
+// .constructor is the host Function), so it is flattened into primitives and
+// rebuilt inside the sandbox realm. That rebuilt object still has to behave
+// like a fetch response, and must not become a new way back to the host.
+describe("sandbox grandchild marshals fetch responses into the sandbox realm", () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(async () => {
+    server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname === "/cookies") {
+        res.writeHead(200, { "set-cookie": ["a=1", "b=2"] });
+        res.end("ok");
+        return;
+      }
+      if (url.pathname === "/big") {
+        res.writeHead(200, { "content-type": "application/octet-stream" });
+        res.end(Buffer.alloc(64 * 1024, 0x61));
+        return;
+      }
+      res.writeHead(201, {
+        "content-type": "application/json",
+        "x-marker": "yes",
+      });
+      res.end(JSON.stringify({ path: url.pathname }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  it("exposes the response contract without exposing the host realm", async () => {
+    const code = `
+      const r = await fetch(${JSON.stringify(`${base}/ping`)});
+      const escape = r.constructor.constructor;
+      let reached;
+      try {
+        reached = String(escape("return typeof process")());
+      } catch (_err) {
+        reached = "throws";
+      }
+      return {
+        status: r.status,
+        statusText: r.statusText,
+        ok: r.ok,
+        url: r.url,
+        redirected: r.redirected,
+        marker: r.headers.get("x-marker"),
+        body: await r.json(),
+        reached: reached,
+      };
+    `;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as {
+        status: number;
+        statusText: string;
+        ok: boolean;
+        url: string;
+        redirected: boolean;
+        marker: string;
+        body: { path: string };
+        reached: string;
+      };
+      expect(r.status).toBe(201);
+      expect(r.ok).toBe(true);
+      expect(r.url).toBe(`${base}/ping`);
+      expect(r.redirected).toBe(false);
+      expect(r.marker).toBe("yes");
+      expect(r.body.path).toBe("/ping");
+      expect(["undefined", "throws"]).toContain(r.reached);
+    }
+  }, 10_000);
+
+  it("keeps repeated set-cookie headers separate", async () => {
+    const code = `
+      const r = await fetch(${JSON.stringify(`${base}/cookies`)});
+      return { cookies: r.headers.getSetCookie(), joined: r.headers.get("set-cookie") };
+    `;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as { cookies: string[]; joined: string };
+      expect(r.cookies).toEqual(["a=1", "b=2"]);
+      expect(r.joined).toBe("a=1, b=2");
+    }
+  }, 10_000);
+
+  it("reads the same body as text and as bytes", async () => {
+    const code = `
+      const r = await fetch(${JSON.stringify(`${base}/ping`)});
+      const text = await r.text();
+      const bytes = await r.clone().bytes();
+      return { text: text, length: bytes.length, first: bytes[0] };
+    `;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      const r = outcome.result as {
+        text: string;
+        length: number;
+        first: number;
+      };
+      expect(JSON.parse(r.text)).toEqual({ path: "/ping" });
+      expect(r.length).toBe(r.text.length);
+      expect(r.first).toBe("{".charCodeAt(0));
+    }
+  }, 10_000);
+
+  it("rejects with an AbortError when the caller's signal fires", async () => {
+    const code = `
+      const controller = new AbortController();
+      const pending = fetch(${JSON.stringify(`${base}/ping`)}, { signal: controller.signal });
+      controller.abort();
+      try {
+        await pending;
+        return "resolved";
+      } catch (err) {
+        return err.name;
+      }
+    `;
+    const outcome = await runSandboxed(code, 3000, REDIRECT_TEST_SOURCE);
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("AbortError");
+    }
+  }, 10_000);
+
+  it("errors instead of buffering a body past the cap", async () => {
+    const source = REDIRECT_TEST_SOURCE.replace(
+      `const MAX_RESPONSE_BODY_BYTES = ${SANDBOX_RESULT_MAX_BYTES};`,
+      "const MAX_RESPONSE_BODY_BYTES = 1024;"
+    );
+    expect(source).not.toBe(REDIRECT_TEST_SOURCE);
+    const code = `const r = await fetch(${JSON.stringify(`${base}/big`)}); return await r.text();`;
+    const outcome = await runSandboxed(code, 3000, source);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.errorMessage).toContain("response body exceeds");
     }
   }, 10_000);
 }, 30_000);


### PR DESCRIPTION
## Problem

The Code node sandbox was built with `createContext({...})` populated by copying roughly 55 intrinsics in from the spawning process: `Array`, `JSON`, `Math`, `Object`, every typed array, `URL`, `Response` and so on. Those are the host realm's objects, so `X.constructor.constructor` resolves to the host `Function`, and any user who can add a Code node could compile a function that runs outside the sandbox.

From there `process`, `process.env` and `process.binding("spawn_sync")` are all reachable. The env scrub holds, so no credentials are exposed, but `spawn_sync` reaches the network directly and bypasses the pinned fetch and the SSRF blocklist that the rest of that file exists to enforce. On the default `SANDBOX_BACKEND=local` path the child runs inside the main app pod, so it inherits the app pod's network namespace rather than a sandbox specific one.

## Scope of the leak

This is not one intrinsic. Enumerating every global the sandbox exposes and testing each for a route to the host:

| | before | after |
|---|---|---|
| globals reaching host `process` | 103 | 0 |
| user built instances reaching host `process` | 41 | 0 |

Every injected intrinsic leaked, along with each of their prototypes and every instance built from them: `Array`, `Object`, `JSON`, `Math`, `Date`, the whole `Error` hierarchy, all 12 typed arrays, `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, `RegExp`, `String`, `Number`, `Boolean`, `Symbol`, `BigInt`, `URL`, `URLSearchParams`, `Headers`, `Request`, `Response`, `AbortController`, `AbortSignal`, `TextEncoder`, `TextDecoder`, `Intl`, `console`, `crypto`, `fetch`, `atob`, `btoa`, `structuredClone`, `parseInt`, `isNaN`, `encodeURIComponent`.

The realm's own untouched intrinsics were never leaking on either side: `Reflect`, `Atomics`, `Proxy`, `WebAssembly`, `WeakRef`, `FinalizationRegistry`, `Iterator`, `Uint8ClampedArray`, `Float16Array`, `AggregateError`, `EvalError`, `eval`, `Function`. That is the shape of the fix.

## A second route, independent of the intrinsics

`globalThis` leaked too, and removing the intrinsics did not close it. `createContext` keeps the object it is given as the context's contextified object, and the global proxy forwards property lookups to it including inherited ones. A plain object literal carrier therefore publishes the host `Object.prototype` as `globalThis.constructor`, and the host `Function` one hop later. The carrier is now `Object.create(null)`.

Only the enumeration surfaced this one. A spot check on `Array` would have shipped it.

## Fix

A fresh `createContext` already owns a complete set of realm-local intrinsics whose constructor chains terminate inside the sandbox, so nothing is injected any more.

The globals a new realm does not provide, because they are Node's rather than the language's, are rebuilt inside the realm by a bootstrap evaluated in the context: `console`, `fetch`, `URL`, `URLSearchParams`, `Headers`, `TextEncoder`, `TextDecoder`, `atob`, `btoa`, `structuredClone`, `AbortController`, `AbortSignal`, `crypto.randomUUID`. URL parsing still goes through the host's WHATWG implementation so normalisation matches what the fetch guard re-parses, but only strings cross.

The only host values that cross are bridge functions held in the bootstrap's closure. They are never published to user code, their prototypes are severed as defence in depth, and they exchange primitives only. None of them may throw, since a host exception crossing into user code would itself be a catchable host `Error` and `err.constructor.constructor` is the host `Function` again; failures come back as a JSON envelope or through a reject callback.

Fetch responses are flattened on the host into `{url, status, statusText, redirected, headers, bodyBase64}` and rebuilt in realm, because handing back a host `Response` would reopen the same hole. The SSRF guard, the single-coercion URL validation, address pinning and per-hop redirect re-validation are untouched.

The result encoder now identifies user values with `node:util` predicates rather than `instanceof`. Those values belong to the sandbox realm now, so `value instanceof Date` was about to start returning false for a sandbox `Date` and silently degrade every structured result.

## User visible changes

The `Request` and `Response` constructors are no longer exposed; constructing either inside a sandbox had no use. A fetch response body is read in full rather than streamed, so there is no `body` property, bounded at the same budget as the existing gzip cap. Repeated `set-cookie` headers survive separately via `getSetCookie()`. Public docs are updated, including a security section that no longer claims the sandbox is not a boundary against determined attackers.

## Verification

The tests enumerate the property rather than spot checking it:

- every own global plus its `.prototype`, asserting none reaches host `process`
- a breadth first crawl of the entire object graph reachable from `globalThis`, covering own properties, symbol keys, accessors both as functions and by what they return, and prototypes. It asserts the crawl exhausted the graph and that zero reachable objects are confirmed to reach the host. 849 objects, fully exhausted, zero leaks. The one foreign hit is `Array.prototype[Symbol.unscopables]`, the spec's null prototype object, which has no constructor and is inert
- a named regression for the contextified carrier prototype
- a 22 case table over the values user code actually constructs

Three escape based tests were asserting the old behaviour, since their premise was the hole itself. The env scrub they covered is still real and still tested, moved to the spawn boundary now that user code cannot observe the child's `process`.

I mutation tested the new tests: reverting the carrier to an object literal fails three of them, so they are load bearing.

637 test files and 23244 tests pass. Lint and type check clean.
