### PR TITLE
chore: KEEP-1042 turn off dry run for execution retention on staging

### DIFF
--- a/deploy/keeperhub-stack/staging/values.yaml
+++ b/deploy/keeperhub-stack/staging/values.yaml
@@ -51,12 +51,13 @@ app:
     EXECUTION_RETENTION_EXECUTIONS_ENABLED:
       type: kv
       value: "false"
-    # Report what each pass would touch and delete nothing. Staging ships
-    # enabled-but-dry so the CronJob and the queries are exercised; flip to
-    # "false" once the reported counts look right.
+    # Real deletes on staging. The dry run on 2026-09-11 resolved every
+    # organization to its plan window and reported 2,260 step logs past it and
+    # 1,482,131 output_raw payloads to null, in 41s of the 240s budget. Set
+    # back to "true" to stop deleting without a code change.
     EXECUTION_RETENTION_DRY_RUN:
       type: kv
-      value: "true"
+      value: "false"
     # Ceiling on the no-join backstop pass. That pass runs at the longest
     # window any organization is actually on, capped here, so raising this
     # only bites once some plan sells a longer window than the value below.


### PR DESCRIPTION
## What

Turns off dry run for the execution retention job on staging, so the next run deletes for real. Prod is unchanged: the job ships disabled there.

## Why now

The retention job is deployed on staging, and a dry run on 2026-09-11 reported:

| pass | rows |
| --- | --- |
| `logs_floor` (backstop at 90 days on staging) | 0 |
| `logs_plan_window`, 7-day window, 316 organizations | 2,260 |
| `logs_plan_window`, 30-day window, 53 organizations | 0 |
| `output_raw` nulled on runs that can no longer resume | 1,482,131 |
| `logs_soft_deleted` | 0 |
| `executions_flat_window` | skipped, off |

It finished in 41 s of its 240 s budget and returned 200. Every organization resolved to the window its plan sells, and nothing was deferred for a recent plan change.

## After merge

The CronJob runs daily at 03:48 UTC. Setting `EXECUTION_RETENTION_DRY_RUN` back to `"true"` stops deletes without a code change.
