### PR TITLE
feat: #2375 add approval exploit lookup

### DIFF
--- a/plugins/web3/index.ts
+++ b/plugins/web3/index.ts
@@ -1722,6 +1722,68 @@ const web3Plugin: IntegrationPlugin = {
       ],
     },
     {
+      slug: "check-approval-exploits",
+      label: "Check Known Approval Exploits",
+      description:
+        "Match supplied token and spender pairs against Revoke.cash's public known approval exploit list on the selected chain. This does not discover approvals, read allowances or Permit2 state, or certify safety; not_listed means only that no match exists in the retrieved list revision.",
+      category: "Web3",
+      stepFunction: "checkApprovalExploitsStep",
+      stepImportPath: "check-approval-exploits",
+      outputFields: [
+        {
+          field: "success",
+          description:
+            "Whether the lookup completed. Also true when failOnError is off and a failed lookup was softened; lookupStatus remains error and result fields remain null.",
+        },
+        {
+          field: "lookupStatus",
+          description:
+            "complete when the full source snapshot was checked, otherwise error",
+        },
+        {
+          field: "results",
+          description:
+            "One result per supplied pair with its input index, token, spender, matched or not_listed status, and every matching incident. Incident amount is historical source data, not the wallet's value at risk.",
+        },
+        {
+          field: "matchedPairCount",
+          description:
+            "Number of supplied pairs whose spender matched at least one incident on the selected chain",
+        },
+        {
+          field: "source",
+          description:
+            "Revoke.cash exploit-list repository, exact commit revision, and retrieval time",
+        },
+        {
+          field: "coverage",
+          description:
+            "Explicit limits of the lookup, including that not_listed is not a safety verdict",
+        },
+        {
+          field: "error",
+          description:
+            "Error message when lookupStatus is error, including softened failures",
+        },
+      ],
+      configFields: [
+        evmNetworkField(),
+        {
+          key: "approvalPairs",
+          label: "Token and Spender Pairs",
+          type: "json-editor",
+          placeholder:
+            '[{"tokenAddress":"0x...","spenderAddress":"0x..."}]',
+          example:
+            '[{"tokenAddress":"0x6B175474E89094C44Da98b954EedeAC495271d0F","spenderAddress":"0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"}]',
+          helpTip:
+            "JSON array with 1 to 100 tokenAddress and spenderAddress pairs. Template references may be used inside the JSON string. Token addresses keep results tied to the approval being checked; exploit matching uses spender address plus the selected chain.",
+          required: true,
+        },
+        readFailOnErrorField(),
+      ],
+    },
+    {
       slug: "write-contract",
       label: "Write Contract",
       description: "Write data to a smart contract (state-changing functions)",

--- a/plugins/web3/steps/check-approval-exploits-core.ts
+++ b/plugins/web3/steps/check-approval-exploits-core.ts
@@ -1,0 +1,443 @@
+import "server-only";
+
+import { getChainIdFromNetwork } from "@/lib/rpc/network-utils";
+import { safeFetch } from "@/lib/safe-fetch";
+import { getErrorMessage } from "@/lib/utils";
+import type { ReadDestinationFailure } from "./read-fail-on-error-core";
+
+const REPOSITORY = "RevokeCash/approval-exploit-list";
+const GITHUB_COMMIT_FEED_URL =
+  "https://github.com/" + REPOSITORY + "/commits/main.atom";
+const RAW_BASE_URL = "https://raw.githubusercontent.com/" + REPOSITORY;
+const COVERAGE =
+  "Matches supplied token and spender pairs against known exploit addresses on the selected chain. It does not discover approvals, read allowances, inspect Permit2 state, or certify that a wallet is safe. not_listed means only that the spender had no match in the retrieved source revision.";
+const EVM_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_PAIRS = 100;
+const MAX_INCIDENTS = 250;
+const MAX_ADDRESSES_PER_INCIDENT = 20_000;
+const MAX_TOTAL_ADDRESSES = 100_000;
+const FETCH_CONCURRENCY = 6;
+const FETCH_TIMEOUT_MS = 10_000;
+const CACHE_TTL_MS = 5 * 60_000;
+
+export const APPROVAL_EXPLOIT_COVERAGE = COVERAGE;
+
+type ApprovalPair = { tokenAddress: string; spenderAddress: string };
+type ExploitAddress = { chainId: number; address: string };
+type ExploitRecord = {
+  slug: string;
+  name: string;
+  description: string;
+  date: string;
+  amount: number;
+  addresses: ExploitAddress[];
+  metaArticleUrls: string[];
+  fixed?: boolean;
+};
+
+export type ApprovalExploitIncident = {
+  slug: string;
+  name: string;
+  description: string;
+  date: string;
+  amount: number;
+  fixed?: boolean;
+  articleUrls: string[];
+  sourceRecordUrl: string;
+};
+
+export type ApprovalExploitPairResult = {
+  inputIndex: number;
+  tokenAddress: string;
+  spenderAddress: string;
+  status: "matched" | "not_listed";
+  incidents: ApprovalExploitIncident[];
+};
+
+export type CheckApprovalExploitsResult =
+  | {
+      success: true;
+      lookupStatus: "complete" | "error";
+      results: ApprovalExploitPairResult[] | null;
+      matchedPairCount: number | null;
+      source: {
+        repository: typeof REPOSITORY;
+        revision: string;
+        retrievedAt: string;
+      } | null;
+      coverage: string;
+      error?: string;
+    }
+  | (ReadDestinationFailure & {
+      success: false;
+      lookupStatus: "error";
+      results: null;
+      matchedPairCount: null;
+      source: null;
+      coverage: string;
+      error: string;
+    });
+
+export type CheckApprovalExploitsCoreInput = {
+  network: string;
+  approvalPairs: unknown;
+};
+
+type Snapshot = {
+  revision: string;
+  retrievedAt: string;
+  incidents: ExploitRecord[];
+};
+
+let cache: { snapshot: Snapshot; expiresAt: number } | undefined;
+let inFlight: Promise<Snapshot> | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fail(
+  error: string,
+  destinationError = false
+): CheckApprovalExploitsResult {
+  return {
+    success: false,
+    lookupStatus: "error",
+    results: null,
+    matchedPairCount: null,
+    source: null,
+    coverage: COVERAGE,
+    error,
+    ...(destinationError ? { destinationError: true as const } : {}),
+  };
+}
+
+function parsePairs(value: unknown): ApprovalPair[] {
+  let parsed = value;
+  if (typeof value === "string") {
+    if (!value.trim()) {
+      throw new Error("Approval pairs are required");
+    }
+    try {
+      parsed = JSON.parse(value);
+    } catch (error) {
+      throw new Error(
+        "Approval pairs must be valid JSON: " + getErrorMessage(error)
+      );
+    }
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("Approval pairs must be a JSON array");
+  }
+  if (parsed.length === 0 || parsed.length > MAX_PAIRS) {
+    throw new Error("Approval pairs must contain between 1 and 100 entries");
+  }
+  return parsed.map((item, index) => {
+    if (!isRecord(item)) {
+      throw new Error("Approval pair at index " + index + " must be an object");
+    }
+    const tokenAddress = item.tokenAddress;
+    const spenderAddress = item.spenderAddress;
+    if (
+      typeof tokenAddress !== "string" ||
+      !EVM_ADDRESS_PATTERN.test(tokenAddress)
+    ) {
+      throw new Error("Invalid tokenAddress at approval pair index " + index);
+    }
+    if (
+      typeof spenderAddress !== "string" ||
+      !EVM_ADDRESS_PATTERN.test(spenderAddress)
+    ) {
+      throw new Error("Invalid spenderAddress at approval pair index " + index);
+    }
+    return { tokenAddress, spenderAddress };
+  });
+}
+
+async function fetchText(url: string, maxBytes: number): Promise<string> {
+  const response = await safeFetch(url, {
+    plugin: "web3",
+    headers: {
+      Accept: "application/json, application/atom+xml",
+      "User-Agent": "KeeperHub",
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error("GitHub returned HTTP " + response.status);
+  }
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new Error("GitHub response exceeded the allowed size");
+  }
+  const body = await response.arrayBuffer();
+  if (body.byteLength > maxBytes) {
+    throw new Error("GitHub response exceeded the allowed size");
+  }
+  return new TextDecoder().decode(body);
+}
+
+async function fetchJson(url: string, maxBytes: number): Promise<unknown> {
+  try {
+    return JSON.parse(await fetchText(url, maxBytes)) as unknown;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(
+        "GitHub returned invalid JSON: " + getErrorMessage(error)
+      );
+    }
+    throw error;
+  }
+}
+
+async function fetchRevision(): Promise<string> {
+  const feed = await fetchText(GITHUB_COMMIT_FEED_URL, 64_000);
+  const match = feed.match(/Grit::Commit\/([0-9a-f]{40})/);
+  if (!match) {
+    throw new Error(
+      "GitHub returned a commit feed without a valid head revision"
+    );
+  }
+  return match[1];
+}
+
+function parseSlugs(value: unknown): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    value.length > MAX_INCIDENTS
+  ) {
+    throw new Error("The exploit index has an invalid record count");
+  }
+  const slugs = value.map((slug) => {
+    if (typeof slug !== "string" || !SLUG_PATTERN.test(slug)) {
+      throw new Error("The exploit index contains an invalid slug");
+    }
+    return slug;
+  });
+  if (new Set(slugs).size !== slugs.length) {
+    throw new Error("The exploit index contains duplicate slugs");
+  }
+  return slugs;
+}
+
+function parseArticleUrls(value: unknown, slug: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Exploit record " + slug + " has invalid article URLs");
+  }
+  return value.map((url) => {
+    if (typeof url !== "string") {
+      throw new Error("Exploit record " + slug + " has an invalid article URL");
+    }
+    try {
+      const protocol = new URL(url).protocol;
+      if (protocol !== "https:" && protocol !== "http:") {
+        throw new Error();
+      }
+    } catch {
+      throw new Error("Exploit record " + slug + " has an invalid article URL");
+    }
+    return url;
+  });
+}
+
+function parseRecord(value: unknown, slug: string): ExploitRecord {
+  if (!isRecord(value)) {
+    throw new Error("Exploit record " + slug + " must be an object");
+  }
+  const { name, description, date, amount, addresses, fixed } = value;
+  if (typeof name !== "string" || name.length === 0) {
+    throw new Error("Exploit record " + slug + " has an invalid name");
+  }
+  if (typeof description !== "string" || description.length === 0) {
+    throw new Error("Exploit record " + slug + " has an invalid description");
+  }
+  if (typeof date !== "string" || !DATE_PATTERN.test(date)) {
+    throw new Error("Exploit record " + slug + " has an invalid date");
+  }
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 0) {
+    throw new Error("Exploit record " + slug + " has an invalid amount");
+  }
+  if (
+    !Array.isArray(addresses) ||
+    addresses.length === 0 ||
+    addresses.length > MAX_ADDRESSES_PER_INCIDENT
+  ) {
+    throw new Error("Exploit record " + slug + " has invalid addresses");
+  }
+  const parsedAddresses = addresses.map((entry) => {
+    if (!isRecord(entry)) {
+      throw new Error("Exploit record " + slug + " has an invalid address");
+    }
+    const chainId = entry.chainId;
+    const address = entry.address;
+    if (
+      typeof chainId !== "number" ||
+      !Number.isSafeInteger(chainId) ||
+      chainId <= 0 ||
+      typeof address !== "string" ||
+      !EVM_ADDRESS_PATTERN.test(address)
+    ) {
+      throw new Error("Exploit record " + slug + " has an invalid address");
+    }
+    return { chainId, address };
+  });
+  if (fixed !== undefined && typeof fixed !== "boolean") {
+    throw new Error("Exploit record " + slug + " has an invalid fixed value");
+  }
+  return {
+    slug,
+    name,
+    description,
+    date,
+    amount,
+    addresses: parsedAddresses,
+    metaArticleUrls: parseArticleUrls(value.metaArticleUrls, slug),
+    ...(fixed === undefined ? {} : { fixed }),
+  };
+}
+
+async function mapConcurrent<T, R>(
+  items: T[],
+  worker: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  async function run(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await worker(items[index]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(FETCH_CONCURRENCY, items.length) }, run)
+  );
+  return results;
+}
+
+async function fetchSnapshot(): Promise<Snapshot> {
+  const revision = await fetchRevision();
+  const slugs = parseSlugs(
+    await fetchJson(RAW_BASE_URL + "/" + revision + "/index.json", 64_000)
+  );
+  const incidents = await mapConcurrent(slugs, async (slug) =>
+    parseRecord(
+      await fetchJson(
+        RAW_BASE_URL + "/" + revision + "/exploits/" + slug + ".json",
+        1_000_000
+      ),
+      slug
+    )
+  );
+  if (
+    incidents.reduce((sum, incident) => sum + incident.addresses.length, 0) >
+    MAX_TOTAL_ADDRESSES
+  ) {
+    throw new Error("The exploit snapshot exceeds the total address limit");
+  }
+  return { revision, retrievedAt: new Date().toISOString(), incidents };
+}
+
+async function loadSnapshot(): Promise<Snapshot> {
+  if (cache && cache.expiresAt > Date.now()) {
+    return cache.snapshot;
+  }
+  inFlight ??= fetchSnapshot();
+  try {
+    const snapshot = await inFlight;
+    cache = { snapshot, expiresAt: Date.now() + CACHE_TTL_MS };
+    return snapshot;
+  } finally {
+    inFlight = undefined;
+  }
+}
+
+export async function checkApprovalExploits(
+  input: CheckApprovalExploitsCoreInput
+): Promise<CheckApprovalExploitsResult> {
+  let chainId: number;
+  try {
+    chainId = getChainIdFromNetwork(input.network);
+  } catch (error) {
+    return fail(getErrorMessage(error), true);
+  }
+
+  let pairs: ApprovalPair[];
+  try {
+    pairs = parsePairs(input.approvalPairs);
+  } catch (error) {
+    return fail(getErrorMessage(error));
+  }
+
+  let snapshot: Snapshot;
+  try {
+    snapshot = await loadSnapshot();
+  } catch (error) {
+    return fail("Exploit list unavailable: " + getErrorMessage(error));
+  }
+
+  const bySpender = new Map<string, ApprovalExploitIncident[]>();
+  for (const incident of snapshot.incidents) {
+    const outputIncident: ApprovalExploitIncident = {
+      slug: incident.slug,
+      name: incident.name,
+      description: incident.description,
+      date: incident.date,
+      amount: incident.amount,
+      ...(incident.fixed === undefined ? {} : { fixed: incident.fixed }),
+      articleUrls: incident.metaArticleUrls,
+      sourceRecordUrl:
+        "https://github.com/" +
+        REPOSITORY +
+        "/blob/" +
+        snapshot.revision +
+        "/exploits/" +
+        incident.slug +
+        ".json",
+    };
+    for (const item of incident.addresses) {
+      if (item.chainId !== chainId) {
+        continue;
+      }
+      const key = item.address.toLowerCase();
+      const matches = bySpender.get(key) ?? [];
+      matches.push(outputIncident);
+      bySpender.set(key, matches);
+    }
+  }
+
+  const results = pairs.map(
+    (pair, inputIndex): ApprovalExploitPairResult => {
+      const incidents = bySpender.get(pair.spenderAddress.toLowerCase()) ?? [];
+      return {
+        inputIndex,
+        tokenAddress: pair.tokenAddress,
+        spenderAddress: pair.spenderAddress,
+        status: incidents.length > 0 ? "matched" : "not_listed",
+        incidents,
+      };
+    }
+  );
+
+  return {
+    success: true,
+    lookupStatus: "complete",
+    results,
+    matchedPairCount: results.filter((result) => result.status === "matched")
+      .length,
+    source: {
+      repository: REPOSITORY,
+      revision: snapshot.revision,
+      retrievedAt: snapshot.retrievedAt,
+    },
+    coverage: COVERAGE,
+  };
+}
+
+export function clearApprovalExploitSnapshotCache(): void {
+  cache = undefined;
+  inFlight = undefined;
+}

--- a/plugins/web3/steps/check-approval-exploits.ts
+++ b/plugins/web3/steps/check-approval-exploits.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import {
+  runPluginStep,
+  type StepInput,
+} from "@/lib/workflow/executor/step-handler";
+import {
+  APPROVAL_EXPLOIT_COVERAGE,
+  type CheckApprovalExploitsCoreInput,
+  type CheckApprovalExploitsResult,
+  checkApprovalExploits,
+} from "./check-approval-exploits-core";
+import {
+  applyReadFailOnError,
+  type ReadFailOnErrorInput,
+} from "./read-fail-on-error-core";
+
+export type CheckApprovalExploitsInput = StepInput &
+  CheckApprovalExploitsCoreInput &
+  ReadFailOnErrorInput;
+
+export async function checkApprovalExploitsStep(
+  input: CheckApprovalExploitsInput
+): Promise<CheckApprovalExploitsResult> {
+  "use step";
+
+  return runPluginStep(
+    { pluginName: "web3", actionName: "check-approval-exploits" },
+    input,
+    async (stepInput) =>
+      applyReadFailOnError(
+        await checkApprovalExploits(stepInput),
+        stepInput.failOnError,
+        {
+          lookupStatus: "error",
+          results: null,
+          matchedPairCount: null,
+          source: null,
+          coverage: APPROVAL_EXPLOIT_COVERAGE,
+        }
+      )
+  );
+}
+
+checkApprovalExploitsStep.maxRetries = 0;
+
+export const _integrationType = "web3";

--- a/tests/unit/check-approval-exploits.test.ts
+++ b/tests/unit/check-approval-exploits.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const { safeFetch } = vi.hoisted(() => ({ safeFetch: vi.fn() }));
+
+vi.mock("@/lib/safe-fetch", () => ({ safeFetch }));
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (network: string) => {
+    if (network === "ethereum") {
+      return 1;
+    }
+    if (network === "polygon") {
+      return 137;
+    }
+    throw new Error(`Unknown network: ${network}`);
+  },
+}));
+vi.mock("@/lib/metrics/instrumentation/plugin", async () =>
+  (await import("../mocks/step-mocks")).pluginMetricsPassthrough()
+);
+vi.mock("@/lib/workflow/executor/step-handler", async () =>
+  (await import("../mocks/step-mocks")).stepHandlerPassthrough()
+);
+
+import { checkApprovalExploitsStep } from "@/plugins/web3/steps/check-approval-exploits";
+import {
+  checkApprovalExploits,
+  clearApprovalExploitSnapshotCache,
+} from "@/plugins/web3/steps/check-approval-exploits-core";
+
+const REVISION = "a".repeat(40);
+const TOKEN_A = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const TOKEN_B = "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const SPENDER = "0x75eB01BF6E265e2a7dbba1644913b5ADf0cC12DE";
+const UNLISTED = "0x1111111111111111111111111111111111111111";
+
+function textResponse(text: string, status = 200): Response {
+  const encoded = new TextEncoder().encode(text);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-length"
+          ? String(encoded.byteLength)
+          : null,
+    },
+    arrayBuffer: async () =>
+      encoded.buffer.slice(
+        encoded.byteOffset,
+        encoded.byteOffset + encoded.byteLength
+      ),
+  } as unknown as Response;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return textResponse(JSON.stringify(data), status);
+}
+
+function record(
+  name: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    name,
+    description: "Known approval exploit",
+    date: "2024-01-02",
+    amount: 12.5,
+    addresses: [{ chainId: 1, address: SPENDER }],
+    metaArticleUrls: ["https://example.com/incident"],
+    ...overrides,
+  };
+}
+
+function mockSnapshot(): void {
+  safeFetch.mockImplementation(async (url: string) => {
+    if (url.endsWith("/commits/main.atom")) {
+      return textResponse(
+        "<entry><id>tag:github.com,2008:Grit::Commit/REVISION</id></entry>".replace(
+          "REVISION",
+          REVISION
+        )
+      );
+    }
+    if (url.endsWith("/index.json")) {
+      return jsonResponse(["incident-a", "incident-b"]);
+    }
+    if (url.endsWith("/incident-a.json")) {
+      return jsonResponse(record("Incident A", { fixed: true }));
+    }
+    if (url.endsWith("/incident-b.json")) {
+      return jsonResponse(
+        record("Incident B", {
+          metaArticleUrls: ["http://web.archive.org/web/example"],
+        })
+      );
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  safeFetch.mockReset();
+  clearApprovalExploitSnapshotCache();
+});
+
+describe("check-approval-exploits", () => {
+  it("matches by normalized spender and exact chain while preserving each input", async () => {
+    mockSnapshot();
+    const upperSpender = `0x${SPENDER.slice(2).toUpperCase()}`;
+
+    const result = await checkApprovalExploits({
+      network: "ethereum",
+      approvalPairs: JSON.stringify([
+        { tokenAddress: TOKEN_A, spenderAddress: upperSpender },
+        { tokenAddress: TOKEN_B, spenderAddress: SPENDER.toLowerCase() },
+        { tokenAddress: TOKEN_A, spenderAddress: UNLISTED },
+      ]),
+    });
+
+    expect(result.success).toBe(true);
+    if (!(result.success && result.results && result.source)) {
+      return;
+    }
+    expect(result.lookupStatus).toBe("complete");
+    expect(result.matchedPairCount).toBe(2);
+    expect(result.results.map((item) => item.inputIndex)).toEqual([0, 1, 2]);
+    expect(result.results[0]).toMatchObject({
+      tokenAddress: TOKEN_A,
+      spenderAddress: upperSpender,
+      status: "matched",
+    });
+    expect(result.results[0].incidents.map((item) => item.slug)).toEqual([
+      "incident-a",
+      "incident-b",
+    ]);
+    expect(result.results[0].incidents[0]).toMatchObject({
+      fixed: true,
+      amount: 12.5,
+    });
+    expect(result.results[2]).toMatchObject({
+      status: "not_listed",
+      incidents: [],
+    });
+    expect(result.source).toMatchObject({
+      repository: "RevokeCash/approval-exploit-list",
+      revision: REVISION,
+    });
+    expect(result.results[0].incidents[0].sourceRecordUrl).toContain(REVISION);
+    expect(result.coverage).toContain("not_listed");
+    expect(safeFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not match the same address on another chain", async () => {
+    mockSnapshot();
+
+    const result = await checkApprovalExploits({
+      network: "polygon",
+      approvalPairs: [{ tokenAddress: TOKEN_A, spenderAddress: SPENDER }],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success && result.results) {
+      expect(result.results[0].status).toBe("not_listed");
+      expect(result.matchedPairCount).toBe(0);
+    }
+  });
+
+  it("fails closed when any source record is unavailable", async () => {
+    mockSnapshot();
+    safeFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith("/commits/main.atom")) {
+        return textResponse(
+          "<entry><id>tag:github.com,2008:Grit::Commit/REVISION</id></entry>".replace(
+            "REVISION",
+            REVISION
+          )
+        );
+      }
+      if (url.endsWith("/index.json")) {
+        return jsonResponse(["incident-a", "incident-b"]);
+      }
+      if (url.endsWith("/incident-a.json")) {
+        return jsonResponse(record("Incident A"));
+      }
+      return jsonResponse({ message: "missing" }, 404);
+    });
+
+    const result = await checkApprovalExploits({
+      network: "ethereum",
+      approvalPairs: [{ tokenAddress: TOKEN_A, spenderAddress: UNLISTED }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      lookupStatus: "error",
+      results: null,
+      matchedPairCount: null,
+      source: null,
+    });
+    expect(result.error).toContain("Exploit list unavailable");
+  });
+
+  it("keeps a softened retrieval failure visibly incomplete", async () => {
+    safeFetch.mockRejectedValue(new Error("connection reset"));
+
+    const result = await checkApprovalExploitsStep({
+      network: "ethereum",
+      approvalPairs: [{ tokenAddress: TOKEN_A, spenderAddress: UNLISTED }],
+      failOnError: false,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      lookupStatus: "error",
+      results: null,
+      matchedPairCount: null,
+      source: null,
+    });
+    expect(result.error).toContain("Exploit list unavailable");
+  });
+
+  it("rejects invalid pair input without fetching the source", async () => {
+    const result = await checkApprovalExploits({
+      network: "ethereum",
+      approvalPairs: '[{"tokenAddress":"bad","spenderAddress":"also-bad"}]',
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      lookupStatus: "error",
+      results: null,
+    });
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("hard-fails an unknown chain even when failOnError is off", async () => {
+    const result = await checkApprovalExploitsStep({
+      network: "unknown",
+      approvalPairs: [{ tokenAddress: TOKEN_A, spenderAddress: SPENDER }],
+      failOnError: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("disables workflow-level retries", () => {
+    expect(checkApprovalExploitsStep.maxRetries).toBe(0);
+  });
+});


### PR DESCRIPTION
## Issue

Closes #2375

## What this changes

Adds web3/check-approval-exploits, a credential-free read action that matches up to 100 supplied token/spender pairs against RevokeCash/approval-exploit-list for the selected EVM chain.

The action resolves one exact upstream commit from GitHub's public commit feed, then fetches the index and all incident records from that immutable revision through safeFetch. Retrieval uses bounded concurrency, timeouts, response-size limits, schema validation, and a short-lived cache that is populated only after the complete snapshot validates.

Results preserve the input index, token address, and spender address. Matching is case-insensitive for EVM addresses and exact for chain ID. Each match includes the incident slug, context, historical source amount, article URLs, optional fixed value, and revision-pinned source URL.

A source or validation failure cannot produce a clean negative result. With the default failOnError, the step fails. When the option is disabled, the step continues with lookupStatus: "error" and null results and counts.

The action description and coverage output state that it does not discover approvals, read allowances or Permit2 state, or certify wallet safety.

No npm dependency, credential, database change, pricing change, signing path, or existing response shape changes.

## Scope

This is one read-only Web3 action. The registry entry, step wrapper, source retrieval and matching core, and focused tests are interdependent parts of that action.

## How it was verified

- pnpm check
- pnpm type-check
- pnpm vitest run tests/unit/check-approval-exploits.test.ts
- Full unit-suite run: 23,025 tests passed; the two existing loopback-binding suites were rerun with local socket access and all 124 tests passed.
- Live source verification loaded and validated all 67 current Revoke.cash incident records by immutable revision through KeeperHub's safeFetch path.

The focused tests cover normalized address matching, exact chain matching, duplicate input association, multiple incident matches, revision-pinned evidence, invalid inputs, partial retrieval failure, softened fail-closed output, and disabled workflow retries.

---

- [x] Targets staging
- [x] Title carries the issue number
- [x] pnpm check and pnpm type-check pass
- [x] No secrets, .env files, or credentials committed
