### PR TITLE
fix: #2105 add a broadcastable example to the write-type workflow-call 200 schema

### DIFF
--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -177,6 +177,32 @@ const COMMON_ERROR_RESPONSES: Record<string, unknown> = {
   500: { $ref: "#/components/responses/InternalError" },
 };
 
+/**
+ * Example 200 body for a write-type workflow call.
+ *
+ * The endpoint's whole contract is "here is calldata for you to sign and
+ * broadcast", so the example is one a client could actually sign and
+ * broadcast, built from the same parts the handler emits (lib/mcp/calldata.ts):
+ *
+ * - `to` is the workflow's contract address. Base USDC, the asset this route's
+ *   x402 payment rail settles in (lib/payments/rails.ts), on the network its
+ *   x-payment-info already names - not a precompile or a zero-ish placeholder.
+ * - `data` is full `encodeFunctionData` output: the `transfer(address,uint256)`
+ *   selector followed by two 32-byte ABI words, the recipient and 1 USDC (6
+ *   decimals). The bare 4-byte selector alone is never what the field carries.
+ * - `value` is wei as a decimal string, the form calldata.ts returns.
+ *
+ * Plural `examples` because this is an OpenAPI 3.1 document: singular `example`
+ * is deprecated inside Schema Objects, and ERROR_SCHEMA above already uses the
+ * plural form.
+ */
+const WRITE_CALL_EXAMPLE = {
+  type: "calldata",
+  to: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  data: "0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240",
+  value: "0",
+};
+
 function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
   const isPaid = Number(workflow.priceUsdcPerCall ?? "0") > 0;
   const isWrite = workflow.workflowType === "write";
@@ -259,6 +285,7 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
               data: { type: "string" },
               value: { type: "string" },
             },
+            examples: [WRITE_CALL_EXAMPLE],
           },
         },
       },

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -180,26 +180,32 @@ const COMMON_ERROR_RESPONSES: Record<string, unknown> = {
 /**
  * Example 200 body for a write-type workflow call.
  *
- * The endpoint's whole contract is "here is calldata for you to sign and
- * broadcast", so the example is one a client could actually sign and
- * broadcast, built from the same parts the handler emits (lib/mcp/calldata.ts):
+ * Structurally exact, deliberately not broadcastable. The shape and encoding
+ * match what the handler emits (lib/mcp/calldata.ts): `data` is full
+ * `encodeFunctionData` output - the `transfer(address,uint256)` selector plus
+ * two 32-byte ABI words - and `value` is wei as a decimal string.
  *
- * - `to` is the workflow's contract address. Base USDC, the asset this route's
- *   x402 payment rail settles in (lib/payments/rails.ts), on the network its
- *   x-payment-info already names - not a precompile or a zero-ish placeholder.
- * - `data` is full `encodeFunctionData` output: the `transfer(address,uint256)`
- *   selector followed by two 32-byte ABI words, the recipient and 1 USDC (6
- *   decimals). The bare 4-byte selector alone is never what the field carries.
- * - `value` is wei as a decimal string, the form calldata.ts returns.
+ * The addresses are placeholders on purpose. A live token address would be
+ * wrong twice over: this response carries no chain identifier, so an address
+ * that only has code on one chain silently no-ops when broadcast anywhere
+ * else, and calldata a reader could sign turns the obvious smoke test - paste
+ * the documented body into a signer - into an irreversible transfer. `to` is a
+ * plainly fictitious contract and the recipient is the burn address, so the
+ * bytes decode correctly and mean nothing.
  *
- * Plural `examples` because this is an OpenAPI 3.1 document: singular `example`
- * is deprecated inside Schema Objects, and ERROR_SCHEMA above already uses the
- * plural form.
+ * `to` is the target the caller broadcasts to on the workflow's own chain: the
+ * workflow's contract for a single write, MULTICALL3 for a batch write
+ * (lib/mcp/calldata.ts:352). It is unrelated to x-payment-info, which says
+ * where the caller pays KeeperHub.
+ *
+ * Plural `examples` because this is an OpenAPI 3.1 document: singular
+ * `example` is deprecated inside Schema Objects, and ERROR_SCHEMA already uses
+ * the plural form.
  */
 const WRITE_CALL_EXAMPLE = {
   type: "calldata",
-  to: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-  data: "0xa9059cbb000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa9604500000000000000000000000000000000000000000000000000000000000f4240",
+  to: "0x1111111111111111111111111111111111111111",
+  data: "0xa9059cbb000000000000000000000000000000000000000000000000000000000000dead00000000000000000000000000000000000000000000000000000000000f4240",
   value: "0",
 };
 
@@ -273,7 +279,8 @@ function buildPathEntry(workflow: DiscoveryWorkflow): Record<string, unknown> {
 
   if (isWrite) {
     responses["200"] = {
-      description: "Unsigned transaction calldata",
+      description:
+        "Unsigned transaction calldata, to be signed and broadcast on the workflow's own chain. The example is illustrative: its addresses are placeholders, and its `value` of 0 refers to native currency only - an ERC-20 transfer in `data` still moves tokens.",
       headers: RATE_LIMIT_HEADERS,
       content: {
         "application/json": {

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDbSelect = vi.fn();
@@ -246,6 +247,65 @@ describe("GET /api/openapi", () => {
     expect(op["x-payment-info"]).toBeUndefined();
     expect(op.responses["402"]).toBeUndefined();
     expect(op["x-workflow-type"]).toBe("write");
+  });
+
+  // The write endpoint hands back calldata for the caller to sign and
+  // broadcast, so its example has to be calldata that could be: a real
+  // contract address and a complete ABI encoding. Decoded rather than compared
+  // to a string, so a truncated selector or a placeholder address fails here.
+  it("write workflows: the 200 example is calldata a client could broadcast", async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([
+          {
+            id: "wf-write-example",
+            name: "Write Workflow",
+            description: null,
+            listedSlug: "write-example",
+            inputSchema: null,
+            priceUsdcPerCall: null,
+            workflowType: "write",
+            category: null,
+            chain: null,
+          },
+        ]),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/openapi/route");
+    const response = await GET(
+      new Request("https://app.keeperhub.com/api/openapi")
+    );
+    const body = await response.json();
+    const schema =
+      body.paths["/api/mcp/workflows/write-example/call"].post.responses["200"]
+        .content["application/json"].schema;
+
+    // OpenAPI 3.1: the plural form, never the deprecated singular.
+    expect(schema.example).toBeUndefined();
+    expect(schema.examples).toHaveLength(1);
+    const [example] = schema.examples;
+
+    // Every key is one the schema declares, and `type` meets its const.
+    for (const key of Object.keys(example)) {
+      expect(schema.properties).toHaveProperty(key);
+    }
+    expect(example.type).toBe(schema.properties.type.const);
+
+    // `to`: a checksummed contract address, not a precompile.
+    expect(ethers.getAddress(example.to)).toBe(example.to);
+    expect(BigInt(example.to)).toBeGreaterThan(0xff_ffn);
+
+    // `data`: selector plus two 32-byte ABI words, decoding to real arguments.
+    expect(example.data).toHaveLength(2 + 8 + 2 * 64);
+    const [recipient, amount] = new ethers.Interface([
+      "function transfer(address to, uint256 amount)",
+    ]).decodeFunctionData("transfer", example.data);
+    expect(ethers.isAddress(recipient)).toBe(true);
+    expect(amount).toBeGreaterThan(0n);
+
+    // `value`: wei as a decimal string, as lib/mcp/calldata.ts emits it.
+    expect(example.value).toMatch(/^\d+$/);
   });
 
   it("DB-backed inputSchema takes precedence over the open-object fallback", async () => {

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -294,7 +294,7 @@ describe("GET /api/openapi", () => {
 
     // `to`: a checksummed contract address, not a precompile.
     expect(ethers.getAddress(example.to)).toBe(example.to);
-    expect(BigInt(example.to)).toBeGreaterThan(0xff_ffn);
+    expect(BigInt(example.to)).toBeGreaterThan(BigInt(0xff_ff));
 
     // `data`: selector plus two 32-byte ABI words, decoding to real arguments.
     expect(example.data).toHaveLength(2 + 8 + 2 * 64);
@@ -302,7 +302,7 @@ describe("GET /api/openapi", () => {
       "function transfer(address to, uint256 amount)",
     ]).decodeFunctionData("transfer", example.data);
     expect(ethers.isAddress(recipient)).toBe(true);
-    expect(amount).toBeGreaterThan(0n);
+    expect(amount).toBeGreaterThan(BigInt(0));
 
     // `value`: wei as a decimal string, as lib/mcp/calldata.ts emits it.
     expect(example.value).toMatch(/^\d+$/);

--- a/tests/unit/openapi-route.test.ts
+++ b/tests/unit/openapi-route.test.ts
@@ -249,11 +249,12 @@ describe("GET /api/openapi", () => {
     expect(op["x-workflow-type"]).toBe("write");
   });
 
-  // The write endpoint hands back calldata for the caller to sign and
-  // broadcast, so its example has to be calldata that could be: a real
-  // contract address and a complete ABI encoding. Decoded rather than compared
-  // to a string, so a truncated selector or a placeholder address fails here.
-  it("write workflows: the 200 example is calldata a client could broadcast", async () => {
+  // Two things to hold at once: the encoding has to be exact, and the
+  // addresses have to stay inert. Decoding rather than string-comparing
+  // catches a truncated selector; pinning the recipient catches the change
+  // that would matter most - swapping in a live payee, which no shape
+  // assertion can detect.
+  it("write workflows: the 200 example is exactly encoded and not broadcastable", async () => {
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([
@@ -292,17 +293,21 @@ describe("GET /api/openapi", () => {
     }
     expect(example.type).toBe(schema.properties.type.const);
 
-    // `to`: a checksummed contract address, not a precompile.
+    // `to`: a well-formed, checksummed address. This response carries no
+    // chain identifier, so it must not name a token that exists on one chain
+    // and is codeless on another - broadcasting there mines a no-op that
+    // looks like success.
     expect(ethers.getAddress(example.to)).toBe(example.to);
-    expect(BigInt(example.to)).toBeGreaterThan(BigInt(0xff_ff));
 
     // `data`: selector plus two 32-byte ABI words, decoding to real arguments.
     expect(example.data).toHaveLength(2 + 8 + 2 * 64);
     const [recipient, amount] = new ethers.Interface([
       "function transfer(address to, uint256 amount)",
     ]).decodeFunctionData("transfer", example.data);
-    expect(ethers.isAddress(recipient)).toBe(true);
     expect(amount).toBeGreaterThan(BigInt(0));
+    // The burn address, so the documented body cannot be pasted into a signer
+    // and send tokens to a real party.
+    expect(recipient).toBe("0x000000000000000000000000000000000000dEaD");
 
     // `value`: wei as a decimal string, as lib/mcp/calldata.ts emits it.
     expect(example.value).toMatch(/^\d+$/);


### PR DESCRIPTION
## Issue

Part of #2105: the write branch. The read branch waits on the open question of whether its 200 should model the success/error/running union, raised in the review on #2275.

## What this changes

**This is a production API surface change, not a documentation edit.** `GET /api/openapi` is unauthenticated and `force-dynamic`, so this alters the JSON body served to every caller and to the discovery scanners that index it.

The write-type branch of `buildPathEntry` gains `examples: [WRITE_CALL_EXAMPLE]` on its 200 schema, and the response description is expanded.

The example is structurally exact and deliberately not broadcastable. `data` is complete `encodeFunctionData` output - the `transfer(address,uint256)` selector plus two 32-byte ABI words - and `value` is wei as a decimal string, as `lib/mcp/calldata.ts` emits it. The addresses are placeholders: a plainly fictitious `to` and the burn address as recipient. The response carries no chain identifier, so a live token address would silently no-op when broadcast on a chain where it has no code, and signable calldata would turn a paste-into-a-signer smoke test into an irreversible transfer. The description now says the example is illustrative and that `value` refers to native currency only.

Uses the 3.1 plural `examples`, matching `ERROR_SCHEMA`.

## Scope

One change. The read branch sits in a mutually exclusive branch with no shared state and is deliberately untouched, including its `executionId` example and pattern, until the union question is settled.

## How it was verified

A test in `tests/unit/openapi-route.test.ts` decodes the example rather than comparing strings: every key is declared, `type` meets its const, `to` is checksummed, `data` is 138 characters and ABI-decodes to a non-zero amount, the recipient is pinned as the burn address, and `value` is a decimal string. Pinning the recipient catches a swap to a live payee, which no shape assertion can. All 28 tests in the file pass, Biome is clean, a scoped `tsgo` run over the changed files is clean, and `check-api-docs-routes` reports no drift.

---

- [x] Targets `staging`
- [x] Title carries the issue number
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
