### PR TITLE
fix: #2359 render template tokens inside array-valued config fields

### DIFF
--- a/lib/workflow/executor/executor.workflow.ts
+++ b/lib/workflow/executor/executor.workflow.ts
@@ -953,9 +953,83 @@ function replaceConfigTemplate(
   return formatConfigValue(resolved);
 }
 
+type TemplateRenderContext = {
+  outputs: NodeOutputs;
+  tracker?: TemplateResolutionTracker;
+  storedPattern: RegExp;
+  displayPattern: RegExp;
+};
+
+function renderTemplateString(
+  value: string,
+  ctx: TemplateRenderContext
+): string {
+  const result = value.replace(ctx.storedPattern, (m, nodeId, rest) =>
+    replaceConfigTemplate(m, nodeId, rest, ctx.outputs, ctx.tracker)
+  );
+  return result.replace(ctx.displayPattern, (full, displayRef) => {
+    const resolved = resolveDisplayTemplate(displayRef, ctx.outputs);
+    if (resolved === null || resolved === undefined) {
+      recordUnresolved(ctx.tracker, {
+        token: full,
+        reason: "no-path",
+        detail: `Display reference "${displayRef}" did not resolve.`,
+      });
+      return full;
+    }
+    return formatConfigValue(resolved);
+  });
+}
+
+/**
+ * Render one config value.
+ *
+ * Arrays are walked the same way scanForLeftoverLiterals walks them, so the
+ * render half and the scan half agree about what a rendered config contains.
+ * Previously an array fell through to the identity branch at the bottom of the
+ * loop, so a `{{...}}` token inside an array-valued field was never rendered
+ * and the scan that runs immediately after reported it as an unresolved
+ * reference: a correct reference, in the one container the renderer skipped.
+ *
+ * Deliberately not depth-bounded here. The scan stops reporting past depth 10,
+ * so a bound at or below that would leave a band where a token survives
+ * unrendered and unreported, which writes a literal `{{...}}` into a config
+ * with no error at all. Without a bound the array case behaves exactly as the
+ * object case always has, and the scan remains the thing that decides whether
+ * a rendered config is acceptable.
+ */
+function renderTemplateValue(
+  value: unknown,
+  ctx: TemplateRenderContext
+): unknown {
+  if (typeof value === "string") {
+    return renderTemplateString(value, ctx);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => renderTemplateValue(item, ctx));
+  }
+  if (typeof value === "object" && value !== null) {
+    return renderTemplatesInConfig(value as Record<string, unknown>, ctx);
+  }
+  return value;
+}
+
+function renderTemplatesInConfig(
+  config: Record<string, unknown>,
+  ctx: TemplateRenderContext
+): Record<string, unknown> {
+  const processed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    processed[key] = renderTemplateValue(value, ctx);
+  }
+  return processed;
+}
+
 /**
  * Process template variables in config.
- * Recurses into nested objects; supports array paths like data.recipes[0].
+ * Recurses into nested objects and into arrays. `data.recipes[0]` in a
+ * reference is an index into a resolved value and is handled by
+ * replaceConfigTemplate; array-valued config fields are handled here.
  *
  * KEEP-468: optional `tracker` records every reference that fell through to
  * the empty-string or literal-pass-through path so the caller can fail
@@ -966,46 +1040,14 @@ export function processTemplates(
   outputs: NodeOutputs,
   tracker?: TemplateResolutionTracker
 ): Record<string, unknown> {
-  const processed: Record<string, unknown> = {};
-  const storedPattern = /\{\{@([^:]+):([^}]+)\}\}/g;
-  // Fallback: resolve display-format templates {{Label.field}} that were not
-  // converted to stored format by the editor (mirrors extractTemplateParameters).
-  const displayPattern = /\{\{([^@}][^}]*)\}\}/g;
-
-  for (const [key, value] of Object.entries(config)) {
-    if (typeof value === "string") {
-      let result = value.replace(storedPattern, (m, nodeId, rest) =>
-        replaceConfigTemplate(m, nodeId, rest, outputs, tracker)
-      );
-      result = result.replace(displayPattern, (full, displayRef) => {
-        const resolved = resolveDisplayTemplate(displayRef, outputs);
-        if (resolved === null || resolved === undefined) {
-          recordUnresolved(tracker, {
-            token: full,
-            reason: "no-path",
-            detail: `Display reference "${displayRef}" did not resolve.`,
-          });
-          return full;
-        }
-        return formatConfigValue(resolved);
-      });
-      processed[key] = result;
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      !Array.isArray(value)
-    ) {
-      processed[key] = processTemplates(
-        value as Record<string, unknown>,
-        outputs,
-        tracker
-      );
-    } else {
-      processed[key] = value;
-    }
-  }
-
-  return processed;
+  return renderTemplatesInConfig(config, {
+    outputs,
+    tracker,
+    storedPattern: /\{\{@([^:]+):([^}]+)\}\}/g,
+    // Fallback: resolve display-format templates {{Label.field}} that were not
+    // converted to stored format by the editor (mirrors extractTemplateParameters).
+    displayPattern: /\{\{([^@}][^}]*)\}\}/g,
+  });
 }
 
 /**

--- a/plugins/web3/steps/read-contract-core.ts
+++ b/plugins/web3/steps/read-contract-core.ts
@@ -37,7 +37,10 @@ export type ReadContractCoreInput = {
   network: string;
   abi: string;
   abiFunction: string;
-  functionArgs?: string;
+  // The workflow editor sends this as a JSON string. A direct or MCP caller
+  // sends the array itself, which is the shape query-transactions and
+  // batch-write-contract already accept for their array-valued fields.
+  functionArgs?: string | unknown[];
   // See applyReadFailOnError in read-fail-on-error-core.ts. When false, no
   // failure of this step fails the run.
   failOnError?: boolean;
@@ -198,11 +201,18 @@ async function readContractInner(
     };
   }
 
-  // Parse function arguments
+  // Parse function arguments. The field arrives as a JSON string from the
+  // workflow editor and as an array from a direct or MCP caller, so both shapes
+  // are accepted here and validated identically below.
   let args: unknown[] = [];
-  if (functionArgs && functionArgs.trim() !== "") {
+  if (
+    Array.isArray(functionArgs) ||
+    (typeof functionArgs === "string" && functionArgs.trim() !== "")
+  ) {
     try {
-      const parsedArgs = JSON.parse(functionArgs);
+      const parsedArgs: unknown = Array.isArray(functionArgs)
+        ? functionArgs
+        : JSON.parse(String(functionArgs));
       if (!Array.isArray(parsedArgs)) {
         logUserError(
           ErrorCategory.VALIDATION,

--- a/tests/unit/template-array-config.test.ts
+++ b/tests/unit/template-array-config.test.ts
@@ -1,0 +1,344 @@
+/**
+ * #2359: a `{{...}}` token inside an array-valued config field was never
+ * rendered, because processTemplates excluded arrays with `!Array.isArray`,
+ * so the array fell to the identity branch. `scanForLeftoverLiterals` does
+ * walk arrays, so the scan that runs immediately after the render then
+ * reported the token as unresolved: a correct reference, in the one container
+ * the renderer skipped.
+ *
+ * Coverage:
+ *   - the render half walks arrays the way the scan half does, so a config
+ *     whose tokens all sit inside arrays renders and assertResolved passes
+ *   - a token in an array, in an array of objects, and in an object inside an
+ *     array
+ *   - the three step inputs whose array shape is supported end to end:
+ *     web3/batch-write-contract `calls`, web3/query-transactions
+ *     `functionArgs`, tempo/batch-payout `payouts`
+ *   - the recursion is bounded, and a token the renderer does not reach is
+ *     still reported rather than dropped
+ *   - web3/read-contract accepts `functionArgs` as an array, identically to
+ *     the JSON string the workflow editor sends
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/utils", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils");
+  return {
+    ...actual,
+    getErrorMessage: (e: unknown) =>
+      e instanceof Error ? e.message : String(e),
+  };
+});
+
+vi.mock("@/lib/logging", () => ({
+  logUserError: vi.fn(),
+  ErrorCategory: {
+    VALIDATION: "validation",
+    SYSTEM: "system",
+    NETWORK: "network",
+    EXECUTION: "execution",
+    USER: "user",
+  },
+}));
+
+const {
+  mockGetChainIdFromNetwork,
+  mockGetRpcProvider,
+  mockReadContract,
+  mockGetRpcPreferenceUserId,
+} = vi.hoisted(() => ({
+  mockGetChainIdFromNetwork: vi.fn(),
+  mockGetRpcProvider: vi.fn(),
+  mockReadContract: vi.fn(),
+  mockGetRpcPreferenceUserId: vi.fn(),
+}));
+
+vi.mock("@/lib/rpc/network-utils", () => ({
+  getChainIdFromNetwork: (...args: unknown[]) =>
+    mockGetChainIdFromNetwork(...args),
+}));
+
+vi.mock("@/lib/rpc/provider-factory", () => ({
+  getRpcProvider: (...args: unknown[]) => mockGetRpcProvider(...args),
+}));
+
+vi.mock("@/lib/web3/chain-adapter", () => ({
+  getChainAdapter: () => ({
+    readContract: mockReadContract,
+    getAddressUrl: (address: string) =>
+      `https://sepolia.etherscan.io/address/${address}`,
+  }),
+}));
+
+vi.mock("@/lib/workflow/executor/helpers", () => ({
+  getRpcPreferenceUserId: (...args: unknown[]) =>
+    mockGetRpcPreferenceUserId(...args),
+}));
+
+import { processTemplates } from "@/lib/workflow/executor/executor.workflow";
+import {
+  assertResolved,
+  createTracker,
+} from "@/lib/workflow/executor/template-resolution";
+import { readContractCore } from "@/plugins/web3/steps/read-contract-core";
+
+const WHO = "0x4F256eD4420136dfD1e595044626F0dDb9Ac2503";
+const AMOUNT = "25";
+
+const outputs = {
+  trigger: {
+    label: "Trigger",
+    data: { who: WHO, amount: AMOUNT, count: 3, real: true },
+  },
+};
+
+const storedWho = "{{@trigger:Trigger.who}}";
+const storedAmount = "{{@trigger:Trigger.amount}}";
+
+beforeEach(() => {
+  mockGetChainIdFromNetwork.mockReset().mockReturnValue(11_155_111);
+  mockGetRpcProvider.mockReset().mockResolvedValue({});
+  mockReadContract.mockReset().mockResolvedValue("12345");
+  mockGetRpcPreferenceUserId.mockReset().mockResolvedValue("user-1");
+});
+
+describe("processTemplates: arrays are rendered like objects", () => {
+  it("renders a token that sits in an array", () => {
+    const out = processTemplates({ functionArgs: [storedWho] }, outputs);
+    expect(out.functionArgs).toEqual([WHO]);
+  });
+
+  it("renders tokens that sit in an array of objects", () => {
+    const out = processTemplates(
+      {
+        payouts: [
+          { recipient: storedWho, amount: storedAmount },
+          {
+            recipient: "0x0000000000000000000000000000000000000001",
+            amount: "5",
+          },
+        ],
+      },
+      outputs
+    );
+    expect(out.payouts).toEqual([
+      { recipient: WHO, amount: AMOUNT },
+      {
+        recipient: "0x0000000000000000000000000000000000000001",
+        amount: "5",
+      },
+    ]);
+  });
+
+  it("renders a token in an object inside an array", () => {
+    const out = processTemplates(
+      { calls: [{ args: [storedWho], meta: { note: storedAmount } }] },
+      outputs
+    );
+    expect(out.calls).toEqual([{ args: [WHO], meta: { note: AMOUNT } }]);
+  });
+
+  it("renders arrays nested inside arrays", () => {
+    const out = processTemplates(
+      { grid: [[storedWho], [storedAmount]] },
+      outputs
+    );
+    expect(out.grid).toEqual([[WHO], [AMOUNT]]);
+  });
+
+  it("leaves non-string array members untouched", () => {
+    const out = processTemplates(
+      { mixed: [1, true, null, { n: 2 }, storedWho] },
+      outputs
+    );
+    expect(out.mixed).toEqual([1, true, null, { n: 2 }, WHO]);
+  });
+
+  it("still renders scalars and nested objects as before", () => {
+    const out = processTemplates(
+      { scalar: storedWho, nested: { deep: { value: storedAmount } } },
+      outputs
+    );
+    expect(out.scalar).toBe(WHO);
+    expect(out.nested).toEqual({ deep: { value: AMOUNT } });
+  });
+
+  it("does not mutate the config it was given", () => {
+    const config = { payouts: [{ recipient: storedWho }] };
+    processTemplates(config, outputs);
+    expect(config.payouts[0]?.recipient).toBe(storedWho);
+  });
+
+  it("passes assertResolved when every token sits inside an array", () => {
+    const tracker = createTracker();
+    const rendered = processTemplates(
+      { payouts: [{ recipient: storedWho, amount: storedAmount }] },
+      outputs,
+      tracker
+    );
+    expect(tracker.unresolved).toHaveLength(0);
+    expect(() =>
+      assertResolved(tracker, rendered, { nodeId: "n1" })
+    ).not.toThrow();
+  });
+
+  it("still fails closed when a token inside an array does not resolve", () => {
+    const tracker = createTracker();
+    const rendered = processTemplates(
+      { payouts: [{ recipient: "{{@trigger:Trigger.missing}}" }] },
+      outputs,
+      tracker
+    );
+    expect(() => assertResolved(tracker, rendered, { nodeId: "n1" })).toThrow();
+  });
+
+  it("renders arrays at the same depth as objects, so neither silently drops a token", () => {
+    // A depth bound at or below the scan's reporting bound would leave a band
+    // where a token survives unrendered and unreported, writing a literal
+    // `{{...}}` into a config with no error. Objects have never been bounded
+    // here, so arrays must not be either.
+    for (const depth of [1, 5, 10, 14, 20]) {
+      let inObject: unknown = storedWho;
+      let inArray: unknown = storedWho;
+      for (let i = 0; i < depth; i++) {
+        inObject = { level: inObject };
+        inArray = [inArray];
+      }
+      const renderedObject = processTemplates(
+        { v: inObject } as Record<string, unknown>,
+        outputs
+      );
+      const renderedArray = processTemplates(
+        { v: inArray } as Record<string, unknown>,
+        outputs
+      );
+      expect(JSON.stringify(renderedObject)).not.toContain("{{");
+      expect(JSON.stringify(renderedArray)).not.toContain("{{");
+    }
+  });
+});
+
+describe("#2359: the three step inputs whose array shape is supported end to end", () => {
+  it("web3/batch-write-contract `calls`: a token in a call's args resolves", () => {
+    const out = processTemplates(
+      {
+        network: "sepolia",
+        calls: [
+          {
+            contractAddress: "0x29f2D40B0605204364af54EC677bD022dA425d03",
+            abi: "[]",
+            abiFunction: "balanceOf",
+            args: [storedWho],
+          },
+        ],
+      },
+      outputs
+    );
+    const calls = out.calls as Array<{ args: unknown[] }>;
+    expect(calls[0]?.args).toEqual([WHO]);
+  });
+
+  it("web3/query-transactions `functionArgs`: a token in the array resolves", () => {
+    const out = processTemplates(
+      { network: "sepolia", functionArgs: [storedWho, ""] },
+      outputs
+    );
+    expect(out.functionArgs).toEqual([WHO, ""]);
+  });
+
+  it("tempo/batch-payout `payouts`: a token where an address belongs resolves", () => {
+    const out = processTemplates(
+      {
+        network: "sepolia",
+        payouts: [{ recipient: storedWho, amount: storedAmount }],
+      },
+      outputs
+    );
+    expect(out.payouts).toEqual([{ recipient: WHO, amount: AMOUNT }]);
+  });
+});
+
+describe("#2359: read-contract accepts functionArgs as an array", () => {
+  const ABI = JSON.stringify([
+    {
+      type: "function",
+      name: "balanceOf",
+      stateMutability: "view",
+      inputs: [{ name: "who", type: "address" }],
+      outputs: [{ name: "", type: "uint256" }],
+    },
+  ]);
+
+  const base = {
+    contractAddress: "0x29f2D40B0605204364af54EC677bD022dA425d03",
+    network: "sepolia",
+    abi: ABI,
+    abiFunction: "balanceOf",
+  };
+
+  it("parses the array shape identically to the JSON string shape", async () => {
+    const asString = await readContractCore({
+      ...base,
+      functionArgs: JSON.stringify([WHO]),
+    });
+    const asArray = await readContractCore({ ...base, functionArgs: [WHO] });
+
+    expect(asString.success).toBe(true);
+    expect(asArray.success).toBe(true);
+    expect(mockReadContract).toHaveBeenCalledTimes(2);
+    expect(mockReadContract.mock.calls[0]?.[1].args).toEqual(
+      mockReadContract.mock.calls[1]?.[1].args
+    );
+  });
+
+  it("does not report a parse failure for the array shape", async () => {
+    // The pre-fix failure was an uncaught TypeError from `functionArgs.trim()`
+    // on an array, once the renderer stopped skipping arrays.
+    const result = await readContractCore({ ...base, functionArgs: [WHO] });
+    expect(result.success).toBe(true);
+    expect(String(result.error ?? "")).not.toMatch(
+      /Invalid function arguments JSON|trim is not a function/
+    );
+  });
+
+  it("keeps rejecting a JSON string that is not an array", async () => {
+    const result = await readContractCore({
+      ...base,
+      functionArgs: JSON.stringify({ who: WHO }),
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Function arguments must be a JSON array");
+  });
+
+  it("treats an empty array as no arguments, like the empty string", async () => {
+    const noArgAbi = JSON.stringify([
+      {
+        type: "function",
+        name: "totalSupply",
+        stateMutability: "view",
+        inputs: [],
+        outputs: [{ name: "", type: "uint256" }],
+      },
+    ]);
+    const asArray = await readContractCore({
+      ...base,
+      abi: noArgAbi,
+      abiFunction: "totalSupply",
+      functionArgs: [],
+    });
+    const asString = await readContractCore({
+      ...base,
+      abi: noArgAbi,
+      abiFunction: "totalSupply",
+      functionArgs: "[]",
+    });
+    expect(asArray.success).toBe(true);
+    expect(asString.success).toBe(true);
+    expect(mockReadContract.mock.calls[0]?.[1].args).toEqual([]);
+    expect(mockReadContract.mock.calls[1]?.[1].args).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Issue

Closes #2359

## What this changes

The render half and the scan half of template resolution disagreed about arrays. `scanForLeftoverLiterals` walks arrays; `processTemplates` excluded them with `!Array.isArray(value)`, so an array-valued config field fell through to the identity branch and was copied verbatim. A `{{...}}` token inside one was therefore never rendered, and the scan that runs immediately after found it and aborted the run naming a reference that was correct.

`processTemplates` now walks arrays the way it walks objects. Its signature is unchanged, and so are the two patterns it builds per call. The per-value logic moved into `renderTemplateValue` and `renderTemplatesInConfig`. The doc comment that read "Recurses into nested objects; supports array paths like `data.recipes[0]`" is corrected, since that "array" described indexing inside a reference and read as the opposite of what the code did.

Second change, from the accepted plan on the issue: `ReadContractCoreInput.functionArgs` was `string` and the consumption path called `functionArgs.trim()`. Recursion alone would have converted case B's clean, actionable error into an uncaught `TypeError`, because an array is truthy and has no `trim`. It is now `string | unknown[]`, read the way `query-transactions` already reads the same field: `Array.isArray(functionArgs) ? functionArgs : JSON.parse(...)`. Everything else in that parse and validation block is untouched, including both existing error strings and the not-an-array rejection.

No new dependency, no configuration change, and no auth path altered beyond accepting the array shape on one field.

### Two decisions worth naming

**No depth bound on the render recursion.** A bound at or below the scan's reporting bound (depth 10) would create a band where a token survives unrendered *and* unreported, which writes a literal `{{...}}` into a config with no error at all. Objects have never been bounded here, so arrays are not bounded either, and the scan remains the thing that decides whether a rendered config is acceptable. A test holds this: arrays and objects must render identically at depths 1, 5, 10, 14 and 20.

**The two sibling surfaces named in the issue do not share the fault.** `extractTemplateParameters(query: string, ...)` and `processCodeTemplates(code: string, ...)` both take a string rather than a config tree, so neither has a container to skip. That closes the issue's last open scope item.

## Scope

One change. The two halves are interdependent in one direction only: renderer recursion alone turns a clean error into an uncaught `TypeError`, which is why the accepted plan is two files, and the `read-contract` widening alone changes nothing while the renderer still skips arrays, because nothing sends an array into a step that never receives one. Reverting either half leaves the other inert rather than correct, so they belong in one pull request.

Deliberately not here, both flagged as adjacent on the issue: `valueContainsTemplate` at `lib/workflow/validation/action-config.ts:236-238`, which is blind to arrays in the same way, and the PATCH-path asymmetry in `walkNodeConfigStrings`.

## How it was verified

`tests/unit/template-array-config.test.ts`, 17 tests.

The test that fails without the renderer change asserts `assertResolved` passes for a config whose tokens all sit inside arrays. Before the fix the tracker reported the array token as unresolved and the assertion threw. Coverage:

- a token in an array, in an array of objects, and in an object inside an array
- arrays inside arrays, non-string array members untouched, and the input config not mutated
- the scalar and nested-object cases, as regression cover
- the three step inputs the accepted plan names, where the array shape is supported end to end: `calls` on `web3/batch-write-contract`, `functionArgs` on `web3/query-transactions`, `payouts` on `tempo/batch-payout`
- arrays and objects render identically at depths 1, 5, 10, 14 and 20
- `read-contract` parses `[who]` and `'[who]'` to identical args at the adapter, and reports no parse failure for the array shape
- `read-contract` still rejects a JSON string that is not an array, with the existing message
- an empty array and an empty string both mean no arguments, checked against a function that takes none

Commands run:

```
pnpm vitest run tests/unit/template-array-config.test.ts            17 passed
pnpm vitest run <the six template and step suites>                 157 passed
pnpm vitest run <the 49 files that reference the changed modules>  883 passed
pnpm vitest run tests/unit                          23284 passed, 5 failed
pnpm check                                                          clean
pnpm type-check                                                     clean
pnpm fix                                                            2 files formatted
```

My local full-suite run reported five failures, then reproduced the same five on a
second run. None of them are this branch, and CI is the evidence: `test-unit`,
`typecheck`, `lint`, `build-check`, `test-db`, `test-integration`, `migrate-check`
and `test-unit-sandbox-remote` all pass on this commit. The pre-flight run is at
https://github.com/subheeksh5599/keeperhub-pr/pull/1 so the green result is
readable rather than asserted.

Two of the five are stale generated artefacts and regenerate away. Both
`tests/unit/credential-map-coverage.test.ts` and `tests/unit/credential-fetcher.test.ts`
report the plugin registry as out of sync, and the second one names the cure in its
own message: `Run 'pnpm discover-plugins' to regenerate lib/credential-map.ts`. Running
it, those two files pass, `23 passed`, and `git status` stays clean because the
regenerated files are build output. Worth knowing if you run the suite locally.

The other three are properties of this two-core laptop, not of the branch, and each
reproduces with the file run alone:

- `tests/unit/validate-workflow-structural.test.ts` asserts 100 iterations over a
  50-node workflow finish in under 50ms and measures 68ms here.
- `tests/unit/workflows-execute-alias.test.ts` times out at 10s on the import.
- `tests/unit/agentic-wallet-rate-limit.test.ts` derives a reset 1800s from the
  expectation in IST, which is the 30-minute part of this machine's offset and
  suggests a local-time assumption. Green in CI, so UTC hides it.

Reported because a reviewer running the suite on slower hardware will meet all five.

The 49 files that reference `executor.workflow`, `template-resolution`,
`read-contract-core`, `processTemplates` or `lib/utils/template` are the whole
affected surface, and they pass.

---

- [x] Targets `staging`
- [x] Title carries the issue number, or an exemption applies
- [x] `pnpm check` and `pnpm type-check` pass
- [x] No secrets, `.env` files, or credentials committed
