### PR TITLE
feat(web3): #2399 add an optional caller address to read-contract

### DIFF
--- a/lib/web3/chain-adapter/evm.ts
+++ b/lib/web3/chain-adapter/evm.ts
@@ -258,9 +258,17 @@ export class EvmChainAdapter implements ChainAdapter {
       // fragment instead of the inherited method.
       const fn = contract.getFunction(request.functionKey);
 
+      // ethers reads a trailing object as call overrides, which is how the
+      // write path passes its own `from` above. Build it only when a caller
+      // was given: with the field unset nothing is appended and the call is
+      // identical to the one made before this field existed.
+      const overrides = request.callerAddress
+        ? [{ from: request.callerAddress }]
+        : [];
+
       return request.isView
-        ? await fn(...request.args)
-        : await fn.staticCall(...request.args);
+        ? await fn(...request.args, ...overrides)
+        : await fn.staticCall(...request.args, ...overrides);
     });
   }
 

--- a/lib/web3/chain-adapter/types.ts
+++ b/lib/web3/chain-adapter/types.ts
@@ -43,6 +43,12 @@ export type ReadContractRequest = {
   functionKey: string;
   args: unknown[];
   isView: boolean;
+  // The `from` of the eth_call. Some contracts answer differently depending on
+  // who asks: OptimismPortal2 reveals a failing withdrawal target only to
+  // address(1), and a toll-gated Chronicle feed reads only for an authed
+  // caller. Unset means no overrides object is built at all, so the call is
+  // the one this made before the field existed.
+  callerAddress?: string;
 };
 
 export interface ChainAdapter {

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -898,7 +898,7 @@ const web3Plugin: IntegrationPlugin = {
           type: "template-input",
           placeholder: "Optional - 0x... or {{NodeName.address}}",
           helpTip:
-            "Optional. The address the call is made from. Some contracts answer differently depending on the caller. Leave empty for the current behaviour.",
+            "Optional. The address this read is made from - some contracts answer differently depending on who asks. Nothing is signed or sent from it, and a write is never sent from this address, so take care before gating a transfer on an answer obtained as someone else. Leave empty to keep the current behaviour.",
           isAddressField: true,
         },
         readFailOnErrorField(),

--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -892,6 +892,15 @@ const web3Plugin: IntegrationPlugin = {
           abiField: "abi",
           abiFunctionField: "abiFunction",
         },
+        {
+          key: "callerAddress",
+          label: "Caller Address",
+          type: "template-input",
+          placeholder: "Optional - 0x... or {{NodeName.address}}",
+          helpTip:
+            "Optional. The address the call is made from. Some contracts answer differently depending on the caller. Leave empty for the current behaviour.",
+          isAddressField: true,
+        },
         readFailOnErrorField(),
       ],
     },

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -38,6 +38,12 @@ export type ReadContractCoreInput = {
   abi: string;
   abiFunction: string;
   functionArgs?: string;
+  // The address the call is made from. Some contracts answer differently
+  // depending on who asks, and a read with no caller is a read as address(0),
+  // which is itself a specific address. Empty or whitespace-only means absent,
+  // the same rule functionArgs uses, so a template that renders to nothing
+  // leaves the call unchanged rather than failing it.
+  callerAddress?: string;
   // See applyReadFailOnError in read-fail-on-error-core.ts. When false, no
   // failure of this step fails the run.
   failOnError?: boolean;
@@ -81,8 +87,15 @@ export async function readContractCore(
 async function readContractInner(
   input: ReadContractCoreInput
 ): Promise<ReadContractResult> {
-  const { contractAddress, network, abi, abiFunction, functionArgs, _context } =
-    input;
+  const {
+    contractAddress,
+    network,
+    abi,
+    abiFunction,
+    functionArgs,
+    callerAddress,
+    _context,
+  } = input;
 
   if (!abiFunction || abiFunction.trim() === "") {
     logUserError(
@@ -114,6 +127,25 @@ async function readContractInner(
       success: false,
       destinationError: true,
       error: `Invalid contract address: ${contractAddress}`,
+      errorClass: ExecutionErrorType.USER,
+    };
+  }
+
+  // A blank caller is no caller. Only a value that is present and not an
+  // address is an error, and it is a payload error rather than a destination
+  // one: failOnError softens it the way it softens an unparseable argument
+  // list, not the way it hard-fails an invalid contract address.
+  const caller = callerAddress?.trim();
+  if (caller !== undefined && caller !== "" && !ethers.isAddress(caller)) {
+    logUserError(
+      ErrorCategory.VALIDATION,
+      "[Read Contract] Invalid caller address:",
+      callerAddress,
+      { plugin_name: "web3", action_name: "read-contract" }
+    );
+    return {
+      success: false,
+      error: `Invalid caller address: ${callerAddress}`,
       errorClass: ExecutionErrorType.USER,
     };
   }
@@ -301,6 +333,7 @@ async function readContractInner(
       functionKey: abiFunctionKey,
       args,
       isView,
+      ...(caller ? { callerAddress: caller } : {}),
     });
 
     // Convert BigInt values to strings for JSON serialization. This also

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -40,9 +40,9 @@ export type ReadContractCoreInput = {
   functionArgs?: string;
   // The address the call is made from. Some contracts answer differently
   // depending on who asks, and a read with no caller is a read as address(0),
-  // which is itself a specific address. Empty or whitespace-only means absent,
-  // the same rule functionArgs uses, so a template that renders to nothing
-  // leaves the call unchanged rather than failing it.
+  // which is itself a specific address. Absent means the field carries
+  // nothing - undefined, null or the empty string - so a template that renders
+  // to nothing leaves the call unchanged rather than failing it.
   callerAddress?: string;
   // See applyReadFailOnError in read-fail-on-error-core.ts. When false, no
   // failure of this step fails the run.
@@ -131,12 +131,22 @@ async function readContractInner(
     };
   }
 
-  // A blank caller is no caller. Only a value that is present and not an
-  // address is an error, and it is a payload error rather than a destination
-  // one: failOnError softens it the way it softens an unparseable argument
-  // list, not the way it hard-fails an invalid contract address.
-  const caller = callerAddress?.trim();
-  if (caller !== undefined && caller !== "" && !ethers.isAddress(caller)) {
+  // A blank caller is no caller. Absent is undefined, null or the empty
+  // string, which is exactly the set validateFieldValue early-returns as valid
+  // (lib/workflow/validation/action-config.ts), so save time and run time
+  // agree on what "no caller" is. A whitespace-only value is deliberately not
+  // in that set: the isAddressField branch rejects it at save time, and it
+  // fails isAddress here, rather than one layer treating it as absent while
+  // the other calls it invalid. The value is still trimmed before it is read,
+  // so a template that renders with stray whitespace around an address works.
+  //
+  // Only a value that is present and not an address is an error, and it is a
+  // payload error rather than a destination one: failOnError softens it the
+  // way it softens an unparseable argument list, not the way it hard-fails an
+  // invalid contract address.
+  const givenCaller = callerAddress ?? "";
+  const caller = givenCaller === "" ? undefined : givenCaller.trim();
+  if (caller !== undefined && !ethers.isAddress(caller)) {
     logUserError(
       ErrorCategory.VALIDATION,
       "[Read Contract] Invalid caller address:",

--- a/tests/unit/evm-chain-adapter-read.test.ts
+++ b/tests/unit/evm-chain-adapter-read.test.ts
@@ -163,3 +163,66 @@ describe("EvmChainAdapter.readContract — BaseContract name collision", () => {
     expect(result).toBe(expectedBalance);
   });
 });
+
+// The core suite mocks ethers.Contract away, so it can only prove the value is
+// appended as a trailing argument. This suite drives a real ethers.Contract
+// against a stub provider, so it is the one place that can prove ethers reads
+// that argument as call overrides and puts it on the eth_call (#2399).
+describe("EvmChainAdapter.readContract - caller address (#2399)", () => {
+  const ESTIMATION_ADDRESS = "0x0000000000000000000000000000000000000001";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends callerAddress as the eth_call from field", async () => {
+    const adapter = createAdapter();
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256"],
+      [BigInt(1000)]
+    );
+    const { executeWithFailover, callMock } =
+      createRpcManagerWithCallReturning(encoded);
+
+    await adapter.readContract(
+      { executeWithFailover } as unknown as RpcProviderManagerArg,
+      {
+        contractAddress: TOKEN_ADDRESS,
+        abi: BALANCE_OF_ABI as unknown as ethers.InterfaceAbi,
+        functionKey: "balanceOf",
+        args: [HOLDER_ADDRESS],
+        isView: true,
+        callerAddress: ESTIMATION_ADDRESS,
+      } as ReadContractRequest
+    );
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(callMock.mock.calls[0][0]).toMatchObject({
+      from: ESTIMATION_ADDRESS,
+    });
+  });
+
+  it("sends no from field when callerAddress is absent", async () => {
+    const adapter = createAdapter();
+    const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["uint256"],
+      [BigInt(1000)]
+    );
+    const { executeWithFailover, callMock } =
+      createRpcManagerWithCallReturning(encoded);
+
+    await adapter.readContract(
+      { executeWithFailover } as unknown as RpcProviderManagerArg,
+      {
+        contractAddress: TOKEN_ADDRESS,
+        abi: BALANCE_OF_ABI as unknown as ethers.InterfaceAbi,
+        functionKey: "balanceOf",
+        args: [HOLDER_ADDRESS],
+        isView: true,
+      } as ReadContractRequest
+    );
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(callMock.mock.calls[0][0].from).toBeUndefined();
+  });
+});

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -615,3 +615,174 @@ describe("ABI fragment validation before RPC failover", () => {
     expect(mockContractFunction).not.toHaveBeenCalled();
   });
 });
+
+// A read with no caller is a read as address(0), which is itself a specific
+// address: OptimismPortal2 reveals a failing withdrawal target only to
+// address(1), and a toll-gated Chronicle feed reads only for an authed caller.
+// These cover the value reaching the chain on both branches of the isView
+// ternary, and every blank shape leaving the call exactly as it was (#2399).
+describe("read-contract-core - caller address (#2399)", () => {
+  const CALLER = "0x2c9F694183A4240B6431771F6c714a8106179dF5";
+  const NO_ARG_ABI = [
+    {
+      name: "totalSupply",
+      type: "function",
+      stateMutability: "view",
+      inputs: [],
+      outputs: [{ name: "supply", type: "uint256" }],
+    },
+  ];
+
+  it("passes the caller to a view call as trailing overrides", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(makeInput({ callerAddress: CALLER }));
+
+    expect(result.success).toBe(true);
+    const call = mockContractFunction.mock.calls[0];
+    expect(call).toHaveLength(2);
+    expect(call[1]).toEqual({ from: CALLER });
+  });
+
+  it("passes the caller on the staticCall branch too", async () => {
+    setupRpcMocks();
+    mockStaticCall.mockResolvedValueOnce(BigInt("500000"));
+
+    const result = await readContractCore(
+      makeInput({
+        abi: JSON.stringify(NONPAYABLE_ABI),
+        abiFunction: "quoteExactInputSingle",
+        functionArgs: JSON.stringify([
+          VALID_ADDRESS,
+          VALID_ADDRESS,
+          "3000",
+          "1000000",
+          "0",
+        ]),
+        callerAddress: CALLER,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    const call = mockStaticCall.mock.calls[0];
+    expect(call).toHaveLength(6);
+    expect(call[5]).toEqual({ from: CALLER });
+  });
+
+  it("passes the caller as the only argument to a no-argument function", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt(7));
+
+    const result = await readContractCore(
+      makeInput({
+        abi: JSON.stringify(NO_ARG_ABI),
+        abiFunction: "totalSupply",
+        functionArgs: "",
+        callerAddress: CALLER,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction).toHaveBeenCalledWith({ from: CALLER });
+  });
+
+  it("does not fold the caller into the decoded ABI arguments", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    await readContractCore(makeInput({ callerAddress: CALLER }));
+
+    expect(mockContractFunction.mock.calls[0][0]).toBe(VALID_ADDRESS);
+  });
+
+  it("accepts an all-lowercase caller and forwards it unchanged", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(
+      makeInput({ callerAddress: CALLER.toLowerCase() })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction.mock.calls[0][1]).toEqual({
+      from: CALLER.toLowerCase(),
+    });
+  });
+
+  it("calls the contract exactly as before when no caller is given", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(makeInput());
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction.mock.calls[0]).toEqual([VALID_ADDRESS]);
+  });
+
+  it("treats an empty string caller as no caller, as before", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(makeInput({ callerAddress: "" }));
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction.mock.calls[0]).toEqual([VALID_ADDRESS]);
+  });
+
+  // A caller fed by {{PreviousNode.address}} that renders to blank must be a
+  // field left empty, not a hard error.
+  it("treats a whitespace-only caller as no caller", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(makeInput({ callerAddress: "   " }));
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction.mock.calls[0]).toEqual([VALID_ADDRESS]);
+  });
+
+  it("refuses a malformed caller without calling the chain", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(
+      makeInput({ callerAddress: "not-an-address" })
+    );
+
+    expect(result).toMatchObject({ success: false, errorClass: "user" });
+    if (!result.success) {
+      expect(result.error).toContain("Invalid caller address");
+    }
+    expect(mockContractFunction).not.toHaveBeenCalled();
+    expect(mockStaticCall).not.toHaveBeenCalled();
+  });
+
+  it("refuses a mixed-case caller whose checksum does not hold", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(
+      makeInput({ callerAddress: "0x2C9f694183A4240B6431771F6c714a8106179dF5" })
+    );
+
+    expect(result).toMatchObject({ success: false, errorClass: "user" });
+    expect(mockContractFunction).not.toHaveBeenCalled();
+  });
+
+  // The caller is payload, like the arguments, not a destination: failOnError
+  // softens it the way it softens an unparseable argument list rather than
+  // hard-failing it the way it hard-fails an invalid contract address.
+  it("softens a malformed caller when failOnError is false", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(
+      makeInput({ callerAddress: "not-an-address", failOnError: false })
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toBeNull();
+      expect(result.error).toContain("Invalid caller address");
+    }
+    expect(mockContractFunction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/read-contract-core.test.ts
+++ b/tests/unit/read-contract-core.test.ts
@@ -730,16 +730,54 @@ describe("read-contract-core - caller address (#2399)", () => {
     expect(mockContractFunction.mock.calls[0]).toEqual([VALID_ADDRESS]);
   });
 
-  // A caller fed by {{PreviousNode.address}} that renders to blank must be a
-  // field left empty, not a hard error.
-  it("treats a whitespace-only caller as no caller", async () => {
+  // A caller fed by {{PreviousNode.address}} that renders to nothing must be a
+  // field left empty, not a hard error. null reaches here the same way: it is
+  // what an MCP-authored config carries, and isMissingRequiredValue treats it
+  // as missing, so such a workflow persists and then has to run.
+  it("treats a null caller as no caller", async () => {
     setupRpcMocks();
     mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
 
-    const result = await readContractCore(makeInput({ callerAddress: "   " }));
+    const result = await readContractCore(
+      makeInput({ callerAddress: null as unknown as string })
+    );
 
     expect(result.success).toBe(true);
     expect(mockContractFunction.mock.calls[0]).toEqual([VALID_ADDRESS]);
+  });
+
+  // validateFieldValue early-returns valid for undefined, null and "", and
+  // rejects a whitespace-only value through its isAddressField branch. Reading
+  // whitespace as absent here would have left run time saying a field is empty
+  // that save time calls invalid, and that half was unreachable anyway.
+  it("refuses a whitespace-only caller, as save time does", async () => {
+    setupRpcMocks();
+
+    const result = await readContractCore(makeInput({ callerAddress: "   " }));
+
+    expect(result).toMatchObject({ success: false, errorClass: "user" });
+    if (!result.success) {
+      expect(result.error).toContain("Invalid caller address");
+    }
+    expect(mockContractFunction).not.toHaveBeenCalled();
+    expect(mockStaticCall).not.toHaveBeenCalled();
+  });
+
+  // What a template actually produces is an address with whitespace around it,
+  // which is read rather than refused.
+  it("trims whitespace around a real caller", async () => {
+    setupRpcMocks();
+    mockContractFunction.mockResolvedValueOnce(BigInt("1000"));
+
+    const result = await readContractCore(
+      makeInput({ callerAddress: `  ${CALLER}  ` })
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockContractFunction.mock.calls[0]).toEqual([
+      VALID_ADDRESS,
+      { from: CALLER },
+    ]);
   });
 
   it("refuses a malformed caller without calling the chain", async () => {


### PR DESCRIPTION
Closes #2399.

## What this changes

`web3/read-contract` gains an optional `callerAddress`. Unset, the payload is byte-identical to today: no overrides object is constructed and the `eth_call` carries no `from` key. Set, it becomes `{ from }` on the call, so a contract that answers by caller can be asked as the address that matters.

`ReadContractRequest` (`lib/web3/chain-adapter/types.ts`) gains `callerAddress?: string`. `EvmChainAdapter.readContract` (`evm.ts`) appends the overrides object when it is present and appends nothing when it is not, on both the view and the `staticCall` branch. `read-contract-core.ts` validates and forwards it, and `plugins/web3/index.ts` adds the config field between `functionArgs` and `readFailOnError`.

## The three amendments from the issue

**Absence rule.** You were right that the two layers disagreed. `validateFieldValue` (`lib/workflow/validation/action-config.ts`) early-returns valid for `undefined`, `null` and `""` only, and rejects a whitespace-only value through its `isAddressField` branch, so "empty or whitespace-only means absent" was unreachable for that input and contradicted save time about it. Absent is now that same set. A whitespace-only value fails `isAddress` here the way it fails validation there. `null` is mapped alongside `undefined`, because that is what an MCP-authored config carries and `isMissingRequiredValue` treats it as missing, so such a workflow persists and then has to run. The value is still trimmed before it is read - an address with whitespace around it is what a template actually produces - and that case is asserted rather than assumed.

**Help text.** It now says nothing is signed or sent from the address and that a write is never sent from it, with the warning pointed where you put it: gating a transfer on an answer obtained as someone else.

**Scope.** Stated rather than implied. `readContractCore` is also called from `app/api/execute/contract-call/route.ts:99`, `check-and-execute/route.ts:175` and `:436`, and `[...slug]/route.ts:206`, each enumerating fields explicitly, so each drops this one. The Direct Execution API is deliberately out of scope; this reaches the workflow surface only. Say if you want it there and I will add it.

## The design fork

Taking your reading: optional, defaulting to unset. Defaulting to the org wallet would change the answer every existing read gets, and a silent change of answer is the thing this issue is about. An explicit opt-in leaves `address(0)` as the default caller, which is not neutral, but it is the default that is already there rather than a new one. Happy to be argued out of it.

## Out of scope, and worse than what I filed

Recording your find so it is not rediscovered: `check-and-execute/route.ts:175-182` calls `readContractCore` with `resolvedWriteAbi` - the `staticCall` branch - to decide whether to broadcast. That is a write preflight with no caller, in a route that elsewhere calls `simulateContractCall`, which resolves the org wallet and sends a real `from` (`lib/execute/simulate.ts:675,684`). Two preflight styles in one file, one of them answering as `address(0)`.

`batch-read-contract` stays excluded, and your Multicall3 run is the sharper reason: with `from=0x00...01` `aggregate3` returns `success:false, returnData:0xab581036`, so the portal's estimation branch keys on `tx.origin`. A caller field there would appear to work for this case and be wrong for every `msg.sender`-gated contract.

## Checks

41 tests across `read-contract-core` and `evm-chain-adapter-read`; 346 across the 24 contract/adapter/web3 suites; biome clean on the four lintable files (`plugins/` is excluded by `biome.jsonc`).

Five mutants were planted and each went red: the absence test trimming again, `null` no longer absent, the value no longer trimmed, the `isAddress` check dropped, and the caller never reaching the adapter.

Rebased onto staging. `read-contract-core.ts` is also touched by #2382, so whichever lands first the other rebases.
